### PR TITLE
Fixes

### DIFF
--- a/src/egcombat.c
+++ b/src/egcombat.c
@@ -496,7 +496,7 @@ int samCanAcquireTarget(int slot, int targetX, int targetY, int targetAlt, int m
         g_acqRange = range;
         return 1;
     }
-    bearDiff = abs((int16)(g_acqAimY - g_projectiles[slot].worldX));
+    bearDiff = abs16Compat((int16)(g_acqAimY - g_projectiles[slot].worldX));
     if (bearDiff > 0x1000 && mode != 3) {
         if (bearDiff > 0x6000 && slot < 8) {
             if ((g_projectiles[slot].speed << 4) / g_frameRateScaling < range) {
@@ -506,7 +506,7 @@ int samCanAcquireTarget(int slot, int targetX, int targetY, int targetAlt, int m
         return 0;
     }
     if (mode == 0) {
-        if (abs((int16)(g_projectiles[slot].worldX - g_ourHead)) > 0x2000) {
+        if (abs16Compat((int16)(g_projectiles[slot].worldX - g_ourHead)) > 0x2000) {
             return 0;
         }
     }
@@ -514,7 +514,7 @@ int samCanAcquireTarget(int slot, int targetX, int targetY, int targetAlt, int m
         g_acqRange = range;
         return 1;
     }
-    bearDiff = abs((int16)(g_projectiles[slot].worldX - g_ourHead));
+    bearDiff = abs16Compat((int16)(g_projectiles[slot].worldX - g_ourHead));
     if (abs(bearDiff - 0x4000) >= 0x2000 - g_missionStatus * 2048) {
         g_acqRange = range;
         return 1;

--- a/src/egkeys.c
+++ b/src/egkeys.c
@@ -130,9 +130,7 @@ void keyDispatch(uint16 scanCode) {
         break;
     case SCAN_ALT_T:
         g_playerPlaneFlags ^= 0x1000;
-        if (g_playerPlaneFlags & 0x1000) {
-            *(char far *)&commData->trainingFlag |= 1;
-        }
+        commData->trainingFlag = (g_playerPlaneFlags & 0x1000) ? 1 : 0;
         break;
     case SCAN_S:
         missileSpecIndex = 0;

--- a/src/egtick.c
+++ b/src/egtick.c
@@ -25,6 +25,7 @@
 #include "egdata.h"
 #include "inttype.h"
 #include "slot.h"
+#include "gfx.h"
 
 void FAR egAdvanceFrameTick(void) {
     /* Clear the per-frame sync flag the render loop raises each iteration
@@ -35,4 +36,5 @@ void FAR egAdvanceFrameTick(void) {
     g_frameSyncPending = 0;
     g_timerTickByte[0]++;
     g_frameTimingAccum++;
+    gfx_dacCycle();
 }

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -5,6 +5,7 @@
 // state (threat scoring, SAM acquisition, target/mission bookkeeping, replay
 // log, director scheduling, wreck physics, timing/LOD math).
 #include "egdata.h"
+#include "egkeys.h"
 #include "egmath.h"
 #include "inttype.h"
 #include "struct.h"
@@ -180,7 +181,7 @@ int main() {
     g_projectiles[0].worldX = 0;
     g_projectiles[0].ttl = 1000;
     g_frameRateScaling = 20;
-    require(samCanAcquireTarget(0, 1000, 3000, 0, 1) == 0,
+    require(samCanAcquireTarget(0, 1100, 3000, 0, 1) == 0,
             "samCanAcquireTarget rejects targets outside the turn cone");
     require(g_projectiles[0].ttl == (g_frameRateScaling << 4),
             "samCanAcquireTarget clamps far off-boresight SAM ttl for active slots");
@@ -194,6 +195,26 @@ int main() {
     g_frameRateScaling = 20;
     require(samCanAcquireTarget(0, 3000, 1000, 0, 0) == 0,
             "samCanAcquireTarget mode 0 requires the forward-heading cone");
+
+    resetGameplayState();
+    g_projectiles[0].mapX = 1000;
+    g_projectiles[0].mapY = 1000;
+    g_projectiles[0].speed = 1;
+    g_projectiles[0].worldX = static_cast<int16>(0x8000);
+    g_ourHead = 0;
+    g_frameRateScaling = 20;
+    require(samCanAcquireTarget(0, 1000, 3000, 0, 0) == 1,
+            "samCanAcquireTarget mode 0 preserves original int16 abs(-32768) heading seam");
+
+    resetGameplayState();
+    g_projectiles[0].mapX = 1000;
+    g_projectiles[0].mapY = 1000;
+    g_projectiles[0].speed = 1;
+    g_projectiles[0].worldX = static_cast<int16>(0x8000);
+    g_ourHead = 0;
+    g_frameRateScaling = 20;
+    require(samCanAcquireTarget(0, 1000, -1000, 0, 1) == 1,
+            "samCanAcquireTarget preserves original int16 abs(-32768) acquisition seam");
 
     // --- markTargetReached (egcombat) ---------------------------------------
     resetGameplayState();
@@ -390,6 +411,17 @@ int main() {
     exitSlowMotion();
     require(g_slowMotionMode == 1 && g_frameRateScaling == 8,
             "exitSlowMotion is a no-op when not in mode 2");
+
+    // --- training toggle shared-state handoff (egkeys) ----------------------
+    resetGameplayState();
+    comm = {};
+    commData = &comm;
+    keyDispatch(SCAN_ALT_T);
+    require((g_playerPlaneFlags & 0x1000) != 0 && comm.trainingFlag == 1,
+            "ALT+T sets the player training flag and shared debrief flag");
+    keyDispatch(SCAN_ALT_T);
+    require((g_playerPlaneFlags & 0x1000) == 0 && comm.trainingFlag == 0,
+            "ALT+T clears the player training flag and shared debrief flag");
 
     // --- setupLodDistances thresholds (egkeys) ------------------------------
     resetGameplayState();

--- a/tests/tick_behavior_tests.cpp
+++ b/tests/tick_behavior_tests.cpp
@@ -7,6 +7,15 @@
 
 extern void far egAdvanceFrameTick(void);
 
+static int g_gfxDacCycleCalls = 0;
+
+void FAR CDECL gfx_dacCycle(void) {
+    // egAdvanceFrameTick calls the renderer's DAC/colour-cycle hook once per
+    // tick. This test links only the timer/data objects, so provide the hook
+    // locally instead of pulling the full SDL renderer into the unit test.
+    g_gfxDacCycleCalls++;
+}
+
 /* Backs egdata.c's regnStr global (defined in stdata.c, not linked here). MSVC
  * links whole objects so this reference needs a definition; unused by the test. */
 char aRegn_xxx[] = "regn.xxx";
@@ -37,6 +46,7 @@ void resetTickState() {
     g_frameSyncPending = kFrameSyncPendingBeforeTick;
     g_timerTickByte[0] = kTimerTickBefore;
     g_frameTimingAccum = kFrameTimingBefore;
+    g_gfxDacCycleCalls = 0;
 }
 
 } // namespace
@@ -51,6 +61,8 @@ int main() {
             "egAdvanceFrameTick increments the original waitFrameSync tick byte");
     require(g_frameTimingAccum == kFrameTimingAfter,
             "egAdvanceFrameTick increments the original frame timing accumulator");
+    require(g_gfxDacCycleCalls == 1,
+            "egAdvanceFrameTick advances the renderer DAC/colour-cycle hook once per tick");
 
     // The tick byte is a uint8 that waitFrameSync busy-waits on; it must wrap
     // 0xFF -> 0x00 (not saturate or widen), or the pacing compare after a wrap
@@ -59,6 +71,8 @@ int main() {
     egAdvanceFrameTick();
     require(g_timerTickByte[0] == 0x00,
             "egAdvanceFrameTick wraps the uint8 tick byte 0xFF -> 0x00");
+    require(g_gfxDacCycleCalls == 2,
+            "egAdvanceFrameTick keeps DAC/colour-cycle timing tied to every timer tick");
 
     std::cout << "tick_behavior_tests passed\n";
     return 0;


### PR DESCRIPTION
  - src/stmain.c
      - restores intro/title splash sequencing behavior (lab/adv fade timing and title fallback flow).

  - src/egkeys.c
      - makes slow-motion toggles update frame-rate scaling through recalcTimeScale().
      - training mode toggle to mirror legacy bit handling at COMM area.

  - src/egframe.c
      - return COMM area writes for training/mission handoff (including legacy offsets in finalizeMission).
