### PR TITLE
Add modern asset replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ coverage.txt
 *.gcda
 *.gcno
 *.actual.bmp
+
+# Python test/tool caches
+__pycache__/
+*.pyc
+
+# Generated replacement asset exports. Keep these out of source commits.
+/converted_assets_all/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,11 @@ find_package(OpenGL REQUIRED)
 # across toolchains (not all fold pthread into libc).
 find_package(Threads REQUIRED)
 
+# TrueType/OpenType font replacements are optional. When FreeType is available,
+# fonts/font_<id>.ttf and .otf are loaded directly by the runtime; otherwise the
+# game still builds and falls back to BDF/PNG/built-in font paths.
+find_package(Freetype QUIET)
+
 #------------------------------------------------------------------------------
 # Sanitizers (GCC/Clang, opt-in). Applied at directory scope so the executable
 # and the tests (which each compile the game code they exercise) are instrumented
@@ -284,6 +289,10 @@ if(AUTOSTART)
     target_compile_definitions(f15se2_core PUBLIC DEBUG_AUTOSTART)
 endif()
 target_link_libraries(f15se2_core PUBLIC SDL3::SDL3 OpenGL::GL)
+if(FREETYPE_FOUND)
+    target_compile_definitions(f15se2_core PUBLIC F15_HAVE_FREETYPE=1)
+    target_link_libraries(f15se2_core PUBLIC Freetype::Freetype)
+endif()
 
 add_executable(f15se2 ${SRC_DIR}/f15.c)
 set_target_properties(f15se2 PROPERTIES OUTPUT_NAME "f15se2-ex")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ add_custom_target(GenerateVersionHeader ALL
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     BYPRODUCTS "${SRC_DIR}/generated/version.h"
 )
+add_dependencies(f15se2_core GenerateVersionHeader)
 add_dependencies(f15se2 GenerateVersionHeader)
 
 # Strip symbols from Release builds to shrink the binary (GNU/Clang only; MSVC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,13 @@ option(COVERAGE "Build with gcov code-coverage instrumentation" OFF)
 # through the front end each run.
 option(AUTOSTART "Skip menus and start a mission directly (DEBUG_AUTOSTART)" OFF)
 
+# Full asset replacement proof is intentionally a test-time integration check,
+# not runtime game instrumentation. The paths default to the local developer
+# layout when available, but can be overridden by packagers/CI.
+set(F15SE2_ORIGINAL_ASSETS "/home/xor/games/f15" CACHE PATH "Original F-15 asset directory used by full replacement validation")
+set(F15SE2_CONVERTED_ASSETS "${CMAKE_CURRENT_SOURCE_DIR}/converted_assets_all" CACHE PATH "Converted asset directory used by full replacement validation")
+option(F15SE2_ENABLE_ASSET_VALIDATION_TEST "Register full old-vs-modern asset validation as a CTest when asset dirs exist" ON)
+
 #==============================================================================
 # Global settings
 #==============================================================================
@@ -101,6 +108,12 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_compare.c
+    ${SRC_DIR}/shared/asset_compare_bytes.c
+    ${SRC_DIR}/shared/asset_compare_image.c
+    ${SRC_DIR}/shared/asset_compare_font.c
+    ${SRC_DIR}/shared/asset_compare_sound.c
+    ${SRC_DIR}/shared/asset_compare_3d.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -460,6 +473,7 @@ add_behavior_test(original_behavior_tests LINK_CORE)
 add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
+add_behavior_test(asset_compare_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
@@ -476,6 +490,48 @@ add_behavior_test(eg3drast_internal_behavior_tests SOURCES ${SRC_DIR}/egdata.c)
 add_behavior_test(start_behavior_tests LINK_CORE)
 add_behavior_test(log_behavior_tests LINK_CORE)
 add_behavior_test(vgapal_behavior_tests SOURCES ${SRC_DIR}/vgapal.c DEFS main=vgapal_program_main)
+
+if(IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}" AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(asset_runtime_loader_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}"
+            F15_ASSET_TOOL_COMMAND="python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/f15assets/cli.py"
+    )
+    set_tests_properties(asset_runtime_loader_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120
+    )
+else()
+    message(STATUS "Skipping asset_runtime_loader_validation_tests: set F15SE2_ORIGINAL_ASSETS and F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
+
+if(F15SE2_ENABLE_ASSET_VALIDATION_TEST)
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(Python3_Interpreter_FOUND AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}" AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+        add_test(
+            NAME asset_replacement_full_validation
+            COMMAND
+                ${CMAKE_COMMAND} -E env
+                "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/tools/f15assets"
+                ${Python3_EXECUTABLE}
+                -m tools.f15assets.cli
+                validate-replacements
+                "${F15SE2_ORIGINAL_ASSETS}"
+                "${F15SE2_CONVERTED_ASSETS}"
+                --repo-root "${CMAKE_CURRENT_SOURCE_DIR}"
+                --require-all
+                --require-source-proof
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+        set_tests_properties(asset_replacement_full_validation PROPERTIES
+            LABELS "assets;integration"
+            TIMEOUT 120
+        )
+    else()
+        message(STATUS "Skipping asset_replacement_full_validation: set F15SE2_ORIGINAL_ASSETS and F15SE2_CONVERTED_ASSETS to existing directories")
+    endif()
+endif()
 
 
 #------------------------------------------------------------------------------

--- a/docs/reverse_engineering_asset_formats.md
+++ b/docs/reverse_engineering_asset_formats.md
@@ -62,34 +62,45 @@ The converter prioritizes forward conversion only:
 - The modern baseline used for authoring is:
   - `glTF 2.0` (`.glb` by default, `.gltf` optional) for models.
   - Indexed `PNG` (with embedded palette chunk) for image assets.
-  - `JSON` (with optional `YAML`) for structured world/terrain/table data.
+  - Ordered `JSON` for structured world/terrain/table data.
 - The default developer workflow is stable-then-edit: export to modern formats
   first, then modify only the exported modern format plus metadata sidecars.
+- If a modern media file and JSON sidecar contain overlapping information, the
+  modern media file is authoritative. PNG overrides image JSON for pixels,
+  dimensions, and palette; GLB overrides `.3D3.json` for model geometry and
+  GLB extras; WAV overrides sound JSON for sample data and audio format; BDF
+  overrides font JSON for glyph data and metrics, while PNG overrides font JSON
+  for atlas pixels only.
+- Validation invariant: loading an unmodified converted asset should produce
+  the same in-memory game data as loading the original asset. Float or lossy
+  modern encodings may be numerically equivalent within a documented tolerance
+  instead of byte-identical. This comparison belongs in importer
+  validation/tests or explicit diagnostics, not in normal runtime loading.
 - Modern reliable authoring targets:
   - `glTF 2.0` (`.glb` by default, `.gltf` optional) for geometry and model editing (Blender-first).
   - Indexed `PNG` for image art.
-  - `JSON`/`YAML` for structured world/terrain/table data.
+  - Ordered `JSON` for structured world/terrain/table data.
 - For stable pipelines, the modern editable target for 3D is **glTF 2.0**
   (`.glb`) because it is reproducible, self-contained, widely supported, and easy to
   move into Blender.
 - Lossy/editor formats like PNG and glTF should be accompanied by canonical
   structured metadata for any real edit pipeline.
 
-| Game format | Best editable format | Canonical export source | Export from game | Import back to game | Notes |
+| Game format | Best editable format | Canonical export source | Export from game | Runtime modern load | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `*.PIC` | Indexed PNG | PNG + JSON sidecar + original header/compression metadata | Yes | No | Best for full-screen images and cockpit/title art. JSON keeps palette, image mode, max code width, output layout, and original compression metadata. |
-| `*.SPR` | Indexed PNG sprite sheet + JSON atlas | PNG + JSON sidecar + original header/compression metadata | Yes | No | Same compressed image stream as PIC. The atlas is not embedded in SPR; generate/maintain JSON from code sprite descriptors and hand-assigned names. |
-| `*.3D3` theater models | **glTF (`.glb` default)** + `3D3` JSON sidecar | Parsed `.3D3` JSON plus raw display-list chunks and vertex-pool data | Yes | No | glTF is the stable modern mesh target for Blender, tools, and web pipelines. Keep a canonical `3D3` sidecar for traceable edits. |
-| `15FLT.3D3` aircraft models | **glTF (`.glb` default)** + `3D3` JSON sidecar | Parsed `.3D3` JSON plus raw aircraft display-list chunks | Yes | No | Same model-stream issue as theater `.3D3`; preserve shape ids and aircraft table mapping in JSON metadata. |
-| `PHOTO.3D3` target-photo models | **glTF (`.glb` default)** + `3D3` JSON sidecar | Parsed `.3D3` JSON plus raw chunks and append metadata | Yes | No | Treat like `.3D3`; preserve append/slot metadata because runtime appends selected chunks. |
-| `*.3DT` tile placements | YAML or JSON, optional CSV view | Canonical YAML/JSON with every 16-bit field preserved | Yes | No | Text is better than Blender for placements. It is object placement data: tile level, tile index, x/y/z, and a 16-bit shape word whose low byte is used at runtime. CSV can be a view, not the canonical source. |
-| `*.3DG` terrain grid | JSON/YAML data + PNG previews | Canonical JSON/YAML with all five grid buffers | Yes | No | PNG previews are only for visualization. Exact hierarchical grid data must be kept in JSON/YAML. |
-| `*.WLD` world/campaign | YAML or JSON, optional CSV tables | Canonical YAML/JSON preserving named binary tables, name table bytes, and record order | Yes | No | Best as structured text: world objects, flight units, terrain grid, name table, and proven mission/category tables. CSV helps spreadsheet editing, but JSON/YAML should be canonical. |
-| Palette data | GIMP `.gpl` or JASC `.pal` for editing | JSON with exact DAC tables, mode, and 6-bit/8-bit level metadata | Yes | No | Editor palette files are useful but not enough; JSON must preserve exact game palette/register metadata. |
+| `*.PIC` | Indexed PNG | PNG plus optional decode JSON | Yes | Yes | PNG is authoritative for pixels, dimensions, and palette. `convert-tree --include-image-json` keeps image mode, max code width, layout, and bulky decode metadata for diagnostics only. Backward conversion to `.PIC` is intentionally not required. |
+| `*.SPR` | Indexed PNG sprite sheet + optional JSON atlas | PNG plus optional decode/index JSON | Yes | Yes | PNG is authoritative for pixels, dimensions, and palette. The atlas is not embedded in SPR; generate/maintain JSON from code sprite descriptors and hand-assigned names only when needed. Backward conversion to `.SPR` is intentionally not required. |
+| `*.3D3` theater models | **glTF (`.glb` default)** + optional generated `cache/*.glmesh` runtime cache + lightweight `3D3` JSON index | Combined GLB and per-shape GLB files in the related world directory; `.glmesh` is generated from GLB and stores the source GLB checksum; default JSON keeps lightweight ids/lookup metadata only, while `--include-3d3-model-data` writes full bridge dumps | Yes | Partial: OpenGL geometry replacement, legacy `.3D3` still required for slot tables/fallback unless a full JSON bridge dump is provided | glTF is authoritative for model geometry and extras. Default JSON must not duplicate model bytecode; full bridge dumps are opt-in. A future GLB-only/free-asset runtime still needs a native replacement for the `.3D3` shape-slot table load. |
+| `15FLT.3D3` aircraft models | **glTF (`.glb` default)** + optional generated `cache/*.glmesh` runtime cache + lightweight `3D3` JSON index | Combined GLB and per-shape GLB files in `15FLT/`; cache files live in `15FLT/cache/` when generated; default JSON keeps lightweight ids/lookup metadata only, while `--include-3d3-model-data` writes full bridge dumps | Yes | Partial: OpenGL geometry replacement, legacy `.3D3` still required for aircraft shape slots/fallback unless a full JSON bridge dump is provided | Same model-stream issue as theater `.3D3`; preserve shape ids and aircraft table mapping as lightweight JSON metadata. A future GLB-only/free-asset runtime must load this table from modern metadata. |
+| `PHOTO.3D3` target-photo models | **glTF (`.glb` default)** + optional generated `cache/*.glmesh` runtime cache + lightweight `3D3` JSON index | Combined GLB and per-shape GLB files in `PHOTO/`; cache files live in `PHOTO/cache/` when generated; default JSON keeps lightweight ids/lookup metadata only, while `--include-3d3-model-data` writes full bridge dumps | Yes | Partial: OpenGL geometry replacement, legacy `.3D3` still required for appended target-view slots/fallback unless a full JSON bridge dump is provided | Treat like `.3D3`; preserve append/slot metadata without duplicating geometry by default. A future GLB-only/free-asset runtime must load append/slot metadata from modern metadata. |
+| `*.3DT` tile placements | Ordered JSON in the related world directory, optional CSV view | Canonical JSON with every 16-bit field preserved | Yes | Yes, via rebuild bridge | Text is better than Blender for placements. It is object placement data: tile level, tile index, x/y/z, and a 16-bit shape word whose low byte is used at runtime. CSV can be a view, not the canonical source. |
+| `*.3DG` terrain grid | Ordered JSON in the related world directory + PNG previews | Canonical JSON with all five grid buffers | Yes | Yes, via rebuild bridge | PNG previews are only for visualization. Exact hierarchical grid data must be kept in JSON. |
+| `*.WLD` world/campaign | Ordered JSON, optional CSV tables | Canonical JSON preserving named binary tables, name table bytes, and record order | Yes | Yes, via rebuild bridge | Best as structured text: world objects, flight units, terrain grid, name table, and proven mission/category tables. CSV helps spreadsheet editing, but JSON should be canonical. |
+| Palette data | GIMP `.gpl` or JASC `.pal` for editing | JSON with exact DAC tables, mode, and 6-bit/8-bit level metadata | Yes | Indirect via PNG | Editor palette files are useful but not enough; JSON must preserve exact game palette/register metadata. |
 | Text and strings | `.po` + `.json` text bundles | In-binary text regions extracted from executable/overlay segments | Planned | No | No standalone text resource files were identified. Use string-id and source-offset maps to support translation and custom copy editing. |
-| Fonts | Unicode `BDF` + atlas `PNG` + metadata JSON | Extracted font tables in `src/fontdata.h` + metrics in `src/gfx_impl.c` | Yes | No | `export-fonts` emits one BDF, atlas, and sidecar per known font. BDF is the editable Unicode-capable bitmap font target; JSON preserves legacy CP437 source bytes, Unicode codepoints, atlas rects, advance widths, and raw bitmap rows. |
-| Sounds | `.wav` + metadata JSON, unresolved driver sidecars | `F15DGTL.BIN` and sound-driver executables | Partial | No | `export-sounds` emits `F15DGTL.BIN` as a raw unsigned 8-bit PCM WAV plus ASOUND-recovered cue WAVs and metadata. Driver EXEs are preserved as unresolved JSON until synthesized effect tables are decoded. |
-| Manuals/maps | Markdown notes + georeferenced PNG overlays | Not applicable | Yes | No | These are reference material, not game assets. Use them to validate WLD coordinates, target names, and theater symbols. |
+| Fonts | Unicode `BDF` + atlas `PNG`, optional metadata JSON | Extracted font tables in `src/fontdata.h` + metrics in `src/gfx_impl.c` | Yes | Yes | `export-fonts` emits BDF and atlas PNG by default. BDF is authoritative for glyph data and metrics; PNG is authoritative for atlas pixels only. Optional JSON maps codepoints to atlas/index metadata when `--include-metadata` is used. |
+| Sounds | cue `.wav`, optional metadata JSON, optional unresolved driver sidecars | `F15DGTL.BIN` and sound-driver executables | Partial | Yes | `export-sounds` emits ASOUND-recovered cue WAVs by default. Cue WAV files are authoritative for runtime sample replacement; customizers do not need JSON or a full sound blob. `--include-metadata` adds cue JSON, driver sidecars, and `sounds.json`; `--include-raw-blob` additionally emits `F15DGTL.BIN` as a raw unsigned 8-bit PCM reference WAV for reverse engineering only. Driver sidecars preserve hashes/sizes/status, not executable bytes. |
+| Manuals/maps | Markdown notes + georeferenced PNG overlays | Not applicable | Yes | Not a runtime asset | These are reference material, not game assets. Use them to validate WLD coordinates, target names, and theater symbols. |
 
 ### Modern Forward-Compatible Export Target
 
@@ -97,18 +108,133 @@ The modern stable formats for developer workflows are:
 
 - Indexed `PNG` (with embedded palette chunk) for image assets (`.PIC`, `.SPR`) because it is universally supported and
   easy to edit.
-- `glTF 2.0` (`.glb` by default, `.gltf` optional) for `3D3` model previews/editing.  
+- `glTF 2.0` (`.glb` by default, `.gltf` optional) for `3D3` model previews/editing and runtime replacement.  
   Blender users should import/export via glTF (`.blend` is a downstream workspace,
   not the canonical interchange artifact).
-- JSON (and optional YAML) for table/world data (`.3DT`, `.3DG`, `.WLD`), with stable
+- Ordered JSON for table/world data (`.3DT`, `.3DG`, `.WLD`), with stable
   schemas and explicit byte-preservation sidecars.
 - `.po`/`.json` for translatable text bundles and locale work.
 - Unicode `BDF` + font atlas `PNG` + glyph-metrics `JSON` for font extensions and localization.
 - PCM `WAV` (`AIFF/FLAC` as needed) + sidecar JSON for game sounds.
 
+For customizers, the intended authoring surface is the modern media file when it
+can represent the data directly. Edit per-shape GLB in Blender for 3D, indexed
+PNG for images, BDF/PNG for fonts, and WAV for digitized sounds. JSON remains
+the authoritative source for structured tables such as WLD/3DT/3DG, and a small
+manifest/index for media formats. This keeps sidecar editing minimal while still
+preserving ids, offsets, and lookup metadata needed by the loader.
+
+Long-term licensing goal: this pipeline should allow a future install to run
+with freely licensed custom replacement assets only. That is not true for all
+formats today; the current runtime still needs original assets as fallback and
+as the comparison source for unsupported or incomplete replacement paths.
+
 Blender interoperability is achieved via glTF import/export. There is no direct
 `.3D3` editor round-trip in this project. The stable authoritative interchange
-format for model customization is `.glb` (fallback: `.gltf`).
+format for model customization and model replacement is `.glb` (fallback:
+`.gltf`); the matching JSON is only a lightweight index. Per-shape GLBs are
+minimized so a customized model slot carries only the resources referenced by
+that shape. `.glmesh` is a generated runtime cache stored under `cache/`,
+derived from the matching GLB, and not the authoring source. The cache stores
+the MD5 checksum of the source GLB so runtime loading can rebuild stale caches
+automatically.
+
+`PHOTO.3D3` target-view models are a loader special case: the original game
+selectively appends them to the active theater `.3D3` shape table. Modern
+authoring still uses `PHOTO/shape_###.glb`; the OpenGL replacement path maps
+appended target-view slots back to that `PHOTO` directory before looking up the
+per-shape GLB or generated `cache/*.glmesh`.
+
+GLB primitive `extras` are diagnostic/provenance metadata. They let test-time
+validators prove that an unmodified export preserved original `.3D3` primitive
+order and raw color identity, but rendering must still come from GLB
+geometry/materials. A custom GLB exported from Blender may lose those extras and
+still be a valid replacement; old-vs-new proof will simply be weaker for that
+edited shape.
+
+Runtime replacement status:
+
+- The game has a shared converted-asset resolver that searches extensionless
+  export directories (`VN/`, `LIBYA/`, `GULF/`, `15FLT/`, `PHOTO/`, etc.).
+- If `F15_REPLACEMENT_ROOT` is set, the resolver searches that converted/custom
+  asset directory before the usual `converted_assets_all` locations under the
+  game path or current directory. If the variable points at a parent folder, a
+  `converted_assets_all` child is also searched. Missing replacement-root
+  directories are reported once, ignored, and normal fallback locations are
+  still searched. This lets developers test replacement packs without copying
+  them beside the
+  original DOS assets.
+- `F15_ASSET_TOOL` can override the Python bridge command used to rebuild JSON
+  table byte streams and generated GLMESH caches, for example
+  `F15_ASSET_TOOL="python3 /path/to/f15se2-ex/tools/f15assets/cli.py"`. This is
+  useful when `F15_REPLACEMENT_ROOT` points outside the repository layout.
+- Replacement lookup is case-tolerant for modern filenames and grouped model
+  directories, so converted packs do not depend on the source DOS asset casing.
+- Legacy file loads probe for preferred modern replacements before loading old
+  assets and log that the legacy loader remains active until that format has a
+  native modern importer. Current probes cover `.3D3 -> .glb` for OpenGL
+  geometry, full `.3D3.json` for legacy-byte-stream bridge dumps,
+  `.PIC/.SPR -> .png`, and `.WLD/.3DT/.3DG -> .json`.
+- The resolver can locate per-shape model files by stable shape slot, for
+  example `VN/shape_049_SAM_Radar.glb`; those files are the intended runtime
+  source for customized 3D replacements, not the `.3D3.json` sidecar. The
+  OpenGL backend loads matching `cache/*.glmesh` files when their embedded GLB
+  checksum matches and rebuilds missing or stale caches through the
+  `build-glmesh` bridge. The current model loader still reads legacy `.3D3`
+  bytes for shape-slot tables, PHOTO append ranges, comparison, and software
+  fallback; GLB-only/free-asset runtime support requires replacing those table
+  reads with modern metadata before original `.3D3` files can be omitted.
+  Full `.3D3.json` files containing `model_data` can be rebuilt through the
+  legacy-byte-stream bridge; default minimized `.3D3.json` files are treated as
+  metadata-only and leave the old `.3D3` byte stream in place.
+- Digitized sound loading prefers separate `sounds/voice_cue_*.wav` files when
+  present. Each WAV accepts uncompressed mono unsigned 8-bit PCM, and its RIFF
+  sample rate controls replacement playback speed. Missing cue files, empty
+  WAVs, and invalid WAVs fall back to the matching range in `F15DGTL.BIN`.
+  Decoded WAV equivalence is checked by `validate-replacements` and CTest, not
+  during normal gameplay.
+- PIC/SPR loading prefers matching PNG replacements when present. Indexed PNGs
+  are copied as palette indices and their embedded palette is uploaded to the
+  active DAC, so the PNG remains self-contained for pixels and palette.
+  Palette-less indexed PNGs are rejected and fall back to legacy PIC/SPR.
+  `TITLE640.PIC` uses a dedicated 640x350 hi-res PNG path that compares against
+  the original alternating left/right row decode. The replacement path is used
+  by start/end picture wrappers and by flight cockpit picture loads such as
+  `256pit.PIC`. Menu/debrief disk-presence gates for sprite sheets must accept
+  the same PNG replacement path as the later `loadPic()` call, so `.SPR`
+  replacements do not get blocked before loading.
+  `256pit.PIC`, `256Left.Pic`, and `cockpit.PIC`.
+  Truecolor PNGs are accepted as an editing convenience by mapping pixels to the current
+  game palette. Replacement PNGs are sampled into the existing in-game target
+  rectangle, so higher-resolution source PNGs do not enlarge menus, cockpits, or
+  sprite sheets. Pixel and palette equivalence is checked by
+  `validate-replacements` and CTest.
+- WLD/3DT/3DG loading prefers matching JSON replacements when present. Runtime
+  import currently bridges through the converter's `build-binary` command,
+  rebuilding the original byte stream from JSON and feeding that stream to the
+  existing loaders. This preserves runtime memory layout while keeping JSON as
+  the editable source. `F15_ASSET_TOOL` can override the command prefix; by
+  default runtime first looks for `tools/f15assets/cli.py` beside the
+  replacement asset's `converted_assets_all` root, then tries nearby script
+  paths, then falls back to `python3 -m tools.f15assets.cli`. JSON-rebuilt byte
+  equivalence is checked by `validate-replacements` and CTest.
+- Font drawing prefers exported `fonts/font_<id>.bdf`: the runtime parses glyph
+  rows and advance widths, then renders from the BDF data. If BDF is absent or
+  rejected, exported `fonts/font_<id>.png` atlases are tried for glyph pixels;
+  PNG glyph pixels are authoritative, while advance widths currently come from
+  existing font metrics. BDF fonts with incomplete glyphs or zero advance widths
+  are rejected. Built-in font equivalence is checked by `validate-replacements`
+  and CTest.
+- GLB import is implemented for the OpenGL backend through a simple runtime mesh
+  bridge generated from per-shape GLBs. The backend treats `.glb` as the source
+  of truth, loads `cache/*.glmesh` when the embedded source checksum matches,
+  and rebuilds missing or stale cache files from `.glb` through `build-glmesh`.
+  Empty runtime meshes, unsupported primitive modes, bad line/triangle vertex
+  counts, trailing unread bytes, and stale caches are rejected before
+  rebuild/fallback. Replacement runtime mesh equivalence is checked by
+  `validate-replacements` and CTest.
+  Software rendering still uses the original `.3D3` stream. Exported media files
+  are authoritative whenever they overlap JSON.
 
 A practical modernization goal is: export each game format into one of the above
 stable formats plus a machine-readable metadata sidecar (`.json`) before any custom
@@ -129,10 +255,13 @@ executables/overlays rather than as standalone `.txt`, `.fnt`, or `.wav` asset f
 For reliable modding, extend the forward export contract as follows:
 
 1. Text export to `strings.po` + `strings.json`.
-2. Font export to `font_<id>.bdf` + `font_<id>.png` + `font_<id>.json`.
-3. Sound export to `f15dgtl_raw.wav` + `f15dgtl_raw.json`, ASOUND-recovered
-   cue WAVs such as `voice_cue_000_sample0.wav`, plus driver sidecars such as
-   `asound_driver.json` for unresolved synthesis/effect data.
+2. Font export to `font_<id>.bdf` + `font_<id>.png`; optional
+   `font_<id>.json` metadata only with `--include-metadata`.
+3. Sound export to ASOUND-recovered cue WAVs such as
+   `voice_cue_000_sample0.wav`, plus driver sidecars such as
+   `asound_driver.json` for unresolved synthesis/effect data. The full
+   `f15dgtl_raw.wav`/`.json` blob is optional reference output, not the default
+   customizer artifact.
 
 Proposed metadata fields for all three classes:
 
@@ -158,17 +287,17 @@ Translator guidance:
 
 Implement forward export support in this order:
 
-1. `PIC`/`SPR` to indexed PNG + JSON sidecar.
-2. `WLD`, `3DT`, and `3DG` to structured JSON/YAML sidecars.
+1. `PIC`/`SPR` to indexed PNG, with bulky decode JSON only when explicitly requested.
+2. `WLD`, `3DT`, and `3DG` to structured ordered JSON sidecars.
 3. `3D3`/`15FLT.3D3` to glTF export for viewing/editing in modern toolchains.
    Backward conversion/import back to `.3D3` is intentionally unsupported.
 4. Text extraction from executable/overlay data, then export to the formats
    above for localization workflows. Font and sound forward export now have
    initial CLI support.
 
-For editable text, prefer YAML when humans will hand-edit files and JSON when
-tools will generate or validate files. A robust converter can support both, but
-one canonical form should be chosen per format to avoid noisy diffs.
+For editable structured text, use ordered JSON. The converter writes important
+fields first, keeps coordinate-like fields adjacent, and moves large preserved
+base64 fields to the end.
 
 ### Python Converter CLI
 
@@ -181,16 +310,22 @@ model, terrain, world, font, and sound export paths:
 - `.3DG` (`.3dg`)
 - `.WLD` (`.wld`)
 
+The high-level `convert-all` command recurses through the installed game folder
+so campaign/theater subdirectory assets are included.
+
 Usage:
 
 ```text
 python -m tools.f15assets.cli [--pretty] decode <asset> <sidecar.json>
 python -m tools.f15assets.cli [--pretty] decode <input> <output.json> --png <out.png>
-python -m tools.f15assets.cli [--pretty] decode <input> <output.json> --yaml <output.yaml>
 python -m tools.f15assets.cli [--pretty] decode <input.3d3> <output.json> --gltf <out.gltf|out.glb>
-python -m tools.f15assets.cli [--pretty] convert-tree <asset_dir> <out_dir> [--recursive] [--models glb|gltf|none] [--yaml] [--no-png]
+python -m tools.f15assets.cli [--pretty] convert-all <asset_dir> <out_dir> [--include-image-json] [--include-3d3-model-data] [--include-glmesh-cache] [--include-metadata] [--include-raw-blob]
+python -m tools.f15assets.cli [--pretty] convert-tree <asset_dir> <out_dir> [--recursive] [--models glb|gltf|none] [--no-png] [--include-image-json] [--include-3d3-model-data] [--include-glmesh-cache]
 python -m tools.f15assets.cli [--pretty] export-fonts <repo_root> <out_dir> [--no-bdf]
-python -m tools.f15assets.cli [--pretty] export-sounds <asset_dir> <out_dir> [--sample-rate 7850]
+python -m tools.f15assets.cli [--pretty] export-sounds <asset_dir> <out_dir> [--sample-rate 7850] [--include-metadata] [--include-raw-blob]
+python -m tools.f15assets.cli build-binary <asset.json> [--format 3D3|WLD|3DT|3DG]
+python -m tools.f15assets.cli build-glmesh <shape.glb>
+python -m tools.f15assets.cli validate-replacements <asset_dir> <converted_dir> [--repo-root .] [--no-recursive] [--require-all] [--require-generated-cache] [--require-source-proof] [--strict-original-proof] [--allow-custom-glb-differences] [--loadability-only]
 ```
 
 Supported flags:
@@ -198,36 +333,119 @@ Supported flags:
 - `--format`: force a format if the extension is missing or ambiguous.
 - `--png`: extract indexed PNG for PIC/SPR only.
 - `--gltf`: export `*.3D3` to `.gltf` or `.glb` while writing the `3D3` JSON sidecar.
-- `--yaml`: optional YAML sidecar output for table formats (`3DT`, `3DG`, `WLD`) and other parser outputs.
 - `--pretty`: pretty-print JSON output. It is a global option and must appear
   before the subcommand.
 - `convert-tree` command:
   - `--recursive`: recurse input directories.
   - `--models {glb,gltf,none}`: choose 3D model output; defaults to `glb` for self-contained outputs.
   - `--no-png`: skip image exports for PIC/SPR.
-  - `--yaml`: emit YAML sidecars for all supported parsable formats.
+  - `--include-image-json`: also write bulky PIC/SPR decode JSON. Default image
+    conversion writes only PNG because PNG is the runtime source.
+  - `--include-3d3-model-data`: also write bulky `.3D3` `model_data` base64.
+    Default model conversion writes minimized JSON because GLB is the geometry
+    source. Full JSON with `model_data` is required only when `build-binary` or
+    the runtime bridge must rebuild legacy `.3D3` bytes.
+  - `--include-glmesh-cache`: also pre-generate `cache/*.glmesh` runtime caches.
+    Default model conversion writes GLB only and lets the game rebuild caches.
 - `export-fonts` command:
   - Reads `src/fontdata.h` and `src/gfx_impl.c`.
-  - Emits `font_<id>.bdf`, `font_<id>.png`, and `font_<id>.json`.
+  - Emits `font_<id>.bdf` and `font_<id>.png` by default.
+  - `--include-metadata` additionally emits `font_<id>.json` and `fonts.json`.
   - Current known font ids are `0`, `1`, `3`, `4`, and `5`.
   - JSON uses Unicode codepoints while preserving original CP437 source bytes
     (`source_byte`, `source_encoding`) so additional glyphs for other languages
     can be appended without losing the original game mapping.
 - `export-sounds` command:
   - Reads `F15DGTL.BIN` from the installed game directory and emits
-    `f15dgtl_raw.wav` plus `f15dgtl_raw.json`.
-  - Also emits driver-backed cue files (`voice_cue_000_sample0.wav`,
+    driver-backed cue files (`voice_cue_000_sample0.wav`,
     `voice_cue_001_sample4.wav`, `voice_cue_002_sample2_variant0.wav`, ...)
-    with per-cue JSON. ASOUND uses inclusive playback ranges:
+    by default. ASOUND uses inclusive playback ranges:
     `0x0000..0x31F3`, `0x31F4..0x4796`,
     `0x4797..0x5C92`, `0x5C93..0x6A1A`, and `0x6A1B..0x7D9D`.
     The final three ranges are rotating variants for `audio_playSample(2)`.
+  - `--include-metadata` additionally emits per-cue JSON, unresolved driver
+    sidecars, and `sounds.json` for reverse-engineering notes.
+  - `--include-raw-blob` additionally emits `f15dgtl_raw.wav` plus
+    `f15dgtl_raw.json` for reverse-engineering reference.
     `voiceCueThresholds` in `egdata.c` are availability checks before playback,
     not the complete split table.
-  - Preserves sound-driver executables (`ASOUND.EXE`, `ISOUND.EXE`,
-    `NSOUND.EXE`, `RSOUND.EXE`, `TSOUND.EXE`) as unresolved JSON sidecars.
+  - With `--include-metadata`, records sound-driver executables
+    (`ASOUND.EXE`, `ISOUND.EXE`, `NSOUND.EXE`, `RSOUND.EXE`, `TSOUND.EXE`) as
+    unresolved JSON sidecars. Default sound export omits these sidecars.
   - Uses unsigned 8-bit mono PCM at a PIT-derived `7850` Hz by default; override
     with `--sample-rate` if a different recovered driver rate is confirmed.
+- `validate-replacements` command:
+  - Performs explicit old-vs-modern comparison outside runtime loading.
+  - Recurses through the original asset folder by default, matching
+    `convert-all`; use `--no-recursive` for a flat folder check.
+  - `--require-all` requires authoring replacements. Generated
+    `cache/*.glmesh` runtime caches are validated when present and required only
+    with `--require-generated-cache`.
+  - `--require-source-proof` fails validation when GLB/GLMESH source primitive
+    extras are missing or differ from a fresh original export. Without it,
+    metadata loss is a warning because custom Blender exports may strip extras
+    while still providing valid replacement geometry/materials.
+  - `--strict-original-proof` is the converter-regression mode and implies
+    `--require-generated-cache` plus `--require-source-proof`.
+  - `--allow-custom-glb-differences` warns instead of failing when per-shape GLB
+    primitive counts or source proof metadata differ from the original `.3D3`
+    export. It is for customized model packs, not converter regression proof.
+  - `--loadability-only` validates that modern replacements parse and have the
+    required basic structure, but skips old-vs-new equality checks. Use it for
+    edited/custom replacement packs. It is incompatible with
+    `--strict-original-proof`, `--require-source-proof`, and
+    `--allow-custom-glb-differences`. If the original input directory is
+    intentionally absent, `--loadability-only` runs source-free checks directly
+    over the converted output tree; the output argument may be either the
+    `converted_assets_all` folder or a parent folder containing it.
+    `--require-all` is rejected in that case because there is no original asset
+    inventory to require against. If no replacement files are found, the
+    validator prints a warning listing the expected replacement kinds (`PNG`,
+    `WAV`, `BDF`, `WLD/3DT/3DG JSON`, `3D3 JSON`, `GLB`, or `GLMESH`) so a wrong output path is visible. JSON table
+    replacements are still rebuilt and must produce a non-empty legacy byte
+    stream; WAV cue replacements must parse, contain at least one sample, and
+    carry a valid RIFF sample rate; BDF glyphs must have bitmap rows and
+    positive advance widths for all 96 runtime glyphs from U+0020 through
+    U+007F, unless the matching PNG atlas fallback is loadable in
+    `--loadability-only`; source-free PNG font atlases are checked for the
+    current runtime font ids whose cell dimensions are known; indexed PNGs must include an embedded palette, and
+    truecolor PNGs are accepted in loadability-only mode like the runtime
+    loader; per-shape GLBs and generated GLMESH caches must contain renderable
+    geometry or line/point primitives. Source-free minimized `.3D3.json` files
+    are checked for parseable slot metadata, monotonic offsets, and valid
+    `model_data_size`; exact slot-table equivalence still requires original
+    `.3D3` bytes.
+    With `--require-all`, fonts require at least one runtime source per known
+    font: BDF first, or PNG atlas fallback.
+    Extra source-free `sounds/voice_cue_*.wav` files are parsed in loadability
+    mode, but the current runtime playback path uses only the recovered known
+    cue filenames emitted by `export-sounds`.
+    Combined overview GLBs and converter-only proof metadata are ignored in this
+    mode because per-shape GLB geometry is the runtime-editable source of truth.
+  - Currently compares `PIC`/`SPR` legacy decode pixels with indexed PNG
+    replacement pixels byte-for-byte, plus embedded/external PNG palette data
+    when the source palette is known. Byte-for-byte image comparison requires
+    indexed PNG; use `--loadability-only` for edited truecolor PNG replacements.
+  - Also compares `F15DGTL.BIN` ASOUND cue ranges with
+    `sounds/voice_cue_*.wav` sample bytes and compares cue WAV sample rates
+    against the recovered/export default.
+  - Also compares in-repo original font tables with `fonts/font_<id>.bdf`
+    glyph bitmaps/advance widths and `fonts/font_<id>.png` atlas glyph pixels.
+  - Also rebuilds `WLD`, `3DT`, and `3DG` bytes from JSON and compares them with
+    the original files.
+  - Also validates minimized `.3D3.json` slot metadata: shape offset table,
+    `model_data_size`, monotonic offsets, and absence of unnecessary bulky
+    `model_data` in default exports. This proves the compact metadata needed by
+    a future GLB-only/free-asset loader without duplicating geometry bytecode.
+    If bulky `model_data` is present, validation also rebuilds the `.3D3` byte
+    stream and compares it with the original file.
+  - Also validates `.3D3` GLB structure: combined GLB metadata, renderable shape
+    count, per-shape GLB presence, minimized per-shape marker, and stable
+    `source_shape_index` metadata. Present `.glmesh` runtime caches are compared
+    against the source GLB expansion, including triangle/line/point primitive
+    counts.
+  - Future validators should add full GLB rendered-equivalence checks after the
+    OpenGL import path is validated against representative scenes.
 
 Current objective is forward conversion from game assets to modern editable
 formats only. Rebuild/import pathways are intentionally unsupported to keep the
@@ -237,10 +455,12 @@ A required modern compatibility baseline is therefore:
 
 - `.glb` (fallback `.gltf`) for 3D geometry (Blender-first workflows), and it should remain self-contained.
 - Indexed `.png` for image assets.
-- JSON or YAML text for structural tables and world data, with strict,
+- Ordered JSON text for structural tables and world data, with strict,
   versioned sidecar metadata.
 
-PIC/SPR sidecars are lossless for decoded pixel payloads at export time.
+PIC/SPR decode sidecars are optional and lossless for decoded pixel payloads at
+export time. They are useful for reverse engineering, but not needed for normal
+runtime replacement because PNG is authoritative.
 
 - `format`: format tag (`PIC`)
 - `decoded_width`/`decoded_height`: currently expected to be `320`/`200`
@@ -270,9 +490,11 @@ Current text/font/sound extraction state:
 - `PIC`/`SPR`/`3D3`/`3DT`/`3DG`/`WLD` decoding is the current converter focus.
 - Font extraction is implemented from the current recovered font tables and
   metrics.
-- Sound extraction is partial: `F15DGTL.BIN` is exported as a raw WAV plus
-  ASOUND-recovered cue WAVs. Digitized cue ranges are known; synthesized effect
-  driver tables remain unresolved sidecars.
+- Sound extraction is partial: `F15DGTL.BIN` is exported as ASOUND-recovered
+  cue WAVs by default. Cue JSON, driver sidecars, and the full raw WAV blob are
+  optional reverse-engineering output; they are not needed for customization or
+  runtime replacement. Digitized cue ranges are known; synthesized effect driver
+  tables remain unresolved sidecars when metadata export is requested.
 - Text extraction remains a roadmap item and should emit `status: unresolved`
   entries until parsers are implemented.
 
@@ -284,7 +506,7 @@ Reasons:
 
 - Blender scripting is Python, so `.3D3` to Blender import/export can share code
   with the command-line converter.
-- PNG, indexed palettes, YAML, JSON, CSV, and binary struct handling are all
+- PNG, indexed palettes, JSON, CSV, and binary struct handling are all
   well-supported.
 - Reverse-engineering work benefits from quick scripts, readable parsers, and
   fast iteration more than from maximum runtime speed.
@@ -301,15 +523,45 @@ tools/f15assets/
     f15assets/
         pic.py          # PIC/SPR LZW/RLE decode
         fonts.py        # extracted font tables to BDF/PNG/JSON
-        sounds.py       # F15DGTL.BIN WAV/cue export and driver sidecars
+        sounds.py       # F15DGTL.BIN cue WAV export and optional driver sidecars
         model3d.py      # .3D3 container and display-list parser
         terrain.py      # .3DT and .3DG
         world.py        # .WLD
         io.py           # binary/base64 helpers
+        validation_compare.py            # stable facade for validation diff helpers
+        validation_compare_core.py       # shared byte/count/sequence comparisons
+        validation_compare_image.py      # PIC/SPR PNG pixel and palette comparisons
+        validation_compare_font.py       # BDF/PNG font comparisons
+        validation_compare_sound.py      # cue WAV comparisons
+        validation_compare_model3d.py    # GLB/GLMESH primitive comparisons
+        validation_compare_structured.py # WLD/3DT/3DG rebuild comparisons
+        validation_image.py              # PIC/SPR PNG replacement validator
+        validation_font.py               # BDF/PNG font replacement validator
+        validation_sound.py              # cue WAV replacement validator
+        validation_structured.py         # WLD/3DT/3DG JSON replacement validator
+        validation_model3d.py            # .3D3 JSON/GLB/GLMESH replacement validator
     tests/
         test_smoke.py
         test_full_assets.py
 ```
+
+Replacement comparison helpers live under `src/shared/asset_compare*.c` for
+test/developer tooling. Loaders should focus on finding and loading modern
+assets during gameplay; CTest/Python validation owns old-vs-modern equivalence
+proof. Byte-stream checks live in `asset_compare_bytes.c`, indexed image/palette
+checks in `asset_compare_image.c`, bitmap font checks in `asset_compare_font.c`,
+digitized cue checks in `asset_compare_sound.c`, and renderer-independent 3D
+topology/color/source-metadata reporting in `asset_compare_3d.c`. Tool-side
+validation diff helpers live in `tools/f15assets/f15assets/validation_compare.py`;
+that file is a stable facade over per-format `validation_compare_*` modules.
+Per-format replacement validators live in `validation_image.py`,
+`validation_font.py`, `validation_sound.py`, `validation_structured.py`, and
+`validation_model3d.py`; each exposes a `validate_*` entry point, loads/parses
+assets, and delegates reusable diff reporting to `validation_compare.py`.
+`cli.py` should pass repository/output path policy into those validators rather
+than owning format-specific comparison logic. Renderer-specific or
+parser-specific comparisons can remain near their loaders until their
+dependencies are cleanly separable.
 
 Do not start with a mixed-language converter. Add Rust or C++ later only if a
 specific hot path or library boundary needs it. If that happens, keep the file
@@ -643,7 +895,7 @@ mission/runtime fields. A future `.WLD` round-trip converter should preserve the
 original load order above, including the named binary tables.
 
 For editor-facing exports, keep `name_table` bytes as parsed and include any
-suffix bytes beyond the game payload as `trailing_bytes` in the JSON/YAML
+suffix bytes beyond the game payload as `trailing_bytes` in the JSON
 representation so variant or unknown tails are not discarded.
 
 ## Manual and Map Facts Useful for RE

--- a/src/asound/asound_model.c
+++ b/src/asound/asound_model.c
@@ -1068,6 +1068,30 @@ const AsoundU8 asound_release_voice5[] = {
     0x00u,
 };
 
+size_t asound_intro_voice_length(int voice) {
+    switch (voice) {
+    case 0: return sizeof(asound_intro_voice0);
+    case 1: return sizeof(asound_intro_voice1);
+    case 2: return sizeof(asound_intro_voice2);
+    case 3: return sizeof(asound_intro_voice3);
+    case 4: return sizeof(asound_intro_voice4);
+    case 5: return sizeof(asound_intro_voice5);
+    default: return 0;
+    }
+}
+
+size_t asound_release_voice_length(int voice) {
+    switch (voice) {
+    case 0: return sizeof(asound_release_voice0);
+    case 1: return sizeof(asound_release_voice1);
+    case 2: return sizeof(asound_release_voice2);
+    case 3: return sizeof(asound_release_voice3);
+    case 4: return sizeof(asound_release_voice4);
+    case 5: return sizeof(asound_release_voice5);
+    default: return 0;
+    }
+}
+
 void asound_log_init(AsoundEventLog *log, AsoundEvent *events, size_t capacity) {
     log->events = events;
     log->count = 0;

--- a/src/asound/asound_model.h
+++ b/src/asound/asound_model.h
@@ -155,6 +155,8 @@ extern const AsoundU8 asound_release_voice2[];
 extern const AsoundU8 asound_release_voice3[];
 extern const AsoundU8 asound_release_voice4[];
 extern const AsoundU8 asound_release_voice5[];
+size_t asound_intro_voice_length(int voice);
+size_t asound_release_voice_length(int voice);
 
 void asound_log_init(AsoundEventLog *log, AsoundEvent *events, size_t capacity);
 int asound_log_push(AsoundEventLog *log, AsoundEventType type, AsoundU8 voice,

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -14,6 +14,7 @@
 
 #include <SDL3/SDL.h>
 
+#include "../shared/asset_compare.h"
 #include "asound_model.h"
 #include "asopl.h"
 /* opl3.h has no extern "C" guard of its own; this TU compiles as C++ but opl3.c
@@ -23,6 +24,9 @@ extern "C" {
 }
 
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
 #include "inttype.h"
 #include <dos.h>
@@ -33,7 +37,7 @@ extern "C" {
 
 #define ASND_OUT_RATE 44100 /* SDL output sample rate (Hz) */
 #define ASND_TICK_HZ 60     /* sequencer tick = game tick rate */
-#define ASND_SAMPLE_HZ 7231 /* F15DGTL.BIN playback rate (PIT ch2 1193182/165) */
+#define ASND_SAMPLE_HZ 7850 /* Recovered F15DGTL.BIN cue playback rate, shared with exported WAVs. */
 #define ASND_CHUNK 512      /* max frames generated per inner loop pass */
 
 static AsoplState g_opl; /* OPL register shadow (event -> regs) */
@@ -47,12 +51,334 @@ static bool g_ready;                              /* device opened */
 static AsoundU8 *g_blob;
 static int g_blobSize;
 static bool g_smpActive;
+static const AsoundU8 *g_smpData;
+static int g_smpSize;
 static double g_smpPos; /* fractional read position (bytes) */
-static int g_smpEnd;
-static const double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
+static double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
+
+typedef struct ReplacementCue {
+    AsoundU16 start;
+    AsoundU16 endInclusive;
+    const char *id;
+    AsoundU8 *data;
+    int size;
+    int sampleRate;
+} ReplacementCue;
+
+static ReplacementCue g_replacementCues[] = {
+    {0x0000u, 0x31f3u, "voice_cue_000_sample0", NULL, 0, 0},
+    {0x31f4u, 0x4796u, "voice_cue_001_sample4", NULL, 0, 0},
+    {0x4797u, 0x5c92u, "voice_cue_002_sample2_variant0", NULL, 0, 0},
+    {0x5c93u, 0x6a1au, "voice_cue_003_sample2_variant1", NULL, 0, 0},
+    {0x6a1bu, 0x7d9du, "voice_cue_004_sample2_variant2", NULL, 0, 0},
+};
+
+typedef struct ReplacementMusic {
+    AsoundU8 *intro[ASOUND_STREAM_COUNT];
+    AsoundU8 *release[ASOUND_STREAM_COUNT];
+    int introSize[ASOUND_STREAM_COUNT];
+    int releaseSize[ASOUND_STREAM_COUNT];
+    int loaded;
+    int tried;
+} ReplacementMusic;
+
+static ReplacementMusic g_replacementMusic;
 
 /* Fractional countdown (in output frames) to the next sequencer tick. */
 static double g_tickAccum;
+
+static uint16_t rd16le(const AsoundU8 *p) {
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+static uint32_t rd32le(const AsoundU8 *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static AsoundU8 *readEntireIo(SDL_IOStream *io, Sint64 *outSize) {
+    Sint64 size;
+    AsoundU8 *data;
+    size_t got;
+
+    if (outSize) *outSize = 0;
+    if (!io) return NULL;
+    size = SDL_GetIOSize(io);
+    if (size <= 0) return NULL;
+
+    data = (AsoundU8 *)SDL_malloc((size_t)size);
+    if (!data) return NULL;
+    got = SDL_ReadIO(io, data, (size_t)size);
+    if (got != (size_t)size) {
+        SDL_free(data);
+        return NULL;
+    }
+    if (outSize) *outSize = size;
+    return data;
+}
+
+static int decodePcm8Wav(const AsoundU8 *wav, Sint64 wavSize, AsoundU8 **outSamples, int *outSampleRate) {
+    Sint64 pos;
+    int fmtOk = 0;
+    uint32_t sampleRate = 0;
+    uint16_t channels = 0;
+    uint16_t bitsPerSample = 0;
+    uint16_t audioFormat = 0;
+
+    if (outSamples) *outSamples = NULL;
+    if (outSampleRate) *outSampleRate = 0;
+    if (!wav || wavSize < 44 || memcmp(wav, "RIFF", 4) != 0 || memcmp(wav + 8, "WAVE", 4) != 0) {
+        return 0;
+    }
+
+    pos = 12;
+    while (pos + 8 <= wavSize) {
+        const AsoundU8 *chunk = wav + pos;
+        uint32_t chunkSize = rd32le(chunk + 4);
+        Sint64 dataPos = pos + 8;
+        Sint64 nextPos = dataPos + chunkSize + (chunkSize & 1);
+        if (dataPos + chunkSize > wavSize) return 0;
+
+        if (memcmp(chunk, "fmt ", 4) == 0 && chunkSize >= 16) {
+            audioFormat = rd16le(wav + dataPos);
+            channels = rd16le(wav + dataPos + 2);
+            sampleRate = rd32le(wav + dataPos + 4);
+            bitsPerSample = rd16le(wav + dataPos + 14);
+            fmtOk = (audioFormat == 1 && channels == 1 && bitsPerSample == 8 && sampleRate > 0);
+        } else if (memcmp(chunk, "data", 4) == 0) {
+            AsoundU8 *samples;
+            if (!fmtOk || chunkSize == 0) return 0;
+            samples = (AsoundU8 *)SDL_malloc(chunkSize);
+            if (!samples) return 0;
+            memcpy(samples, wav + dataPos, chunkSize);
+            if (outSamples) *outSamples = samples;
+            if (outSampleRate) *outSampleRate = (int)sampleRate;
+            return (int)chunkSize;
+        }
+        pos = nextPos;
+    }
+    return 0;
+}
+
+static AsoundU8 *loadLegacyDigitizedBlob(int *outSize) {
+    SDL_IOStream *io = openFile("F15DGTL.BIN", 0);
+    Sint64 size = 0;
+    AsoundU8 *data;
+    if (outSize) *outSize = 0;
+    if (!io) return NULL;
+    data = readEntireIo(io, &size);
+    SDL_CloseIO(io);
+    if (!data) return NULL;
+    if (outSize) *outSize = (int)size;
+    return data;
+}
+
+static ReplacementCue *findCueForRange(AsoundU16 start, AsoundU16 endInclusive) {
+    int i;
+    for (i = 0; i < (int)(sizeof(g_replacementCues) / sizeof(g_replacementCues[0])); i++) {
+        if (g_replacementCues[i].start == start && g_replacementCues[i].endInclusive == endInclusive) {
+            return &g_replacementCues[i];
+        }
+    }
+    return NULL;
+}
+
+static int loadReplacementCueWavs(const AsoundU8 *legacyBlob, int legacyBlobSize) {
+    int i;
+    int loaded = 0;
+    for (i = 0; i < (int)(sizeof(g_replacementCues) / sizeof(g_replacementCues[0])); i++) {
+        ReplacementCue *cue = &g_replacementCues[i];
+        char replacementPath[512];
+        SDL_IOStream *wavIo;
+        Sint64 wavSize = 0;
+        AsoundU8 *wavData;
+        AsoundU8 *samples = NULL;
+        int sampleSize = 0;
+        int sampleRate = 0;
+
+        SDL_free(cue->data);
+        cue->data = NULL;
+        cue->size = 0;
+        cue->sampleRate = 0;
+
+        if (!findReplacementAssetPath(cue->id, ".wav", replacementPath, sizeof(replacementPath))) {
+            continue;
+        }
+
+        wavIo = SDL_IOFromFile(replacementPath, "rb");
+        wavData = readEntireIo(wavIo, &wavSize);
+        if (wavIo) SDL_CloseIO(wavIo);
+        if (wavData) {
+            sampleSize = decodePcm8Wav(wavData, wavSize, &samples, &sampleRate);
+            SDL_free(wavData);
+        }
+        if (!samples || sampleSize <= 0) {
+            SDL_free(samples);
+            LogWarn(("asset replacement: failed to decode non-empty cue WAV %s; legacy sample range remains fallback", replacementPath));
+            continue;
+        }
+
+        assetCompareSoundCueRange(
+            cue->id,
+            cue->start,
+            cue->endInclusive,
+            ASND_SAMPLE_HZ,
+            legacyBlob,
+            legacyBlobSize > 0 ? (size_t)legacyBlobSize : 0u,
+            samples,
+            (size_t)sampleSize,
+            sampleRate,
+            replacementPath
+        );
+        cue->data = samples;
+        cue->size = sampleSize;
+        cue->sampleRate = sampleRate;
+        loaded++;
+        LogInfo((
+            "asset replacement: loaded sound cue %s from %s (%d bytes, %d Hz)",
+            cue->id,
+            replacementPath,
+            sampleSize,
+            sampleRate
+        ));
+    }
+    return loaded;
+}
+
+static const char *jsonFindAfter(const char *text, const char *needle) {
+    return text && needle ? strstr(text, needle) : NULL;
+}
+
+static AsoundU8 *parseJsonStreamBytes(const char *json, const char *symbol, int *outCount) {
+    char needle[96];
+    const char *p;
+    const char *array;
+    AsoundU8 *bytes = NULL;
+    int count = 0;
+    int cap = 0;
+
+    if (outCount) *outCount = 0;
+    snprintf(needle, sizeof(needle), "\"source_symbol\": \"%s\"", symbol);
+    p = jsonFindAfter(json, needle);
+    if (!p) return NULL;
+    array = jsonFindAfter(p, "\"stream_bytes\"");
+    if (!array) return NULL;
+    array = strchr(array, '[');
+    if (!array) return NULL;
+    array++;
+
+    while (*array && *array != ']') {
+        char *end = NULL;
+        long value;
+        while (*array == ' ' || *array == '\n' || *array == '\r' || *array == '\t' || *array == ',') array++;
+        if (*array == ']') break;
+        value = strtol(array, &end, 10);
+        if (end == array || value < 0 || value > 255) {
+            SDL_free(bytes);
+            return NULL;
+        }
+        if (count >= cap) {
+            int newCap = cap ? cap * 2 : 64;
+            AsoundU8 *newBytes = (AsoundU8 *)SDL_realloc(bytes, (size_t)newCap);
+            if (!newBytes) {
+                SDL_free(bytes);
+                return NULL;
+            }
+            bytes = newBytes;
+            cap = newCap;
+        }
+        bytes[count++] = (AsoundU8)value;
+        array = end;
+    }
+    if (count <= 0) {
+        SDL_free(bytes);
+        return NULL;
+    }
+    if (outCount) *outCount = count;
+    return bytes;
+}
+
+static void freeReplacementMusic(void) {
+    int phase, voice;
+    AsoundU8 **sets[2] = {g_replacementMusic.intro, g_replacementMusic.release};
+    for (phase = 0; phase < 2; phase++) {
+        for (voice = 0; voice < ASOUND_STREAM_COUNT; voice++) {
+            SDL_free(sets[phase][voice]);
+            sets[phase][voice] = NULL;
+            if (phase == 0) g_replacementMusic.introSize[voice] = 0;
+            else g_replacementMusic.releaseSize[voice] = 0;
+        }
+    }
+    g_replacementMusic.loaded = 0;
+}
+
+static int loadReplacementIntroMusic(void) {
+    char replacementPath[512];
+    SDL_IOStream *io;
+    Sint64 jsonSize = 0;
+    char *json;
+    int voice;
+
+    if (g_replacementMusic.tried) return g_replacementMusic.loaded;
+    g_replacementMusic.tried = 1;
+
+    if (!findReplacementAssetPath("sounds/intro_music", ".asound.json", replacementPath, sizeof(replacementPath))) {
+        return 0;
+    }
+
+    io = SDL_IOFromFile(replacementPath, "rb");
+    json = (char *)readEntireIo(io, &jsonSize);
+    if (io) SDL_CloseIO(io);
+    if (!json || jsonSize <= 0) {
+        SDL_free(json);
+        LogWarn(("asset replacement: failed to read intro music %s; using built-in ASOUND streams", replacementPath));
+        return 0;
+    }
+
+    /* readEntireIo returns exact file bytes. Add a terminator for this
+     * purpose-built parser; the JSON remains the authoritative music data. */
+    {
+        char *terminated = (char *)SDL_realloc(json, (size_t)jsonSize + 1u);
+        if (!terminated) {
+            SDL_free(json);
+            return 0;
+        }
+        json = terminated;
+        json[jsonSize] = '\0';
+    }
+
+    freeReplacementMusic();
+    for (voice = 0; voice < ASOUND_STREAM_COUNT; voice++) {
+        char symbol[64];
+        snprintf(symbol, sizeof(symbol), "asound_intro_voice%d", voice);
+        g_replacementMusic.intro[voice] = parseJsonStreamBytes(json, symbol, &g_replacementMusic.introSize[voice]);
+        snprintf(symbol, sizeof(symbol), "asound_release_voice%d", voice);
+        g_replacementMusic.release[voice] = parseJsonStreamBytes(json, symbol, &g_replacementMusic.releaseSize[voice]);
+        if (!g_replacementMusic.intro[voice] || !g_replacementMusic.release[voice]) {
+            freeReplacementMusic();
+            SDL_free(json);
+            LogWarn(("asset replacement: malformed intro music %s; using built-in ASOUND streams", replacementPath));
+            return 0;
+        }
+    }
+    SDL_free(json);
+    g_replacementMusic.loaded = 1;
+    LogInfo(("asset replacement: loaded intro music from %s", replacementPath));
+    return 1;
+}
+
+static int startReplacementMusicPhase(int releasePhase) {
+    AsoundDriver *drv;
+    int voice;
+    if (!loadReplacementIntroMusic()) return 0;
+    drv = sound_driver_state();
+    for (voice = 0; voice < ASOUND_STREAM_COUNT; voice++) {
+        asound_stream_init(
+            &drv->streams[voice],
+            releasePhase ? g_replacementMusic.release[voice] : g_replacementMusic.intro[voice]
+        );
+    }
+    return 1;
+}
 static const double g_samplesPerTick = (double)ASND_OUT_RATE / (double)ASND_TICK_HZ;
 
 /* ---- OPL shadow -> chip --------------------------------------------------- */
@@ -74,12 +400,28 @@ static void asnd_syncChip(void) {
 /* ---- sequencer tick (audio thread, under g_lock) -------------------------- */
 
 static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
+    ReplacementCue *cue = findCueForRange(start, end);
+    int s, e;
+    if (cue && cue->data && cue->size > 0) {
+        g_smpData = cue->data;
+        g_smpSize = cue->size;
+        g_smpPos = 0;
+        /* Replacement WAVs are the editable source of truth, so their RIFF
+         * sample rate controls playback speed instead of the legacy blob rate. */
+        g_smpStep = (double)(cue->sampleRate > 0 ? cue->sampleRate : ASND_SAMPLE_HZ) / (double)ASND_OUT_RATE;
+        g_smpActive = true;
+        return;
+    }
+
     if (!g_blob || g_blobSize <= 0) return;
-    int s = start, e = end;
+    s = start;
+    e = (int)end + 1;
     if (e > g_blobSize) e = g_blobSize;
     if (s < 0 || s >= e) return;
-    g_smpPos = s;
-    g_smpEnd = e;
+    g_smpData = g_blob + s;
+    g_smpSize = e - s;
+    g_smpPos = 0;
+    g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
     g_smpActive = true;
 }
 
@@ -108,12 +450,12 @@ static void asnd_mixSample(Sint16 *buf, int frames) {
     if (!g_smpActive) return;
     for (int i = 0; i < frames; i++) {
         int idx = (int)g_smpPos;
-        if (idx >= g_smpEnd) {
+        if (idx >= g_smpSize) {
             g_smpActive = false;
             break;
         }
         /* 8-bit unsigned -> signed, scaled below full-scale to leave OPL headroom */
-        int s = ((int)g_blob[idx] - 128) * 200;
+        int s = ((int)g_smpData[idx] - 128) * 200;
         int l = buf[2 * i] + s;
         int r = buf[2 * i + 1] + s;
         if (l > 32767)
@@ -257,10 +599,16 @@ static bool asnd_introVoicesActive(void) {
  * defensive caps so a stuck stream can never hang the title. */
 int FAR CDECL audio_playIntro(void) {
     asnd_openDevice();
-    if (!g_ready) return 0;
+    if (!g_ready) {
+        LogWarn(("asound: intro music skipped because no audio device is ready"));
+        return 0;
+    }
 
+    LogInfo(("asound: playing intro music"));
     SDL_LockMutex(g_lock);
-    sound_driver_play_intro();
+    if (!startReplacementMusicPhase(0)) {
+        sound_driver_play_intro();
+    }
     SDL_UnlockMutex(g_lock);
 
     input_setMode(INPUT_MODE_MENU);
@@ -272,7 +620,9 @@ int FAR CDECL audio_playIntro(void) {
 
     /* release tail (adlib_start_intro_release), then let it decay out */
     SDL_LockMutex(g_lock);
-    asound_driver_start_intro_rel(sound_driver_state());
+    if (!startReplacementMusicPhase(1)) {
+        asound_driver_start_intro_rel(sound_driver_state());
+    }
     SDL_UnlockMutex(g_lock);
     deadline = SDL_GetTicksNS() + 2 * SDL_NS_PER_SECOND;
     while (asnd_introVoicesActive() && SDL_GetTicksNS() < deadline) {
@@ -288,6 +638,7 @@ int FAR CDECL audio_playIntro(void) {
     asnd_syncChip();
     g_smpActive = false;
     SDL_UnlockMutex(g_lock);
+    LogInfo(("asound: intro music finished"));
     return 0;
 }
 
@@ -335,38 +686,90 @@ int FAR CDECL audio_noiseTick(void) { return 0; }
 
 /* ---- digitized sample blob ----------------------------------------------- */
 
-/* Load F15DGTL.BIN (the digitized voice/effect blob) and return its size, which
- * the game stores in f15DgtlResult and passes to audio_setup as the sample-
- * variant selector (and uses to gate voice cues). 0 on failure -> cues disabled. */
+/* Load F15DGTL.BIN (the digitized voice/effect blob) and any modern cue WAVs.
+ * The legacy blob size is still returned because game code stores it in
+ * f15DgtlResult and passes it to audio_setup as the sample-variant selector.
+ * If the blob is missing but cue WAVs exist, return the known ASOUND span so
+ * those modern replacements can play without requiring JSON sidecars. */
 int loadF15DgtlBin(void) {
-    SDL_IOStream *io = openFile("F15DGTL.BIN", 0);
-    if (!io) {
-        LogError(("asound: cannot open F15DGTL.BIN"));
-        return 0;
-    }
-    Sint64 size = SDL_GetIOSize(io);
-    if (size <= 0) {
-        SDL_CloseIO(io);
-        return 0;
-    }
+    AsoundU8 *data;
+    int size = 0;
+    int replacementCueCount;
 
-    AsoundU8 *data = (AsoundU8 *)SDL_malloc((size_t)size);
-    if (!data) {
-        SDL_CloseIO(io);
-        return 0;
-    }
-    size_t got = SDL_ReadIO(io, data, (size_t)size);
-    SDL_CloseIO(io);
-    if (got != (size_t)size) {
-        SDL_free(data);
+    data = loadLegacyDigitizedBlob(&size);
+    replacementCueCount = loadReplacementCueWavs(data, size);
+    if ((!data || size <= 0) && replacementCueCount <= 0) {
+        LogError(("asound: cannot open F15DGTL.BIN or replacement cue WAVs"));
         return 0;
     }
 
     if (g_lock) SDL_LockMutex(g_lock);
     SDL_free(g_blob);
     g_blob = data;
-    g_blobSize = (int)size;
+    g_blobSize = size;
     if (g_lock) SDL_UnlockMutex(g_lock);
 
-    return (int)size;
+    if (size > 0) return size;
+    return 0x7d9e;
 }
+
+#ifdef DEBUG
+int asound_testCompareReplacementCues(void) {
+    AsoundU8 *legacyBlob = NULL;
+    int legacySize = 0;
+    int loaded;
+    int i;
+
+    legacyBlob = loadLegacyDigitizedBlob(&legacySize);
+    if (!legacyBlob || legacySize <= 0) {
+        SDL_free(legacyBlob);
+        return 0;
+    }
+    loaded = loadReplacementCueWavs(legacyBlob, legacySize);
+    if (loaded != (int)(sizeof(g_replacementCues) / sizeof(g_replacementCues[0]))) {
+        SDL_free(legacyBlob);
+        return 0;
+    }
+    for (i = 0; i < (int)(sizeof(g_replacementCues) / sizeof(g_replacementCues[0])); i++) {
+        ReplacementCue *cue = &g_replacementCues[i];
+        int start = cue->start;
+        int end = (int)cue->endInclusive + 1;
+        int expectedSize = end - start;
+        if (!cue->data || cue->sampleRate != ASND_SAMPLE_HZ ||
+            cue->size != expectedSize || start < 0 || end > legacySize ||
+            memcmp(cue->data, legacyBlob + start, (size_t)expectedSize) != 0) {
+            SDL_free(legacyBlob);
+            return 0;
+        }
+    }
+    SDL_free(legacyBlob);
+    return 1;
+}
+
+int asound_testCompareReplacementIntroMusic(void) {
+    static const AsoundU8 *const legacyIntro[ASOUND_STREAM_COUNT] = {
+        asound_intro_voice0, asound_intro_voice1, asound_intro_voice2,
+        asound_intro_voice3, asound_intro_voice4, asound_intro_voice5
+    };
+    static const AsoundU8 *const legacyRelease[ASOUND_STREAM_COUNT] = {
+        asound_release_voice0, asound_release_voice1, asound_release_voice2,
+        asound_release_voice3, asound_release_voice4, asound_release_voice5
+    };
+    int voice;
+
+    freeReplacementMusic();
+    g_replacementMusic.tried = 0;
+    if (!loadReplacementIntroMusic()) return 0;
+    for (voice = 0; voice < ASOUND_STREAM_COUNT; voice++) {
+        size_t introLen = asound_intro_voice_length(voice);
+        size_t releaseLen = asound_release_voice_length(voice);
+        if (introLen == 0 || releaseLen == 0) return 0;
+        if (!g_replacementMusic.intro[voice] || !g_replacementMusic.release[voice]) return 0;
+        if (g_replacementMusic.introSize[voice] != (int)introLen) return 0;
+        if (g_replacementMusic.releaseSize[voice] != (int)releaseLen) return 0;
+        if (memcmp(g_replacementMusic.intro[voice], legacyIntro[voice], introLen) != 0) return 0;
+        if (memcmp(g_replacementMusic.release[voice], legacyRelease[voice], releaseLen) != 0) return 0;
+    }
+    return 1;
+}
+#endif

--- a/src/eg3dproj.c
+++ b/src/eg3dproj.c
@@ -107,7 +107,7 @@ static void renderGridTile(int lod, int tileX, int tileY, int gridX, int gridY, 
             g_modelStreamPtr = g_world3dData + buf3d3[g_curTileEntry->shape];
         }
         {
-            R3DSubmit obj = {g_modelStreamPtr, 0, 0, 0,
+            R3DSubmit obj = {g_modelStreamPtr, -1, NULL, 0, 0, 0,
                              g_curTileEntry->x, g_curTileEntry->y, g_curTileEntry->z};
             r3d_submit(&obj);
         }
@@ -219,7 +219,7 @@ void projectObjects(int16 heading, int16 rangeGate, int32 worldX, int32 worldY, 
                             g_modelStreamPtr = g_world3dData + buf3d3[g_curTileEntry->shape];
                         }
                         {
-                            R3DSubmit obj = {g_modelStreamPtr, 0, 0, 0,
+                            R3DSubmit obj = {g_modelStreamPtr, -1, NULL, 0, 0, 0,
                                              g_curTileEntry->x, g_curTileEntry->y, g_curTileEntry->z};
                             r3d_submit(&obj);
                         }
@@ -232,7 +232,7 @@ void projectObjects(int16 heading, int16 rangeGate, int32 worldX, int32 worldY, 
                         g_modelStreamPtr = g_world3dData + buf3d3[g_curTileEntry->shape];
                         g_objColorBase = 0x400;
                         {
-                            R3DSubmit obj = {g_modelStreamPtr, 0, 0, 0,
+                            R3DSubmit obj = {g_modelStreamPtr, -1, NULL, 0, 0, 0,
                                              g_curTileEntry->x, g_curTileEntry->y, g_curTileEntry->z};
                             r3d_submit(&obj);
                         }

--- a/src/eg3drast.c
+++ b/src/eg3drast.c
@@ -31,6 +31,7 @@
 #include "gfx_impl.h"
 #include "gfx.h"
 #include "r2d.h"
+#include "r3d_replacement.h"
 #include "inttype.h"
 
 /* Set while rendering an aircraft ground shadow (projectSceneShadow): the object's
@@ -40,6 +41,11 @@
  * GPU backend does the flattened translucent version). */
 #define SHADOW_COLOR_INDEX 0 /* COLOR_BLACK */
 static int g_shadowDraw = 0;
+
+int far r3d_objTransformFar(char far *model, int yaw, int pitch, int roll,
+                            int posX, int posY, int posZ,
+                            int16 *combined, long *camBase, long *camX, long *camY,
+                            int *shade);
 
 /* ---- scratch globals defined in egdata.c but not declared in a header ---- */
 extern int16 g_dirtyRectMinY, g_dirtyRectMaxY;
@@ -1810,6 +1816,7 @@ static long g_camBaseX;              /* word_3424C / word_3424E */
 struct SortRec {
     int16 depthLo, depthHi;
     char far *model;
+    R3DReplacementMesh *replacement;
     int16 relX, relY;
     int16 transform[4];
     long baseX;
@@ -1819,6 +1826,8 @@ struct SortRec {
 };
 static struct SortRec g_sortRecs[35];
 static int g_sortList[35];
+static R3DReplacementMesh *g_activeReplacementMesh;
+static R3DReplacementMesh *g_pendingReplacementMesh;
 
 /* Depth-sorted 3D line segments (cannon tracers, explosion sparks), kept in their
  * own list so they never evict scene objects from the 35-entry object queue;
@@ -2193,6 +2202,219 @@ static void sceneObjEdgeRun(unsigned char far *p) {
     }
 }
 
+typedef struct ReplacementCameraVertex {
+    long x;
+    long y;
+    long depth;
+} ReplacementCameraVertex;
+
+static int replacementNearestPaletteIndex(float r, float g, float b) {
+    int rr = (int)(r * 255.0f + 0.5f);
+    int gg = (int)(g * 255.0f + 0.5f);
+    int bb = (int)(b * 255.0f + 0.5f);
+    if (rr < 0) rr = 0; else if (rr > 255) rr = 255;
+    if (gg < 0) gg = 0; else if (gg > 255) gg = 255;
+    if (bb < 0) bb = 0; else if (bb > 255) bb = 255;
+    return gfx_nearestPaletteIndexRgb8((uint8)rr, (uint8)gg, (uint8)bb);
+}
+
+static int replacementPrimitiveColor(const R3DReplacementPrim *prim) {
+    int i;
+    int base = replacementNearestPaletteIndex(prim->rgba[0], prim->rgba[1], prim->rgba[2]);
+
+    /* Drawing is intentionally material-first: sourceColor is proof metadata for
+     * converter validation, not runtime rendering data. Converted legacy GLBs set
+     * source_order_sensitive in the generated GLMESH cache; that flag opts into
+     * the original distance-shade idea while the GLB material RGB still chooses
+     * the base palette color. Third-party GLBs without converter proof metadata
+     * render exactly from their material colour mapping, so palette-like custom
+     * colors are not accidentally hazed. */
+    if ((prim->sourceFlags & 1u) == 0u) return base;
+    for (i = 0; i < 16; i++) {
+        if (base == colorLut[i]) return colorLut[i] + g_objShade;
+    }
+    return base;
+}
+
+static void transformReplacementVertex(const R3DReplacementPrim *prim, int srcVert,
+                                       const int16 *combined, long camBase, long camX, long camY,
+                                       ReplacementCameraVertex *out) {
+    int shift = 8 - 2 * g_curLod;
+    long scaleDiv = (shift > 0) ? (1L << shift) : 1L;
+    float x = prim->xyz[srcVert * 3];
+    float y = prim->xyz[srcVert * 3 + 1];
+    float z = prim->xyz[srcVert * 3 + 2];
+    out->x = (long)(2.0f * ((float)combined[0] * x + (float)combined[3] * z + (float)combined[6] * y) + (float)camBase);
+    out->y = (long)(2.0f * ((float)combined[1] * x + (float)combined[4] * z + (float)combined[7] * y) + (float)camX);
+    out->depth = (long)(2.0f * ((float)combined[2] * x + (float)combined[5] * z + (float)combined[8] * y) + (float)camY);
+    if (scaleDiv != 1) {
+        out->x /= scaleDiv;
+        out->y /= scaleDiv;
+        out->depth /= scaleDiv;
+    }
+}
+
+static int projectReplacementCameraVertex(const ReplacementCameraVertex *v, int slot) {
+    VCAMX(slot) = v->x;
+    VCAMY(slot) = v->y;
+    setVtxDepth(slot >> 2, v->depth);
+    if (HI16(v->depth) < 1) return 0;
+    projectVertexToScreen(slot >> 2);
+    return 1;
+}
+
+static ReplacementCameraVertex replacementNearIntersection(const ReplacementCameraVertex *behind,
+                                                          const ReplacementCameraVertex *front) {
+    ReplacementCameraVertex out;
+    int div = HI16(front->depth) - HI16(behind->depth);
+    int cx;
+    long delta, prod;
+
+    if (div <= 0) {
+        out = *front;
+        out.depth = 65536L;
+        return out;
+    }
+
+    /* Match clipEdgeNearPlane's fixed-point interpolation instead of using a
+     * separate high-precision path. This keeps software replacement GLB clipping
+     * behavior aligned with legacy .3D3 edge clipping and avoids compiler helper
+     * calls for floating point or 64-bit arithmetic in this rasterizer TU. */
+    /* The formula needs front's low depth word. Cast through int16 to mirror the
+     * legacy vproj.in[].num low word without aliasing ReplacementCameraVertex. */
+    cx = (int)(udiv32by16_full((((unsigned long)(HI16(front->depth) - 1)) << 16) |
+                                   (uint16)(int16)front->depth,
+                               (unsigned)div) >> 1);
+
+    delta = front->x - behind->x;
+    prod = imul16(HI16(delta) + LOCARRY(delta), cx) << 1;
+    out.x = front->x - prod;
+    delta = front->y - behind->y;
+    prod = imul16(HI16(delta) + LOCARRY(delta), cx) << 1;
+    out.y = front->y - prod;
+    out.depth = 65536L;
+    return out;
+}
+
+static int replacementVertexInFront(const ReplacementCameraVertex *v) {
+    return HI16(v->depth) >= 1;
+}
+
+static int clipReplacementLineNear(ReplacementCameraVertex *a, ReplacementCameraVertex *b) {
+    int aIn = replacementVertexInFront(a);
+    int bIn = replacementVertexInFront(b);
+    if (!aIn && !bIn) return 0;
+    if (!aIn) *a = replacementNearIntersection(a, b);
+    else if (!bIn) *b = replacementNearIntersection(b, a);
+    return 1;
+}
+
+static int clipReplacementPolygonNear(const ReplacementCameraVertex *in, int inCount,
+                                      ReplacementCameraVertex *out) {
+    ReplacementCameraVertex cur[5];
+    int curCount = inCount;
+    int i, outCount = 0;
+    for (i = 0; i < inCount; i++) cur[i] = in[i];
+    for (i = 0; i < curCount; i++) {
+        ReplacementCameraVertex a = cur[i];
+        ReplacementCameraVertex b = cur[(i + 1) % curCount];
+        int aIn = replacementVertexInFront(&a);
+        int bIn = replacementVertexInFront(&b);
+        if (aIn && bIn) {
+            out[outCount++] = b;
+        } else if (aIn && !bIn) {
+            out[outCount++] = replacementNearIntersection(&b, &a);
+        } else if (!aIn && bIn) {
+            out[outCount++] = replacementNearIntersection(&a, &b);
+            out[outCount++] = b;
+        }
+    }
+    return outCount;
+}
+
+static int projectReplacementPolygon(const ReplacementCameraVertex *poly, int n, int *points) {
+    int i;
+    if (n < 3 || n > 4) return 0;
+    for (i = 0; i < n; i++) {
+        if (!projectReplacementCameraVertex(&poly[i], i * 4)) return 0;
+        points[i * 2] = (int16)vtxScratch.vproj.x.v[i];
+        points[i * 2 + 1] = (int16)vtxScratch.vproj.y.v[i];
+    }
+    return 1;
+}
+
+static void drawReplacementMesh(R3DReplacementMesh *mesh) {
+    int16 combined[9];
+    long camBase, camX, camY;
+    int i;
+
+    if (!mesh) return;
+    /* projectReplacementSceneObject follows the same cull/LOD/sort path as
+     * projectSceneObject. At this point immediate and sorted objects have the
+     * exact object-origin camera state the legacy software renderer would use.
+     * Build only the orientation*view matrix here, then draw GLB/GLMESH
+     * primitives through the existing software span/line rasterizers. */
+    {
+        int orv = g_objTransform[1] | g_objTransform[2] | g_objTransform[3];
+        int al = (orv | (orv >> 8)) & 0xff;
+        g_objHasRotation = (uint8)al;
+        if (al == 0) {
+            for (i = 0; i < 9; i++) combined[i] = g_viewRotMatrix[i];
+        } else {
+            buildInverseRotationMatrix(g_objOrientMatrix,
+                                       g_objTransform[1], g_objTransform[2], g_objTransform[3]);
+            multiplyMatrix3x3(g_objOrientMatrix, g_viewRotMatrix, combined);
+        }
+    }
+    camBase = g_camBaseX;
+    camX = JOIN32(g_camTransXLo, g_camTransXHi);
+    camY = JOIN32(g_camTransYLo, g_camTransYHi);
+
+    for (i = 0; i < mesh->nPrims; i++) {
+        R3DReplacementPrim *prim = &mesh->prims[i];
+        int color = replacementPrimitiveColor(prim);
+        int v;
+        if (prim->mode == 4) {
+            for (v = 0; v + 2 < prim->nVerts; v += 3) {
+                ReplacementCameraVertex tri[3], clipped[5];
+                int points[8];
+                int n;
+                transformReplacementVertex(prim, v, combined, camBase, camX, camY, &tri[0]);
+                transformReplacementVertex(prim, v + 1, combined, camBase, camX, camY, &tri[1]);
+                transformReplacementVertex(prim, v + 2, combined, camBase, camX, camY, &tri[2]);
+                n = clipReplacementPolygonNear(tri, 3, clipped);
+                if (!projectReplacementPolygon(clipped, n, points)) continue;
+                drawPolygonOutline(color, n, points, color);
+            }
+        } else if (prim->mode == 1) {
+            gfx_setColor((unsigned char)color);
+            for (v = 0; v + 1 < prim->nVerts; v += 2) {
+                ReplacementCameraVertex a, b;
+                transformReplacementVertex(prim, v, combined, camBase, camX, camY, &a);
+                transformReplacementVertex(prim, v + 1, combined, camBase, camX, camY, &b);
+                if (!clipReplacementLineNear(&a, &b)) continue;
+                if (!projectReplacementCameraVertex(&a, 0)) continue;
+                if (!projectReplacementCameraVertex(&b, 4)) continue;
+                g_lineX1 = (int16)vtxScratch.vproj.x.v[0];
+                g_lineY1 = (int16)vtxScratch.vproj.y.v[0];
+                g_lineX2 = (int16)vtxScratch.vproj.x.v[1];
+                g_lineY2 = (int16)vtxScratch.vproj.y.v[1];
+                drawClipLineGlobal();
+            }
+        } else if (prim->mode == 0) {
+            gfx_setColor((unsigned char)color);
+            for (v = 0; v < prim->nVerts; v++) {
+                ReplacementCameraVertex point;
+                transformReplacementVertex(prim, v, combined, camBase, camX, camY, &point);
+                if (!projectReplacementCameraVertex(&point, 0)) continue;
+                g_lineX1 = g_lineX2 = (int16)vtxScratch.vproj.x.v[0];
+                g_lineY1 = g_lineY2 = (int16)vtxScratch.vproj.y.v[0];
+                drawClipLineGlobal();
+            }
+        }
+    }
+}
+
 /* seg001 0x0BE7 — processSceneObject: render one (depth-sorted) object: compute
  * its shade, build its combined orientation*view matrix, rotate+cull its faces,
  * project its vertices and draw its display list. */
@@ -2207,6 +2429,11 @@ static void processSceneObject(void) {
         int v = (h & 0x80) ? 0 : (h >> 1);
         if (v > 7) v = 7;
         g_objShade = (uint8)((v << 4) + 0x80);
+    }
+
+    if (g_activeReplacementMesh) {
+        drawReplacementMesh(g_activeReplacementMesh);
+        return;
     }
 
     op = (*p) & 0x3f;
@@ -2271,6 +2498,7 @@ static void insertSortedObject(unsigned char far *p) {
     r->depthLo = dLo;
     r->depthHi = dHi;
     r->model = g_modelStreamPtr;
+    r->replacement = g_pendingReplacementMesh;
     r->relX = g_objRelX;
     r->relY = g_objRelY;
     r->transform[0] = g_objTransform[0];
@@ -2306,10 +2534,12 @@ static void insertSortedObject(unsigned char far *p) {
 /* seg001 0x0BE7 thunk path — projectSceneObject: entry from the scene walk.
  * Transforms+culls the object origin, then either renders it immediately (when
  * coplanar with the viewer Z) or queues it into the depth-sorted list. */
-void far projectSceneObject(char far *model, int yaw, int pitch, int roll,
-                            int posX, int posY, int posZ) {
+static void projectSceneObjectImpl(char far *model, R3DReplacementMesh *replacement,
+                                   int yaw, int pitch, int roll,
+                                   int posX, int posY, int posZ) {
     unsigned char far *p;
     int opcode, cl;
+    g_pendingReplacementMesh = replacement;
 
     g_objTransform[1] = yaw;
     g_objTransform[2] = pitch;
@@ -2321,11 +2551,17 @@ void far projectSceneObject(char far *model, int yaw, int pitch, int roll,
     g_objTransform[0] = posZ - g_viewPosZ;
     g_objRelX = posX - g_viewPosX;
 
-    if (transformAndCullObject(g_objRelY, g_objTransform[0], g_objRelX)) return;
+    if (transformAndCullObject(g_objRelY, g_objTransform[0], g_objRelX)) {
+        g_pendingReplacementMesh = 0;
+        return;
+    }
 
     skipDisplayListByLod(&p);
     opcode = *p;
-    if (*(unsigned *)&p == 1 && g_detailLevel != 2) return;
+    if (*(unsigned *)&p == 1 && g_detailLevel != 2) {
+        g_pendingReplacementMesh = 0;
+        return;
+    }
     cl = opcode;
     if ((opcode & 0x60) == 0x60) { /* storeObjTransformByOpcode */
         int idx = (*p) & 3;
@@ -2336,11 +2572,49 @@ void far projectSceneObject(char far *model, int yaw, int pitch, int roll,
     if (cl & 0x40) {
         insertSortedObject(p);
     } else if (-g_viewPosZ == g_objTransform[0]) {
+        g_activeReplacementMesh = replacement;
         processSceneObject();
+        g_activeReplacementMesh = 0;
     } else {
         insertSortedObject(p);
     }
+    g_pendingReplacementMesh = 0;
 }
+
+void far projectSceneObject(char far *model, int yaw, int pitch, int roll,
+                            int posX, int posY, int posZ) {
+    projectSceneObjectImpl(model, 0, yaw, pitch, roll, posX, posY, posZ);
+}
+
+void far projectReplacementSceneObject(char far *model, R3DReplacementMesh *replacement,
+                                       int yaw, int pitch, int roll,
+                                       int posX, int posY, int posZ) {
+    projectSceneObjectImpl(model, replacement, yaw, pitch, roll, posX, posY, posZ);
+}
+
+#ifdef DEBUG
+int eg3drast_testReplacementColorFromMaterial(float r, float g, float b, int sourceColor) {
+    R3DReplacementPrim prim;
+    prim.rgba[0] = r;
+    prim.rgba[1] = g;
+    prim.rgba[2] = b;
+    prim.rgba[3] = 1.0f;
+    prim.sourceColor = sourceColor;
+    prim.sourceFlags = 0;
+    return replacementPrimitiveColor(&prim);
+}
+
+int eg3drast_testReplacementLineNearClip(long aDepth, long bDepth) {
+    ReplacementCameraVertex a, b;
+    a.x = 0;
+    a.y = 0;
+    a.depth = aDepth;
+    b.x = 65536L;
+    b.y = 0;
+    b.depth = bDepth;
+    return clipReplacementLineNear(&a, &b);
+}
+#endif
 
 /* Project an aircraft ground shadow: the plane's own model drawn level (the
  * software backend does not project onto the ground) and filled flat black. The
@@ -2459,6 +2733,7 @@ int far multiplyMatrix3x3Far(const int16 *matA, const int16 *matB, int16 *result
  * factored so the object list and the 3D line list can be merge-walked). */
 static void drawSortedObject(struct SortRec *r) {
     g_modelStreamPtr = r->model;
+    g_activeReplacementMesh = r->replacement;
     g_objRelX = r->relX;
     g_objRelY = r->relY;
     g_objTransform[0] = r->transform[0];
@@ -2472,6 +2747,7 @@ static void drawSortedObject(struct SortRec *r) {
     g_camTransYHi = r->camYHi;
     g_shadowDraw = r->shadow;
     processSceneObject();
+    g_activeReplacementMesh = 0;
     g_shadowDraw = 0;
 }
 

--- a/src/egcode.h
+++ b/src/egcode.h
@@ -87,7 +87,12 @@ void timerPump(void);
 void timerYield(void);
 uint64 timerNowNs(void);
 int getTimeOfDay();
-SDL_IOStream *openFile(const char *path, int mode);
+SDL_IOStream *__cdecl openFile(const char *path, int mode);
+int findReplacementAssetPath(const char *legacyFilename, const char *modernExt,
+                             char *outPath, size_t outPathSize);
+int findReplacementShapeModelPath(const char *containerLegacyFilename, int shapeId,
+                                  const char *modernExt, char *outPath,
+                                  size_t outPathSize);
 void fileClose(SDL_IOStream *handle);
 size_t fileRead(void *ptr, size_t size, size_t count, SDL_IOStream *handle);
 size_t fileWrite(const void *ptr, size_t size, size_t count, SDL_IOStream *handle);

--- a/src/egcode.h
+++ b/src/egcode.h
@@ -87,7 +87,7 @@ void timerPump(void);
 void timerYield(void);
 uint64 timerNowNs(void);
 int getTimeOfDay();
-SDL_IOStream *__cdecl openFile(const char *path, int mode);
+SDL_IOStream *openFile(const char *path, int mode);
 int findReplacementAssetPath(const char *legacyFilename, const char *modernExt,
                              char *outPath, size_t outPathSize);
 int findReplacementShapeModelPath(const char *containerLegacyFilename, int shapeId,

--- a/src/egmath.c
+++ b/src/egmath.c
@@ -21,6 +21,60 @@
 
 // ==== seg000:0xc8de ====
 
+static uint8 s_loggedWorldShapeReplacement[128];
+static uint8 s_loggedAircraftShapeReplacement[128];
+static uint8 s_loggedPhotoShapeReplacement[128];
+
+static int isPhotoShapeSlot(int shapeId) {
+    int slot = shapeId & 0x7f;
+    return (shapeId & 0x100) && slot >= (int)size3d3;
+}
+
+static int replacementShapeSlot(int shapeId) {
+    int slot = shapeId & 0x7f;
+    if (isPhotoShapeSlot(shapeId)) {
+        return slot - (int)size3d3;
+    }
+    return slot;
+}
+
+static const char *replacementShapeContainer(int shapeId) {
+    if (isPhotoShapeSlot(shapeId)) {
+        /* PHOTO.3D3 target-view models are appended to the world shape buffer,
+         * but their editable replacements live in the PHOTO/ shape directory. */
+        return "photo.3d3";
+    }
+    return (shapeId & 0x100) ? regnStr : a15flt_xxx;
+}
+
+static uint8 *replacementShapeLogTable(int shapeId) {
+    if (isPhotoShapeSlot(shapeId)) {
+        return s_loggedPhotoShapeReplacement;
+    }
+    return (shapeId & 0x100) ? s_loggedWorldShapeReplacement : s_loggedAircraftShapeReplacement;
+}
+
+static void logShapeReplacementIfPresent(int shapeId) {
+    int slot = replacementShapeSlot(shapeId);
+    const char *container = replacementShapeContainer(shapeId);
+    uint8 *logged = replacementShapeLogTable(shapeId);
+    char replacementPath[512];
+
+    if (slot < 0 || slot >= 128) return;
+    if (logged[slot]) return;
+    logged[slot] = 1;
+    if (!findReplacementShapeModelPath(container, slot, ".glb", replacementPath, sizeof(replacementPath))) {
+        return;
+    }
+    LogInfo((
+        "asset replacement: found per-shape model for %s shape %d at %s; "
+        "OpenGL backend will prefer it; software backend keeps legacy .3D3",
+        container,
+        slot,
+        replacementPath
+    ));
+}
+
 void load15Flt3d3() {
     int16 bytesLeft, chunkSize;
     struct SREGS segs;
@@ -60,6 +114,7 @@ static void drawWorldObjectCore(int16 shapeId, int isShadow,
     int vfx, vfy, vfz;
 
     dataOff = shapeDataOffset(shapeId);
+    logShapeReplacementIfPresent(shapeId);
     drawPg = g_pageFront;
     relX = worldX - g_ViewX;
     relY = worldY + g_ViewY - 0x01000000L;
@@ -109,8 +164,12 @@ static void drawWorldObjectCore(int16 shapeId, int isShadow,
             setViewPositionFrac(vfx, vfy, vfz);
             g_curLod = 1;
             {
-                R3DSubmit obj = {g_world3dData + dataOff, -objYaw, objPitch, objRoll,
-                                 (int16)relX, -(int16)relY, altitude != 0, isShadow};
+                R3DSubmit obj = {g_world3dData + dataOff, shapeId & 0x7f,
+                                 replacementShapeContainer(shapeId),
+                                 -objYaw, objPitch, objRoll,
+                                 (int16)relX, -(int16)relY, altitude != 0,
+                                 isShadow};
+                obj.shapeId = replacementShapeSlot(shapeId);
                 r3d_submit(&obj);
             }
         }
@@ -232,6 +291,7 @@ void drawTargetView(int shapeId, int32 worldX, int32 worldY, int altitude, int o
     g_targetInHudFlag = 1;
 
     dataOff = shapeDataOffset(shapeId);
+    logShapeReplacementIfPresent(shapeId);
     *g_targetViewParams = 1;
 
     dxFine = worldX - g_ViewX;
@@ -344,7 +404,10 @@ void drawTargetView(int shapeId, int32 worldX, int32 worldY, int altitude, int o
     g_offscreenRender = 1;
     {
         R3DScene scene = {g_targetViewParams, -g_trkBearing, g_trkPitch, g_trkRoll, 0, 0, 0, 0};
-        R3DSubmit obj = {g_world3dData + dataOff, -objYaw, objPitch, objRoll, relX, -relY, relZ};
+        R3DSubmit obj = {g_world3dData + dataOff, shapeId & 0x7f,
+                         replacementShapeContainer(shapeId),
+                         -objYaw, objPitch, objRoll, relX, -relY, relZ};
+        obj.shapeId = replacementShapeSlot(shapeId);
         r3d_beginScene(&scene);
         /* after beginScene: setup3DTransform's setViewPosition cleared the frac */
         setViewPositionFrac(fracX, fracY, fracZ);

--- a/src/egpic.c
+++ b/src/egpic.c
@@ -11,7 +11,11 @@
 #include <memory.h>
 
 void openBlitClosePic(const char *filename, int page) { /* Original chain: OpenFile + blit/decode + CloseFile. Open, blit PIC to page, then close. */
-    SDL_IOStream *handle = openFileWrapper(filename, 0);
+    SDL_IOStream *handle;
+    if (loadReplacementPngToPage(filename, page)) {
+        return;
+    }
+    handle = openFileWrapper(filename, 0);
     /* The PIC decoder/blitter consumes the already-open file handle. */
     showPicFile(handle, page);
     /* Always close immediately after the synchronous blit/decode call. */

--- a/src/egtacmap.c
+++ b/src/egtacmap.c
@@ -23,6 +23,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Runtime TTF/OTF text is rendered out-of-page at final window resolution, so
+ * transient HUD strings need explicit row invalidation where the original bitmap
+ * renderer relied on the next 320x200 page repaint to erase old pixels. */
+#define HUD_STALL_TEXT_Y 30
+#define HUD_STATUS_TEXT_Y 24
+#define HUD_DIRECTOR_TEXT_Y 90
+#define HUD_TRANSIENT_TEXT_HEIGHT 8
+
 /* Private helpers for this translation unit. */
 void egDrawStringCentered(int16 *, const char *, int, int, int);
 void renderHudFrame();
@@ -90,6 +98,11 @@ void renderHudFrame(int unused) {
                 drawViewportLine(242, climbMarkerY - 2, 244, climbMarkerY);
                 drawViewportLine(242, climbMarkerY + 2, 244, climbMarkerY);
             }
+            /* The stall warning blinks on alternating frames. Bitmap text was
+             * naturally erased by the next HUD repaint; TTF overlay records are
+             * persistent, so clear this row before optionally drawing it again. */
+            gfx_invalidateTtfTextOverlayRect(0, HUD_STALL_TEXT_Y, 319,
+                                             HUD_STALL_TEXT_Y + HUD_TRANSIENT_TEXT_HEIGHT);
             // stall warning display
             if (g_knots < g_cornerSpeed && g_groundAltitude != g_viewZ && frameTick & 1) {
                 drawStringActivePage("stall warning", 132, 30, 0xf);
@@ -158,18 +171,26 @@ void renderHudFrame(int unused) {
         drawTacticalMap(0);
     }
     if (g_hudMsgTimer != 0 && ((g_viewMode == VIEW_COCKPIT && g_halfScaleRender == 0) || (g_directorMode != 0))) {
-        drawStringActivePage(tempString, -(((int16)strlen(tempString) >> 1) - 40) * 4, 24, 0xf);
         g_hudMsgTimer--;
         if (g_hudMsgTimer == 0) { // cancel pending eject on message disappear
             g_ejectPending = 0;
+            gfx_invalidateTtfTextOverlayRect(0, HUD_STATUS_TEXT_Y, 319,
+                                             HUD_STATUS_TEXT_Y + HUD_TRANSIENT_TEXT_HEIGHT);
+        } else {
+            drawStringActivePage(tempString, -(((int16)strlen(tempString) >> 1) - 40) * 4, 24, 0xf);
         }
         if (g_autopilotEngaged == 1) {
             drawStringActivePage("Press any key to play", 120, 1, g_nightMode != 0 ? 0xe : 0);
         }
     }
     if (g_dirMsgTimer != 0 && g_viewMode == VIEW_COCKPIT && g_halfScaleRender == 0) {
-        drawStringActivePage(string_3C04A, -(((int16)strlen(string_3C04A) >> 1) - 40) * 4, 90, 0xf);
         g_dirMsgTimer--;
+        if (g_dirMsgTimer == 0) {
+            gfx_invalidateTtfTextOverlayRect(0, HUD_DIRECTOR_TEXT_Y, 319,
+                                             HUD_DIRECTOR_TEXT_Y + HUD_TRANSIENT_TEXT_HEIGHT);
+        } else {
+            drawStringActivePage(string_3C04A, -(((int16)strlen(string_3C04A) >> 1) - 40) * 4, 90, 0xf);
+        }
     }
 }
 

--- a/src/endbrf.c
+++ b/src/endbrf.c
@@ -14,6 +14,19 @@
 extern int16 menuItemUnused;
 extern uint8 animExitFlag;
 
+static int canLoadPicOrReplacement(const char *filename) {
+    char replacementPath[512];
+    SDL_IOStream *handle = openFile(filename, 0);
+    if (handle) {
+        fileClose(handle);
+        return 1;
+    }
+    /* Sprite-sheet PNG replacements are authoritative for the later loadPic()
+     * call, so disk-presence checks must accept them even when the original
+     * .SPR is absent. */
+    return findReplacementAssetPath(filename, ".png", replacementPath, sizeof(replacementPath));
+}
+
 void debriefMainLoop(void) {
     char p[2];
     int16 a, b, c;
@@ -45,12 +58,10 @@ insert_scenario:
     misc_getKey();
 
 open_theater:
-    worldBufHandle = openFile(theaterSprFiles[gameData->theater], 0);
-    if (!worldBufHandle)
+    if (!canLoadPicOrReplacement(theaterSprFiles[gameData->theater]))
         goto insert_scenario;
 
     gfx_waitRetrace();
-    fileClose(worldBufHandle);
     gfx_setFadeSteps(9);
     spriteBufSeg = gfx_allocSpriteBuf();
     loadPic(theaterSprFiles[gameData->theater], spriteBufSeg);
@@ -68,12 +79,10 @@ insert_diska:
     misc_getKey();
 
 open_dbicons:
-    worldBufHandle = openFile("dbicons.spr", 0);
-    if (!worldBufHandle)
+    if (!canLoadPicOrReplacement("dbicons.spr"))
         goto insert_diska;
 
     gfx_waitRetrace();
-    fileClose(worldBufHandle);
     gfx_setFadeSteps(8);
     /* Decode the popup icon sheet into a sprite buffer image. */
     g_dbiconsBuf = gfx_allocSpriteBuf();

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -112,6 +112,7 @@ void FAR CDECL gfx_dacAnimate();                                                
 void FAR CDECL gfx_dacCycle();                                                                                                    /* slot 0x2e: DAC fire/colour-cycle animation */
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx);                                                                             /* slot 0x2f: setup font metrics */
 int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx);                                                                        /* native UTF-aware font metric */
+int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx);                                                                   /* native UTF-aware line metric */
 void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2);
 int FAR CDECL gfx_getRowOffset(int y);                                                                                            /* slot 0x3a: returns y*320 */
 /* dseg:0xbe4 */

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -111,6 +111,8 @@ void FAR CDECL gfx_copyRect(int srcPage, uint16 srcX, uint16 srcY, int dstPage, 
 void FAR CDECL gfx_dacAnimate();                                                                                                  /* slot 0x2c: DAC palette animation */
 void FAR CDECL gfx_dacCycle();                                                                                                    /* slot 0x2e: DAC fire/colour-cycle animation */
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx);                                                                             /* slot 0x2f: setup font metrics */
+int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx);                                                                        /* native UTF-aware font metric */
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2);
 int FAR CDECL gfx_getRowOffset(int y);                                                                                            /* slot 0x3a: returns y*320 */
 /* dseg:0xbe4 */
 void FAR CDECL gfx_setMode13(void);          /* slot 0x3c: switch to 320x200 (lo-res) */

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -3,6 +3,11 @@
  */
 
 #include <SDL3/SDL.h>
+#ifdef F15_HAVE_FREETYPE
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include <SDL3/SDL_opengl.h>
+#endif
 
 #include "gfx_impl.h"
 #include "gfx.h"
@@ -25,8 +30,8 @@
  * rendered to a 320x200 MCGA framebuffer; we present that through an SDL renderer
  * scaled to a resizable window. The 320x200 / 640x350 logical resolutions live
  * in gfx.h. */
-#define INITIAL_WINDOW_WIDTH 640
-#define INITIAL_WINDOW_HEIGHT 400
+#define INITIAL_WINDOW_WIDTH 1280
+#define INITIAL_WINDOW_HEIGHT 800
 
 /* Fixed fire colour-cycle rate, independent of render frame rate. The original
  * stepped the cycle once per rendered frame; we pin it at 15 Hz so the pulse
@@ -47,6 +52,12 @@ static void gfx_swLine(int x1, int y1, int x2, int y2, int color);
 static void gfx_swPoint(int x, int y, int color);
 static void gfx_swImage(struct R2DImage *img, int srcX, int srcY, int w, int h,
                         int dstX, int dstY, int key);
+static void cleanupReplacementFonts(void);
+#ifdef F15_HAVE_FREETYPE
+static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL);
+static void invalidateTtfTextOverlayRecords(void);
+static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint);
+#endif
 
 /* Bring up the SDL window and renderer. The 320x200 logical surface is stretched
  * to fill the resizable window (SDL_LOGICAL_PRESENTATION_STRETCH). */
@@ -143,6 +154,7 @@ void gfx_videoShutdown(void) {
         SDL_DestroyPalette(gfxPalette);
         gfxPalette = NULL;
     }
+    cleanupReplacementFonts();
     if (sdlRenderer) SDL_DestroyRenderer(sdlRenderer);
     if (sdlWindow) SDL_DestroyWindow(sdlWindow);
     SDL_Quit();
@@ -443,6 +455,9 @@ static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
     dst.w = (float)surf->w * m.scaleX;
     dst.h = (float)surf->h * m.scaleY;
     SDL_RenderTexture(sdlRenderer, tex, NULL, &dst);
+#ifdef F15_HAVE_FREETYPE
+    renderTtfTextOverlay(&m, sdlRenderer, 0);
+#endif
     SDL_RenderPresent(sdlRenderer);
     SDL_DestroyTexture(tex);
 }
@@ -496,6 +511,9 @@ static void initRowOffsets(void) {
  * SDL. This is also the lo-res restore after the (possibly hi-res) title. */
 void FAR CDECL gfx_setMode13(void) {
     initRowOffsets();
+#ifdef F15_HAVE_FREETYPE
+    invalidateTtfTextOverlayRecords();
+#endif
     gfxHiResActive = false;
     gfx_getState()->modeFlag = 1;
 }
@@ -505,6 +523,9 @@ void FAR CDECL gfx_setMode13(void) {
  * derives the virtual size from the surface), so this just flags hi-res; the
  * present picks up the 640x350 hi-res surface from gfx_presentHiRes. */
 bool video_setHiRes(void) {
+#ifdef F15_HAVE_FREETYPE
+    invalidateTtfTextOverlayRecords();
+#endif
     gfxHiResActive = true;
     return true;
 }
@@ -629,6 +650,243 @@ static uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
 static uint8 *g_fontReplacementBitmaps[8] = {NULL};
 static uint8 *g_fontReplacementWidths[8] = {NULL};
 static uint8 g_fontReplacementTried[8] = {0};
+#ifdef F15_HAVE_FREETYPE
+static FT_Library g_freetypeLibrary = NULL;
+static FT_Face g_fontReplacementTtfFaces[8] = {NULL};
+static char *g_fontReplacementTtfPaths[8] = {NULL};
+typedef struct TtfTextOverlayRecord {
+    char *text;
+    int x, y, color;
+    uint16 fontIdx;
+    int clipL, clipR, clipT, clipB;
+} TtfTextOverlayRecord;
+static TtfTextOverlayRecord g_ttfTextOverlayRecords[512];
+static int g_ttfTextOverlayCount;
+#endif
+
+typedef struct ReplacementFontGlyph {
+    uint32 codepoint;
+    uint8 width;
+    uint8 *rows;
+} ReplacementFontGlyph;
+
+static ReplacementFontGlyph *g_fontReplacementExtraGlyphs[8] = {NULL};
+static int g_fontReplacementExtraGlyphCounts[8] = {0};
+
+static void freeReplacementExtraGlyphs(uint16 fontIdx) {
+    int i;
+    if (fontIdx >= 8 || !g_fontReplacementExtraGlyphs[fontIdx]) return;
+    for (i = 0; i < g_fontReplacementExtraGlyphCounts[fontIdx]; i++) {
+        SDL_free(g_fontReplacementExtraGlyphs[fontIdx][i].rows);
+    }
+    SDL_free(g_fontReplacementExtraGlyphs[fontIdx]);
+    g_fontReplacementExtraGlyphs[fontIdx] = NULL;
+    g_fontReplacementExtraGlyphCounts[fontIdx] = 0;
+}
+
+static void freeReplacementFont(uint16 fontIdx) {
+    if (fontIdx >= 8) return;
+#ifdef F15_HAVE_FREETYPE
+    if (g_fontReplacementTtfFaces[fontIdx]) {
+        FT_Done_Face(g_fontReplacementTtfFaces[fontIdx]);
+        g_fontReplacementTtfFaces[fontIdx] = NULL;
+    }
+    SDL_free(g_fontReplacementTtfPaths[fontIdx]);
+    g_fontReplacementTtfPaths[fontIdx] = NULL;
+#endif
+    SDL_free(g_fontReplacementBitmaps[fontIdx]);
+    SDL_free(g_fontReplacementWidths[fontIdx]);
+    g_fontReplacementBitmaps[fontIdx] = NULL;
+    g_fontReplacementWidths[fontIdx] = NULL;
+    freeReplacementExtraGlyphs(fontIdx);
+}
+
+static void cleanupReplacementFonts(void) {
+    int i;
+    for (i = 0; i < 8; i++) {
+        freeReplacementFont((uint16)i);
+    }
+#ifdef F15_HAVE_FREETYPE
+    if (g_freetypeLibrary) {
+        FT_Done_FreeType(g_freetypeLibrary);
+        g_freetypeLibrary = NULL;
+    }
+#endif
+}
+
+static const ReplacementFontGlyph *findReplacementFontGlyph(uint16 fontIdx, uint32 codepoint) {
+    int i;
+    if (fontIdx >= 8) return NULL;
+    for (i = 0; i < g_fontReplacementExtraGlyphCounts[fontIdx]; i++) {
+        if (g_fontReplacementExtraGlyphs[fontIdx][i].codepoint == codepoint) {
+            return &g_fontReplacementExtraGlyphs[fontIdx][i];
+        }
+    }
+    return NULL;
+}
+
+/* Legacy scripts use bytes >= 0x80 as inline colour escapes. UTF-8 replacement
+ * text also uses high bytes, so only consume a high byte as text when it starts
+ * a complete, valid UTF-8 sequence; malformed high bytes keep the original
+ * colour-escape behavior. */
+static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int *byteCountOut) {
+    const uint8 *s = (const uint8 *)text;
+    uint32 cp;
+    int needed;
+    int i;
+
+    if (s[0] < 0x80) {
+        *codepointOut = s[0];
+        *byteCountOut = 1;
+        return 1;
+    }
+    if ((s[0] & 0xe0) == 0xc0) {
+        cp = (uint32)(s[0] & 0x1f);
+        needed = 2;
+        if (cp == 0) return 0; /* overlong ASCII */
+    } else if ((s[0] & 0xf0) == 0xe0) {
+        cp = (uint32)(s[0] & 0x0f);
+        needed = 3;
+    } else if ((s[0] & 0xf8) == 0xf0) {
+        cp = (uint32)(s[0] & 0x07);
+        needed = 4;
+    } else {
+        return 0;
+    }
+
+    for (i = 1; i < needed; i++) {
+        if ((s[i] & 0xc0) != 0x80) return 0;
+        cp = (cp << 6) | (uint32)(s[i] & 0x3f);
+    }
+    if ((needed == 2 && cp < 0x80) ||
+        (needed == 3 && cp < 0x800) ||
+        (needed == 4 && (cp < 0x10000 || cp > 0x10ffff)) ||
+        (cp >= 0xd800 && cp <= 0xdfff)) {
+        return 0;
+    }
+    *codepointOut = cp;
+    *byteCountOut = needed;
+    return 1;
+}
+
+#ifdef F15_HAVE_FREETYPE
+static void clearTtfTextOverlayRecords(void) {
+    int i;
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        SDL_free(g_ttfTextOverlayRecords[i].text);
+        g_ttfTextOverlayRecords[i].text = NULL;
+    }
+    g_ttfTextOverlayCount = 0;
+}
+
+static void invalidateTtfTextOverlayRecords(void) {
+    if (g_ttfTextOverlayCount > 0) clearTtfTextOverlayRecords();
+}
+
+static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
+    int w, h;
+    if (x2 < x1) {
+        int tmp = x1;
+        x1 = x2;
+        x2 = tmp;
+    }
+    if (y2 < y1) {
+        int tmp = y1;
+        y1 = y2;
+        y2 = tmp;
+    }
+    w = x2 - x1 + 1;
+    h = y2 - y1 + 1;
+    return w > 0 && h > 0 && w * h >= 12000;
+}
+
+static int ttfTextOverlayRecordWidth(const TtfTextOverlayRecord *record) {
+    int charIdx;
+    int drawnChars;
+    int width = 0;
+    if (!record || !record->text) return 0;
+    for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)record->text[charIdx];
+        int byteCount = 1;
+        if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            charIdx++;
+            continue;
+        }
+        width += replacementTtfAdvance(record->fontIdx, codepoint);
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    return width;
+}
+
+static void removeTtfTextOverlayRecord(int index) {
+    if (index < 0 || index >= g_ttfTextOverlayCount) return;
+    SDL_free(g_ttfTextOverlayRecords[index].text);
+    if (index + 1 < g_ttfTextOverlayCount) {
+        memmove(
+            &g_ttfTextOverlayRecords[index],
+            &g_ttfTextOverlayRecords[index + 1],
+            (size_t)(g_ttfTextOverlayCount - index - 1) * sizeof(g_ttfTextOverlayRecords[0])
+        );
+    }
+    g_ttfTextOverlayCount--;
+    memset(&g_ttfTextOverlayRecords[g_ttfTextOverlayCount], 0, sizeof(g_ttfTextOverlayRecords[0]));
+}
+
+static void invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
+    int i;
+    if (x2 < x1) {
+        int tmp = x1;
+        x1 = x2;
+        x2 = tmp;
+    }
+    if (y2 < y1) {
+        int tmp = y1;
+        y1 = y2;
+        y2 = tmp;
+    }
+    for (i = g_ttfTextOverlayCount - 1; i >= 0; i--) {
+        TtfTextOverlayRecord *record = &g_ttfTextOverlayRecords[i];
+        int rx1 = record->x;
+        int ry1 = record->y;
+        int rx2 = record->x + ttfTextOverlayRecordWidth(record) - 1;
+        int ry2 = record->y + g_fontHeightsArr[record->fontIdx] - 1;
+        if (rx2 >= x1 && rx1 <= x2 && ry2 >= y1 && ry1 <= y2) {
+            removeTtfTextOverlayRecord(i);
+        }
+    }
+}
+
+static void switchTtfTextOverlayColorRect(int x1, int y1, int x2, int y2, int oldColor, int newColor) {
+    int i;
+    if (x2 < x1) {
+        int tmp = x1;
+        x1 = x2;
+        x2 = tmp;
+    }
+    if (y2 < y1) {
+        int tmp = y1;
+        y1 = y2;
+        y2 = tmp;
+    }
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        TtfTextOverlayRecord *record = &g_ttfTextOverlayRecords[i];
+        int rx1 = record->x;
+        int ry1 = record->y;
+        int rx2 = record->x + ttfTextOverlayRecordWidth(record) - 1;
+        int ry2 = record->y + g_fontHeightsArr[record->fontIdx] - 1;
+        if ((record->color & 0xff) == (oldColor & 0xff) &&
+            rx2 >= x1 && rx1 <= x2 && ry2 >= y1 && ry1 <= y2) {
+            record->color = newColor;
+        }
+    }
+}
+#endif
 
 static int parseBdfHexByte(const char *text) {
     char *end = NULL;
@@ -636,6 +894,547 @@ static int parseBdfHexByte(const char *text) {
     if (end == text || value < 0 || value > 0xff) return -1;
     return (int)value;
 }
+
+#ifdef F15_HAVE_FREETYPE
+static int ensureFreetypeLibrary(void) {
+    if (g_freetypeLibrary) return 1;
+    if (FT_Init_FreeType(&g_freetypeLibrary) != 0) {
+        g_freetypeLibrary = NULL;
+        LogWarn(("asset replacement: FreeType initialization failed; TTF/OTF fonts disabled"));
+        return 0;
+    }
+    return 1;
+}
+
+static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
+    const uint8 *row;
+    int pitch;
+    if (!bitmap || !bitmap->buffer || x < 0 || y < 0 || x >= (int)bitmap->width || y >= (int)bitmap->rows) return 0;
+    pitch = bitmap->pitch < 0 ? -bitmap->pitch : bitmap->pitch;
+    row = bitmap->buffer + (size_t)y * (size_t)pitch;
+    if (bitmap->pixel_mode == FT_PIXEL_MODE_MONO) {
+        return (row[x >> 3] & (0x80u >> (x & 7))) ? 255 : 0;
+    }
+    if (bitmap->pixel_mode == FT_PIXEL_MODE_GRAY) {
+        return row[x];
+    }
+    return 0;
+}
+
+static int renderReplacementTtfGlyph(FT_Face face, uint32 codepoint, int fontWidth, int fontHeight,
+                                     uint8 *rowsOut, uint8 *advanceOut) {
+    int size;
+    if (!face || !rowsOut || !advanceOut || fontWidth <= 0 || fontWidth > 8 || fontHeight <= 0 || fontHeight > 32) return 0;
+    memset(rowsOut, 0, (size_t)fontHeight);
+
+    /* The original renderer consumes compact 1-bit cells. Fit the scalable
+     * glyph into that legacy cell at load/draw time, keeping TTF/OTF as the
+     * editable source while preserving old layout and clipping behavior. */
+    for (size = fontHeight * 3; size >= 1; size--) {
+        FT_GlyphSlot glyph;
+        FT_Bitmap *bitmap;
+        int xOff, yOff;
+        int x, y;
+        int advance;
+
+        if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)size) != 0) continue;
+        if (FT_Load_Char(face, (FT_ULong)codepoint, FT_LOAD_RENDER) != 0) continue;
+        glyph = face->glyph;
+        bitmap = &glyph->bitmap;
+        advance = (int)((glyph->advance.x + 32) >> 6);
+        if (advance <= 0) advance = bitmap->width > 0 ? (int)bitmap->width : 1;
+        if ((int)bitmap->width > fontWidth || (int)bitmap->rows > fontHeight) continue;
+
+        xOff = (fontWidth - (int)bitmap->width) / 2;
+        yOff = (fontHeight - (int)bitmap->rows) / 2;
+        memset(rowsOut, 0, (size_t)fontHeight);
+        for (y = 0; y < (int)bitmap->rows; y++) {
+            int dstY = y + yOff;
+            if (dstY < 0 || dstY >= fontHeight) continue;
+            for (x = 0; x < (int)bitmap->width; x++) {
+                int dstX = x + xOff;
+                if (dstX < 0 || dstX >= fontWidth || dstX >= 8) continue;
+                if (freetypeBitmapPixel(bitmap, x, y) >= 64) {
+                    rowsOut[dstY] |= (uint8)(0x80u >> dstX);
+                }
+            }
+        }
+        if (advance > fontWidth) advance = fontWidth;
+        if (advance < 1) advance = 1;
+        *advanceOut = (uint8)advance;
+        return 1;
+    }
+
+    *advanceOut = 1;
+    return 1;
+}
+
+static int replacementTtfPixelSize(uint16 fontIdx) {
+    int h;
+    if (fontIdx >= 8) return 8;
+    h = g_fontHeightsArr[fontIdx];
+    /* Replacement TTF text must occupy the same screen footprint as the original
+     * bitmap fonts. FreeType still supplies shape/coverage, but layout remains
+     * compatible with the legacy menu coordinates and clipping windows. */
+    return h;
+}
+
+static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
+    const uint8 *widths;
+    int idx;
+    if (fontIdx >= 8) return 8;
+    widths = g_fontWidthTables[fontIdx];
+    if (widths) {
+        idx = 'n' - 0x20;
+        if (idx >= 0 && idx < 96 && widths[idx] > 0) return widths[idx];
+    }
+    return g_fontMaxWidths[fontIdx] > 0 ? g_fontMaxWidths[fontIdx] : 8;
+}
+
+static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
+    FT_Face face;
+    int advance;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 8;
+    if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
+        return g_fontWidthTables[fontIdx][codepoint - 0x20];
+    }
+    if (codepoint >= 0x80) return replacementTtfUnicodeAdvance(fontIdx);
+    face = g_fontReplacementTtfFaces[fontIdx];
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return 8;
+    if (FT_Load_Char(face, (FT_ULong)codepoint, FT_LOAD_DEFAULT) != 0) return 8;
+    advance = (int)((face->glyph->advance.x + 32) >> 6);
+    return advance > 0 ? advance : 1;
+}
+
+static float replacementTtfAdvanceScaled(uint16 fontIdx, uint32 codepoint, float scaleX, float scaleY) {
+    FT_Face face;
+    int advance;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 8.0f * scaleX;
+    if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
+        return (float)g_fontWidthTables[fontIdx][codepoint - 0x20] * scaleX;
+    }
+    if (codepoint >= 0x80) return (float)replacementTtfUnicodeAdvance(fontIdx) * scaleX;
+    face = g_fontReplacementTtfFaces[fontIdx];
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)SDL_max(1, (int)((float)g_fontHeightsArr[fontIdx] * scaleY + 0.5f))) != 0) {
+        return 8.0f * scaleX;
+    }
+    if (FT_Load_Char(face, (FT_ULong)codepoint, FT_LOAD_DEFAULT) != 0) return 8.0f * scaleX;
+    advance = (int)((face->glyph->advance.x + 32) >> 6);
+    return (float)(advance > 0 ? advance : 1);
+}
+
+static uint8 blendReplacementTtfPixel(uint8 dstColor, uint8 srcColor, uint8 coverage) {
+    uint8 sr, sg, sb;
+    uint8 dr, dg, db;
+    int r, g, b;
+
+    if (coverage == 0) return dstColor;
+    if (coverage >= 250) return srcColor;
+    gfx_paletteRGB(srcColor, &sr, &sg, &sb);
+    gfx_paletteRGB(dstColor, &dr, &dg, &db);
+    r = ((int)sr * coverage + (int)dr * (255 - coverage) + 127) / 255;
+    g = ((int)sg * coverage + (int)dg * (255 - coverage) + 127) / 255;
+    b = ((int)sb * coverage + (int)db * (255 - coverage) + 127) / 255;
+    return (uint8)gfx_nearestPaletteIndexRgb8((uint8)r, (uint8)g, (uint8)b);
+}
+
+static int drawReplacementTtfGlyph(uint16 fontIdx, uint32 codepoint, FT_UInt previousGlyphIndex,
+                                   int *xInOut, int y, int color,
+                                   int clipL, int clipR, int clipT, int clipB,
+                                   SDL_Surface *surf, int submit) {
+    FT_Face face;
+    FT_UInt glyphIndex;
+    FT_Vector kerning;
+    FT_GlyphSlot glyph;
+    FT_Bitmap *bitmap;
+    uint8 *base;
+    int pitch, surfW, surfH;
+    int penX;
+    int baseline;
+    int row, col;
+    int advance;
+
+    if (!xInOut || fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx] || !surf) return previousGlyphIndex;
+    face = g_fontReplacementTtfFaces[fontIdx];
+    glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return previousGlyphIndex;
+
+    if ((codepoint < 0x20 || codepoint >= 0x80) && previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+        if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
+            *xInOut += (int)(kerning.x >> 6);
+        }
+    }
+    if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_RENDER) != 0) return previousGlyphIndex;
+
+    glyph = face->glyph;
+    bitmap = &glyph->bitmap;
+    base = (uint8 *)surf->pixels;
+    pitch = surf->pitch;
+    surfW = surf->w;
+    surfH = surf->h;
+    penX = *xInOut + glyph->bitmap_left;
+    baseline = y + g_fontHeightsArr[fontIdx];
+    advance = (int)((glyph->advance.x + 32) >> 6);
+    if (advance <= 0) advance = 1;
+    if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
+        advance = g_fontWidthTables[fontIdx][codepoint - 0x20];
+    }
+
+    for (row = 0; row < (int)bitmap->rows; row++) {
+        int py = baseline - glyph->bitmap_top + row;
+        uint8 *dstRow;
+        if (py < clipT || py > clipB || py < 0 || py >= surfH) continue;
+        dstRow = base + (size_t)py * pitch;
+        for (col = 0; col < (int)bitmap->width; col++) {
+            int px = penX + col;
+            uint8 coverage;
+            uint8 blended;
+            if (px < clipL || px > clipR || px < 0 || px >= surfW) continue;
+            coverage = freetypeBitmapPixel(bitmap, col, row);
+            if (coverage != 0) {
+                blended = blendReplacementTtfPixel(dstRow[px], (uint8)color, coverage);
+                if (submit) r2d_submitPoint(px, py, blended);
+                else dstRow[px] = blended;
+            }
+        }
+    }
+    *xInOut += advance;
+    return glyphIndex;
+}
+
+static const ReplacementFontGlyph *cacheReplacementTtfGlyph(uint16 fontIdx, uint32 codepoint) {
+    ReplacementFontGlyph *grown;
+    ReplacementFontGlyph *slot;
+    uint8 rows[32];
+    uint8 advance = 1;
+    int fontHeight;
+    int fontWidth;
+
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return NULL;
+    fontHeight = g_fontBitmapRowSize[fontIdx];
+    fontWidth = g_fontMaxWidths[fontIdx];
+    if (!renderReplacementTtfGlyph(g_fontReplacementTtfFaces[fontIdx], codepoint, fontWidth, fontHeight, rows, &advance)) {
+        return NULL;
+    }
+
+    grown = (ReplacementFontGlyph *)SDL_realloc(
+        g_fontReplacementExtraGlyphs[fontIdx],
+        (size_t)(g_fontReplacementExtraGlyphCounts[fontIdx] + 1) * sizeof(*grown)
+    );
+    if (!grown) return NULL;
+    g_fontReplacementExtraGlyphs[fontIdx] = grown;
+    slot = &g_fontReplacementExtraGlyphs[fontIdx][g_fontReplacementExtraGlyphCounts[fontIdx]++];
+    slot->codepoint = codepoint;
+    slot->width = advance;
+    slot->rows = (uint8 *)SDL_malloc((size_t)fontHeight);
+    if (!slot->rows) {
+        g_fontReplacementExtraGlyphCounts[fontIdx]--;
+        return NULL;
+    }
+    memcpy(slot->rows, rows, (size_t)fontHeight);
+    return slot;
+}
+
+static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
+    FT_Face face = NULL;
+    int fontWidth;
+    int fontHeight;
+
+    if (fontIdx >= 8 || !replacementPath) return 0;
+    fontWidth = g_fontMaxWidths[fontIdx];
+    fontHeight = g_fontHeightsArr[fontIdx];
+    if (fontWidth <= 0 || fontWidth > 8 || fontHeight <= 0 || fontHeight > 32) return 0;
+    if (!ensureFreetypeLibrary()) return 0;
+    if (FT_New_Face(g_freetypeLibrary, replacementPath, 0, &face) != 0 || !face) {
+        LogWarn(("asset replacement: failed to load TTF/OTF font %u at %s", (unsigned)fontIdx, replacementPath));
+        return 0;
+    }
+    /* Runtime TTF/OTF replacement is the Unicode source of truth. Some faces do
+     * not expose their Unicode cmap as the default charmap, which makes Cyrillic
+     * and other non-ASCII input resolve to glyph 0 and render as blank cells. */
+    (void)FT_Select_Charmap(face, FT_ENCODING_UNICODE);
+
+    freeReplacementFont(fontIdx);
+    g_fontReplacementTtfFaces[fontIdx] = face;
+    g_fontReplacementTtfPaths[fontIdx] = SDL_strdup(replacementPath);
+
+    LogInfo(("asset replacement: loaded font %u from runtime TTF/OTF %s", (unsigned)fontIdx, replacementPath));
+    return 1;
+}
+
+static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
+                                          int clipL, int clipR, int clipT, int clipB) {
+    TtfTextOverlayRecord *record;
+    int charIdx;
+    int drawnChars;
+    int x;
+    int color;
+    uint16 fontIdx;
+    int i;
+
+    if (!params || !string) return 0;
+    fontIdx = (uint16)params[6] & 7;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+
+    record = NULL;
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        TtfTextOverlayRecord *candidate = &g_ttfTextOverlayRecords[i];
+        if (candidate->x == (int)params[4] &&
+            candidate->y == (int)params[5] &&
+            candidate->fontIdx == fontIdx &&
+            candidate->clipL == clipL &&
+            candidate->clipR == clipR &&
+            candidate->clipT == clipT &&
+            candidate->clipB == clipB) {
+            record = candidate;
+            break;
+        }
+    }
+
+    if (string[0] == '\0') {
+        if (record) {
+            removeTtfTextOverlayRecord((int)(record - g_ttfTextOverlayRecords));
+        }
+        return 1;
+    }
+
+    if (!record) {
+        if (g_ttfTextOverlayCount >= (int)(sizeof(g_ttfTextOverlayRecords) / sizeof(g_ttfTextOverlayRecords[0]))) return 0;
+        record = &g_ttfTextOverlayRecords[g_ttfTextOverlayCount++];
+        memset(record, 0, sizeof(*record));
+    } else {
+        SDL_free(record->text);
+        record->text = NULL;
+    }
+
+    record->text = SDL_strdup(string);
+    if (!record->text) {
+        record->x = 0;
+        return 0;
+    }
+    record->x = (int)params[4];
+    record->y = (int)params[5];
+    record->color = (int)params[2];
+    record->fontIdx = fontIdx;
+    record->clipL = clipL;
+    record->clipR = clipR;
+    record->clipT = clipT;
+    record->clipB = clipB;
+
+    x = record->x;
+    color = record->color;
+    for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)string[charIdx];
+        int byteCount = 1;
+        if (!decodeUtf8Codepoint(&string[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            color = ch & 0x7F;
+            charIdx++;
+            continue;
+        }
+        x += replacementTtfAdvance(fontIdx, codepoint);
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    params[4] = (int16)x;
+    params[2] = (int16)color;
+    return 1;
+}
+
+static void renderTtfTextOverlayGlyphSDL(SDL_Renderer *renderer, FT_Bitmap *bitmap, float x, float y,
+                                         float pixelScaleX, float pixelScaleY, uint8 r, uint8 g, uint8 b, SDL_FRect clip) {
+    int row, col;
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    for (row = 0; row < (int)bitmap->rows; row++) {
+        for (col = 0; col < (int)bitmap->width; col++) {
+            uint8 coverage = freetypeBitmapPixel(bitmap, col, row);
+            SDL_FRect px;
+            if (!coverage) continue;
+            px.x = x + (float)col * pixelScaleX;
+            px.y = y + (float)row * pixelScaleY;
+            px.w = pixelScaleX;
+            px.h = pixelScaleY;
+            if (px.x < clip.x || px.y < clip.y || px.x >= clip.x + clip.w || px.y >= clip.y + clip.h) continue;
+            SDL_SetRenderDrawColor(renderer, r, g, b, coverage);
+            SDL_RenderFillRect(renderer, &px);
+        }
+    }
+}
+
+static void renderTtfTextOverlayGlyphGL(FT_Bitmap *bitmap, float x, float y, float pixelScaleX, float pixelScaleY,
+                                        uint8 r, uint8 g, uint8 b, SDL_FRect clip) {
+    int row, col;
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBegin(GL_QUADS);
+    for (row = 0; row < (int)bitmap->rows; row++) {
+        for (col = 0; col < (int)bitmap->width; col++) {
+            uint8 coverage = freetypeBitmapPixel(bitmap, col, row);
+            float x0, y0, x1, y1;
+            if (!coverage) continue;
+            x0 = x + (float)col * pixelScaleX;
+            y0 = y + (float)row * pixelScaleY;
+            if (x0 < clip.x || y0 < clip.y || x0 >= clip.x + clip.w || y0 >= clip.y + clip.h) continue;
+            x1 = x0 + pixelScaleX;
+            y1 = y0 + pixelScaleY;
+            glColor4ub(r, g, b, coverage);
+            glVertex2f(x0, y0);
+            glVertex2f(x1, y0);
+            glVertex2f(x1, y1);
+            glVertex2f(x0, y1);
+        }
+    }
+    glEnd();
+    glDisable(GL_BLEND);
+}
+
+static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMapping *m,
+                                       SDL_Renderer *renderer, int useGL) {
+    SDL_Color c;
+    SDL_Palette *pal;
+    FT_Face face;
+    FT_UInt previousGlyphIndex = 0;
+    float x;
+    int charIdx;
+    int drawnChars;
+    int pixelSize;
+    float cellY;
+    float cellHeight;
+    float baseline;
+    SDL_FRect clip;
+
+    if (!record || !record->text || record->fontIdx >= 8 || !g_fontReplacementTtfFaces[record->fontIdx]) return;
+    face = g_fontReplacementTtfFaces[record->fontIdx];
+    pixelSize = SDL_max(1, (int)((float)g_fontHeightsArr[record->fontIdx] * m->scaleY + 0.5f));
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)pixelSize) != 0) return;
+    pal = gfx_getPalette();
+    if (!pal) return;
+    c = pal->colors[record->color & 0xff];
+    x = (float)m->offX + (float)record->x * m->scaleX;
+    cellY = (float)m->offY + (float)record->y * m->scaleY;
+    cellHeight = (float)g_fontHeightsArr[record->fontIdx] * m->scaleY;
+    baseline = cellY + cellHeight * 0.88f;
+    clip.x = (float)m->offX + (float)record->clipL * m->scaleX;
+    clip.y = (float)m->offY + (float)record->clipT * m->scaleY;
+    clip.w = (float)(record->clipR - record->clipL + 1) * m->scaleX;
+    clip.h = (float)(record->clipB - record->clipT + 1) * m->scaleY;
+
+    for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)record->text[charIdx];
+        int byteCount = 1;
+        FT_UInt glyphIndex;
+        FT_Vector kerning;
+        FT_GlyphSlot glyph;
+        FT_Bitmap *bitmap;
+        float gx;
+        float gy;
+        float targetAdvance;
+        float inkWidth;
+        float inkHeight;
+        float pixelScaleX;
+        float pixelScaleY;
+
+        if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            c = pal->colors[ch & 0x7f];
+            previousGlyphIndex = 0;
+            charIdx++;
+            continue;
+        }
+        glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
+        if ((codepoint < 0x20 || codepoint >= 0x80) && previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+            if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
+                x += (float)(kerning.x >> 6);
+            }
+        }
+        if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_RENDER) == 0) {
+            glyph = face->glyph;
+            bitmap = &glyph->bitmap;
+            targetAdvance = replacementTtfAdvanceScaled(record->fontIdx, codepoint, m->scaleX, m->scaleY);
+            inkWidth = (float)bitmap->width;
+            inkHeight = (float)bitmap->rows;
+            pixelScaleX = 1.0f;
+            pixelScaleY = 1.0f;
+            gx = x + (float)glyph->bitmap_left;
+            if (inkWidth > 0.0f && targetAdvance > 0.0f) {
+                /* Replacement TTF glyphs must stay inside the original fixed
+                 * bitmap-font cell. This is required for Unicode letters too:
+                 * Cyrillic glyphs from common TTF faces are much wider/taller
+                 * than the DOS 8-pixel menu font and otherwise land outside the
+                 * visible row or collide with following text. */
+                pixelScaleX = targetAdvance / inkWidth;
+                if (pixelScaleX > 1.0f) pixelScaleX = 1.0f;
+                gx = x + (targetAdvance - inkWidth * pixelScaleX) * 0.5f;
+            }
+            if (inkHeight > 0.0f && cellHeight > 0.0f) {
+                pixelScaleY = cellHeight / inkHeight;
+                if (pixelScaleY > 1.0f) pixelScaleY = 1.0f;
+            }
+            gy = baseline - (float)glyph->bitmap_top * pixelScaleY;
+            if (gy < cellY) gy = cellY;
+            /* Do not bottom-clamp descenders: q/g/ф need to hang below the
+             * baseline or the whole glyph is pushed upward relative to x-height
+             * letters. The row-level clip still keeps text inside the viewport. */
+            if (useGL) renderTtfTextOverlayGlyphGL(bitmap, gx, gy, pixelScaleX, pixelScaleY, c.r, c.g, c.b, clip);
+            else renderTtfTextOverlayGlyphSDL(renderer, bitmap, gx, gy, pixelScaleX, pixelScaleY, c.r, c.g, c.b, clip);
+        }
+        x += replacementTtfAdvanceScaled(record->fontIdx, codepoint, m->scaleX, m->scaleY);
+        previousGlyphIndex = glyphIndex;
+        charIdx += byteCount;
+        drawnChars++;
+    }
+}
+
+static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL) {
+    int i;
+    if (!m || g_ttfTextOverlayCount <= 0) return;
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        renderTtfTextOverlayRecord(&g_ttfTextOverlayRecords[i], m, renderer, useGL);
+    }
+}
+
+void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
+    R2DMapping m;
+    r2d_computeMapping(virtW, virtH, winW, winH, 0, &m);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0, winW, winH, 0, -1, 1);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    glDisable(GL_TEXTURE_2D);
+    renderTtfTextOverlay(&m, NULL, 1);
+}
+
+void gfx_clearTtfTextOverlay(void) {
+    clearTtfTextOverlayRecords();
+}
+
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
+    invalidateTtfTextOverlayRect(x1, y1, x2, y2);
+}
+#else
+void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
+    (void)virtW;
+    (void)virtH;
+    (void)winW;
+    (void)winH;
+}
+void gfx_clearTtfTextOverlay(void) {}
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
+    (void)x1;
+    (void)y1;
+    (void)x2;
+    (void)y2;
+}
+#endif
 
 static void compareReplacementFontWithBuiltin(uint16 fontIdx,
                                               const uint8 *newBitmap,
@@ -762,8 +1561,7 @@ static int loadReplacementFontPng(uint16 fontIdx, const char *replacementPath) {
     SDL_DestroySurface(src);
 
     compareReplacementFontWithBuiltin(fontIdx, newBitmap, newWidths, fontHeight, fontWidth, replacementPath);
-    SDL_free(g_fontReplacementBitmaps[fontIdx]);
-    SDL_free(g_fontReplacementWidths[fontIdx]);
+    freeReplacementFont(fontIdx);
     g_fontReplacementBitmaps[fontIdx] = newBitmap;
     g_fontReplacementWidths[fontIdx] = newWidths;
     g_fontBitmapPtrs[fontIdx] = newBitmap;
@@ -777,21 +1575,38 @@ static int loadReplacementFontPng(uint16 fontIdx, const char *replacementPath) {
 }
 
 static void tryLoadReplacementFont(uint16 fontIdx) {
+    typedef struct BdfExtraGlyph {
+        uint32 codepoint;
+        uint8 width;
+        uint8 rows[32];
+    } BdfExtraGlyph;
     char legacyFontName[32];
     char replacementPath[512];
+    char ttfReplacementPath[512];
+    char otfReplacementPath[512];
     char pngReplacementPath[512];
+    int hasTtfReplacement;
+    int hasOtfReplacement;
     int hasPngReplacement;
     FILE *fp;
     char line[256];
     uint8 rows[96][32];
     uint8 widths[96];
     uint8 seen[96];
-    int current = -1;
+    uint8 currentRows[32];
+    int currentCodepoint = -1;
+    int currentAscii = -1;
+    int currentWidth = 0;
     int inBitmap = 0;
     int bitmapRow = 0;
     int fontHeight = -1;
     int fontWidth = -1;
     int seenCount = 0;
+    BdfExtraGlyph *extraGlyphs = NULL;
+    int extraGlyphCount = 0;
+    int extraGlyphCapacity = 0;
+    int parseFailed = 0;
+    ReplacementFontGlyph *newExtraGlyphs = NULL;
     uint8 *newBitmap;
     uint8 *newWidths;
     int i, row;
@@ -800,7 +1615,17 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
     g_fontReplacementTried[fontIdx] = 1;
 
     snprintf(legacyFontName, sizeof(legacyFontName), "font_%u", (unsigned)fontIdx);
+    hasTtfReplacement = findReplacementAssetPath(legacyFontName, ".ttf", ttfReplacementPath, sizeof(ttfReplacementPath));
+    hasOtfReplacement = findReplacementAssetPath(legacyFontName, ".otf", otfReplacementPath, sizeof(otfReplacementPath));
     hasPngReplacement = findReplacementAssetPath(legacyFontName, ".png", pngReplacementPath, sizeof(pngReplacementPath));
+#ifdef F15_HAVE_FREETYPE
+    if (hasTtfReplacement && loadReplacementFontTtf(fontIdx, ttfReplacementPath)) return;
+    if (hasOtfReplacement && loadReplacementFontTtf(fontIdx, otfReplacementPath)) return;
+#else
+    if (hasTtfReplacement || hasOtfReplacement) {
+        LogWarn(("asset replacement: TTF/OTF font %u present but this build has no FreeType support", (unsigned)fontIdx));
+    }
+#endif
     if (!findReplacementAssetPath(legacyFontName, ".bdf", replacementPath, sizeof(replacementPath))) {
         if (hasPngReplacement) {
             (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
@@ -819,56 +1644,94 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
     memset(rows, 0, sizeof(rows));
     memset(widths, 0, sizeof(widths));
     memset(seen, 0, sizeof(seen));
+    memset(currentRows, 0, sizeof(currentRows));
 
     while (fgets(line, sizeof(line), fp) != NULL) {
         int valueA, valueB;
         if (sscanf(line, "ENCODING %d", &valueA) == 1) {
-            current = (valueA >= 0x20 && valueA < 0x80) ? valueA - 0x20 : -1;
+            currentCodepoint = valueA;
+            currentAscii = (valueA >= 0x20 && valueA < 0x80) ? valueA - 0x20 : -1;
+            currentWidth = 0;
             bitmapRow = 0;
             inBitmap = 0;
+            memset(currentRows, 0, sizeof(currentRows));
             continue;
         }
-        if (current >= 0 && sscanf(line, "DWIDTH %d", &valueA) == 1) {
-            widths[current] = (uint8)((valueA < 0) ? 0 : (valueA > 255 ? 255 : valueA));
+        if (currentCodepoint >= 0 && sscanf(line, "DWIDTH %d", &valueA) == 1) {
+            currentWidth = (valueA < 0) ? 0 : (valueA > 255 ? 255 : valueA);
             continue;
         }
-        if (current >= 0 && sscanf(line, "BBX %d %d", &valueA, &valueB) == 2) {
+        if (currentCodepoint >= 0 && sscanf(line, "BBX %d %d", &valueA, &valueB) == 2) {
             if (valueA <= 0 || valueA > 8 || valueB <= 0 || valueB > 32) {
-                current = -1;
+                currentCodepoint = -1;
                 continue;
             }
             if (fontWidth < 0) fontWidth = valueA;
             if (fontHeight < 0) fontHeight = valueB;
             if (fontWidth != valueA || fontHeight != valueB) {
-                current = -1;
+                currentCodepoint = -1;
             }
             continue;
         }
-        if (current >= 0 && strncmp(line, "BITMAP", 6) == 0) {
+        if (currentCodepoint >= 0 && strncmp(line, "BITMAP", 6) == 0) {
             inBitmap = 1;
             bitmapRow = 0;
             continue;
         }
-        if (current >= 0 && inBitmap && strncmp(line, "ENDCHAR", 7) == 0) {
-            if (fontHeight > 0 && bitmapRow == fontHeight && !seen[current]) {
-                seen[current] = 1;
-                seenCount++;
+        if (currentCodepoint >= 0 && inBitmap && strncmp(line, "ENDCHAR", 7) == 0) {
+            if (fontHeight > 0 && bitmapRow == fontHeight && currentWidth > 0) {
+                if (currentAscii >= 0) {
+                    if (!seen[currentAscii]) {
+                        memcpy(rows[currentAscii], currentRows, (size_t)fontHeight);
+                        widths[currentAscii] = (uint8)currentWidth;
+                        seen[currentAscii] = 1;
+                        seenCount++;
+                    }
+                } else {
+                    int exists = 0;
+                    for (i = 0; i < extraGlyphCount; i++) {
+                        if (extraGlyphs[i].codepoint == (uint32)currentCodepoint) {
+                            exists = 1;
+                            break;
+                        }
+                    }
+                    if (!exists) {
+                        if (extraGlyphCount == extraGlyphCapacity) {
+                            int newCapacity = extraGlyphCapacity ? extraGlyphCapacity * 2 : 32;
+                            BdfExtraGlyph *grown = (BdfExtraGlyph *)SDL_realloc(extraGlyphs, (size_t)newCapacity * sizeof(*extraGlyphs));
+                            if (!grown) {
+                                parseFailed = 1;
+                            } else {
+                                extraGlyphs = grown;
+                                extraGlyphCapacity = newCapacity;
+                            }
+                        }
+                        if (!parseFailed) {
+                            extraGlyphs[extraGlyphCount].codepoint = (uint32)currentCodepoint;
+                            extraGlyphs[extraGlyphCount].width = (uint8)currentWidth;
+                            memcpy(extraGlyphs[extraGlyphCount].rows, currentRows, (size_t)fontHeight);
+                            extraGlyphCount++;
+                        }
+                    }
+                }
             }
             inBitmap = 0;
-            current = -1;
+            currentCodepoint = -1;
+            currentAscii = -1;
             continue;
         }
-        if (current >= 0 && inBitmap && fontHeight > 0 && bitmapRow < fontHeight) {
+        if (currentCodepoint >= 0 && inBitmap && fontHeight > 0 && bitmapRow < fontHeight) {
             int byteValue = parseBdfHexByte(line);
             if (byteValue >= 0) {
-                rows[current][bitmapRow++] = (uint8)byteValue;
+                currentRows[bitmapRow++] = (uint8)byteValue;
             }
         }
     }
     fclose(fp);
 
-    if (fontHeight <= 0 || fontWidth <= 0 || seenCount != 96) {
+    if (parseFailed || fontHeight <= 0 || fontWidth <= 0 || seenCount != 96) {
         LogWarn(("asset replacement: rejected BDF font %u at %s; expected 96 complete glyphs", (unsigned)fontIdx, replacementPath));
+        SDL_free(extraGlyphs);
         if (hasPngReplacement) {
             (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
         }
@@ -877,6 +1740,7 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
     for (i = 0; i < 96; i++) {
         if (widths[i] == 0) {
             LogWarn(("asset replacement: rejected BDF font %u at %s; glyph 0x%02x has invalid advance width 0", (unsigned)fontIdx, replacementPath, i + 0x20));
+            SDL_free(extraGlyphs);
             if (hasPngReplacement) {
                 (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
             }
@@ -886,9 +1750,14 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
 
     newBitmap = (uint8 *)SDL_malloc((size_t)96 * (size_t)fontHeight);
     newWidths = (uint8 *)SDL_malloc(96);
-    if (!newBitmap || !newWidths) {
+    if (extraGlyphCount > 0) {
+        newExtraGlyphs = (ReplacementFontGlyph *)SDL_calloc((size_t)extraGlyphCount, sizeof(*newExtraGlyphs));
+    }
+    if (!newBitmap || !newWidths || (extraGlyphCount > 0 && !newExtraGlyphs)) {
         SDL_free(newBitmap);
         SDL_free(newWidths);
+        SDL_free(newExtraGlyphs);
+        SDL_free(extraGlyphs);
         if (hasPngReplacement) {
             LogWarn(("asset replacement: failed to allocate BDF font %u from %s; trying PNG atlas %s", (unsigned)fontIdx, replacementPath, pngReplacementPath));
             (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
@@ -902,12 +1771,33 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
             newBitmap[(i * fontHeight) + row] = rows[i][row];
         }
     }
+    for (i = 0; i < extraGlyphCount; i++) {
+        newExtraGlyphs[i].rows = (uint8 *)SDL_malloc((size_t)fontHeight);
+        if (!newExtraGlyphs[i].rows) {
+            int j;
+            for (j = 0; j < i; j++) SDL_free(newExtraGlyphs[j].rows);
+            SDL_free(newExtraGlyphs);
+            SDL_free(newBitmap);
+            SDL_free(newWidths);
+            SDL_free(extraGlyphs);
+            if (hasPngReplacement) {
+                LogWarn(("asset replacement: failed to allocate BDF Unicode glyphs for font %u from %s; trying PNG atlas %s", (unsigned)fontIdx, replacementPath, pngReplacementPath));
+                (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
+            }
+            return;
+        }
+        newExtraGlyphs[i].codepoint = extraGlyphs[i].codepoint;
+        newExtraGlyphs[i].width = extraGlyphs[i].width;
+        memcpy(newExtraGlyphs[i].rows, extraGlyphs[i].rows, (size_t)fontHeight);
+    }
+    SDL_free(extraGlyphs);
 
     compareReplacementFontWithBuiltin(fontIdx, newBitmap, newWidths, fontHeight, fontWidth, replacementPath);
-    SDL_free(g_fontReplacementBitmaps[fontIdx]);
-    SDL_free(g_fontReplacementWidths[fontIdx]);
+    freeReplacementFont(fontIdx);
     g_fontReplacementBitmaps[fontIdx] = newBitmap;
     g_fontReplacementWidths[fontIdx] = newWidths;
+    g_fontReplacementExtraGlyphs[fontIdx] = newExtraGlyphs;
+    g_fontReplacementExtraGlyphCounts[fontIdx] = extraGlyphCount;
     g_fontBitmapPtrs[fontIdx] = newBitmap;
     g_fontWidthTables[fontIdx] = newWidths;
     g_fontHeightsArr[fontIdx] = (uint8)fontHeight;
@@ -915,9 +1805,10 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
     g_fontBitmapRowSize[fontIdx] = (uint8)fontHeight;
 
     LogInfo((
-        "asset replacement: loaded font %u from BDF %s",
+        "asset replacement: loaded font %u from BDF %s with %d Unicode glyphs",
         (unsigned)fontIdx,
-        replacementPath
+        replacementPath,
+        extraGlyphCount
     ));
 }
 
@@ -981,13 +1872,16 @@ static void drawStringCore(int16 *params, const char *string,
     int pitch, surfW, surfH;
     int x, y, color;
     int charIdx;
-    uint8 ch;
+    int drawnChars;
     int row, col;
     uint16 fontIdx;
     uint8 height, rowSize;
     uint8 *bitmaps;
     const uint8 *widthTab;
     int submit;
+#ifdef F15_HAVE_FREETYPE
+    FT_UInt previousTtfGlyphIndex = 0;
+#endif
 
     if (!string || !params) return;
 
@@ -1018,20 +1912,76 @@ static void drawStringCore(int16 *params, const char *string,
     surfW = surf->w;
     surfH = surf->h;
 
-    for (charIdx = 0; string[charIdx] != 0 && charIdx < 256; charIdx++) {
-        ch = (uint8)string[charIdx];
+#ifdef F15_HAVE_FREETYPE
+    if (!submit && fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
+        (void)recordTtfTextOverlayAndAdvance(params, string, clipL, clipR, clipT, clipB);
+        return;
+    }
+#endif
 
-        /* Inline color escape: chars >= 0x80 change the text color.
-         * The new color is (ch & 0x7F). No glyph is drawn. */
-        if (ch & 0x80) {
+    for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < 256;) {
+        const ReplacementFontGlyph *extraGlyph = NULL;
+        const uint8 *glyph = NULL;
+        uint32 codepoint;
+        uint8 ch = (uint8)string[charIdx];
+        int byteCount = 1;
+        int advance = 8;
+
+        if (!decodeUtf8Codepoint(&string[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+
+        /* Inline color escape: legacy single bytes >= 0x80 change the text
+         * color. Valid UTF-8 high-byte sequences are rendered as Unicode text. */
+        if (byteCount == 1 && (ch & 0x80)) {
             color = ch & 0x7F;
+            charIdx++;
             continue;
         }
 
         if (x > clipR) break; /* rest of the string is right of window */
 
-        if (bitmaps && ch >= 0x20) {
-            uint8 *glyph = bitmaps + (ch - 0x20) * (uint16)rowSize;
+#ifdef F15_HAVE_FREETYPE
+        if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
+            previousTtfGlyphIndex = drawReplacementTtfGlyph(
+                fontIdx,
+                codepoint,
+                previousTtfGlyphIndex,
+                &x,
+                y,
+                color,
+                clipL,
+                clipR,
+                clipT,
+                clipB,
+                surf,
+                submit
+            );
+            charIdx += byteCount;
+            drawnChars++;
+            continue;
+        }
+#endif
+
+        if (bitmaps && codepoint >= 0x20 && codepoint < 0x80) {
+            glyph = bitmaps + (codepoint - 0x20) * (uint16)rowSize;
+            advance = widthTab ? widthTab[codepoint - 0x20] : 8;
+        } else if (codepoint >= 0x80) {
+            extraGlyph = findReplacementFontGlyph(fontIdx, codepoint);
+#ifdef F15_HAVE_FREETYPE
+            if (!extraGlyph) extraGlyph = cacheReplacementTtfGlyph(fontIdx, codepoint);
+#endif
+            if (extraGlyph) {
+                glyph = extraGlyph->rows;
+                advance = extraGlyph->width;
+            } else if (bitmaps) {
+                glyph = bitmaps + ('?' - 0x20) * (uint16)rowSize;
+                advance = widthTab ? widthTab['?' - 0x20] : 8;
+            }
+        }
+
+        if (glyph) {
             for (row = 0; row < height; row++) {
                 int py = y + row;
                 uint8 bits;
@@ -1051,7 +2001,9 @@ static void drawStringCore(int16 *params, const char *string,
                 }
             }
         }
-        x += widthTab ? (ch >= 0x20 ? widthTab[ch - 0x20] : 8) : 8;
+        x += advance;
+        charIdx += byteCount;
+        drawnChars++;
     }
 
     /* Update x position and color in the param block (start/end's menu text
@@ -1185,6 +2137,11 @@ void FAR CDECL gfx_drawGlyphStr(int16 *desc, const char *str, int slot) {
 void FAR CDECL gfx_copyRect(int srcPage, uint16 srcX, uint16 srcY,
                             int dstPage, uint16 dstX, uint16 dstY,
                             int width, int height) {
+#ifdef F15_HAVE_FREETYPE
+    if (ttfOverlayRectIsScreenChange((int)dstX, (int)dstY, (int)dstX + width - 1, (int)dstY + height - 1)) {
+        invalidateTtfTextOverlayRecords();
+    }
+#endif
     r2d_blit(ensurePage(srcPage), (int)srcX, (int)srcY,
              ensurePage(dstPage), (int)dstX, (int)dstY,
              width, height, -1);
@@ -1206,6 +2163,11 @@ void gfx_captureToImage(struct R2DImage *img, int srcPage, int srcX, int srcY,
 
 void gfx_restoreFromImage(struct R2DImage *img, int dstPage, int srcX, int srcY,
                           int dstX, int dstY, int w, int h) {
+#ifdef F15_HAVE_FREETYPE
+    if (ttfOverlayRectIsScreenChange(dstX, dstY, dstX + w - 1, dstY + h - 1)) {
+        invalidateTtfTextOverlayRecords();
+    }
+#endif
     r2d_drawImage(img, srcX, srcY, w, h, ensurePage(dstPage), dstX, dstY, -1);
 }
 
@@ -1226,6 +2188,9 @@ void gfx_drawSpriteOpaque(int handle, int srcX, int srcY, int dstPage,
 /* ---- Slot 0x29: gfx_switchColor ---- */
 void FAR CDECL gfx_switchColor(int16 *pageDesc, int x1, int y1,
                                int x2, int y2, int oldColor, int newColor) {
+#ifdef F15_HAVE_FREETYPE
+    switchTtfTextOverlayColorRect(x1, y1, x2, y2, oldColor, newColor);
+#endif
     SDL_Surface *surf = gfx_getPageSurface((int)*pageDesc);
     uint8 *base;
     int pitch, row, col;
@@ -1253,6 +2218,13 @@ void FAR CDECL gfx_switchColor(int16 *pageDesc, int x1, int y1,
  * colour. Writes straight into the page's backing SDL surface — the same buffer
  * the pic decoder and blitters target — so no DOS segment is involved. */
 void clearRect(int16 *pageNum, int16 x1, int16 y1, int16 x2, int16 y2) {
+#ifdef F15_HAVE_FREETYPE
+    if (ttfOverlayRectIsScreenChange(x1, y1, x2, y2)) {
+        invalidateTtfTextOverlayRecords();
+    } else {
+        invalidateTtfTextOverlayRect(x1, y1, x2, y2);
+    }
+#endif
     SDL_Surface *surf = gfx_getPageSurface((int)*pageNum);
     uint8 color = (uint8)pageNum[3];
     uint8 *base;
@@ -1565,24 +2537,39 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
     }
 }
 
-int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
-    /* Returns the pixel advance width of a single character. stringWidth()
-     * sums this over a string to centre text, so it MUST agree with the
-     * x-advance gfx_drawString uses (wt[ch-0x20]); otherwise centred text
-     * lands off-screen and drawString's clip test discards every glyph.
-     * The width tables are file-scope arrays reached directly as native
-     * pointers, exactly as drawStringCore reads them. */
+int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
+    /* Returns the pixel advance width of one decoded character. stringWidth()
+     * and gfx_setFont both route here so centered/right-aligned UTF-8 text
+     * agrees with drawStringCore's glyph selection and x-advance behavior. */
     const uint8 *wt;
     if (fontIdx >= 8) return 8;
-    /* Chars >= 0x80 are inline color escapes - no glyph, no width */
-    if (ch >= 0x80) return 0;
     /* Font replacements are authoritative for both drawing and layout. Load
      * BDF/PNG before width lookup so centred/right-aligned text uses the same
      * metrics the glyph renderer will use later. */
     tryLoadReplacementFont(fontIdx);
+#ifdef F15_HAVE_FREETYPE
+    if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
+        if (codepoint <= 0xff && codepoint >= 0x80) return 0;
+        return replacementTtfAdvance(fontIdx, codepoint);
+    }
+#endif
+    if (codepoint >= 0x80) {
+        const ReplacementFontGlyph *glyph = findReplacementFontGlyph(fontIdx, codepoint);
+#ifdef F15_HAVE_FREETYPE
+        if (!glyph) glyph = cacheReplacementTtfGlyph(fontIdx, codepoint);
+#endif
+        if (glyph) return glyph->width;
+        /* Legacy single-byte chars >= 0x80 are inline color escapes. */
+        if (codepoint <= 0xff) return 0;
+        return 8;
+    }
     wt = g_fontWidthTables[fontIdx];
-    if (!wt || ch < 0x20) return 8;
-    return wt[ch - 0x20];
+    if (!wt || codepoint < 0x20) return 8;
+    return wt[codepoint - 0x20];
+}
+
+int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
+    return gfx_getGlyphAdvance((uint32)ch, fontIdx);
 }
 void FAR CDECL gfx_setFadeSteps(int steps) {
     (void)steps;

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -11,8 +11,12 @@
 #include "struct.h"
 #include "log.h"
 #include "version.h"
+#include "shared/asset_compare.h"
+#include "shared/common.h"
 #include <dos.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "fontdata.h"
 
@@ -81,7 +85,10 @@ void gfx_videoInit(void) {
                 msaa = 0;
                 continue;
             }
-            LogCritical(("GL init failed; falling back to software renderer"));
+            /* This must not be LogCritical: log_critical exits immediately.
+             * A failed GL context is recoverable because the software renderer
+             * can create a normal SDL window below. */
+            LogError(("GL init failed; falling back to software renderer"));
             s_useGL = false;
             break;
         }
@@ -285,6 +292,26 @@ void gfx_paletteRGB(int idx, uint8 *r, uint8 *g, uint8 *b) {
     *r = pal->colors[idx].r;
     *g = pal->colors[idx].g;
     *b = pal->colors[idx].b;
+}
+
+int gfx_nearestPaletteIndexRgb8(uint8 r, uint8 g, uint8 b) {
+    SDL_Palette *pal = gfx_getPalette();
+    int best = 15;
+    int bestDist = 0x7fffffff;
+    int i;
+    if (!pal || pal->ncolors <= 0) return best;
+    for (i = 0; i < pal->ncolors && i < 256; i++) {
+        int dr = (int)r - pal->colors[i].r;
+        int dg = (int)g - pal->colors[i].g;
+        int db = (int)b - pal->colors[i].b;
+        int dist = dr * dr + dg * dg + db * db;
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = i;
+            if (dist == 0) break;
+        }
+    }
+    return best;
 }
 
 /* Lazily create the 320x200 8-bit surface backing a page index. */
@@ -585,17 +612,354 @@ static const uint8 g_font0_widths[96] = {
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-static const uint8 *const g_fontWidthTables[8] = {
+static const uint8 *g_fontWidthTables[8] = {
     g_font0_widths, g_font1_widths, NULL, g_font3_widths,
     g_font4_widths, g_font5_widths, NULL, NULL};
-static const uint8 g_fontHeightsArr[8] = {5, 8, 7, 6, 7, 6, 4, 0};
-static const uint8 g_fontMaxWidths[8] = {4, 8, 6, 6, 8, 6, 0, 0};
+static uint8 g_fontHeightsArr[8] = {5, 8, 7, 6, 7, 6, 4, 0};
+static uint8 g_fontMaxWidths[8] = {4, 8, 6, 6, 8, 6, 0, 0};
 
 /* Bitmap pointers per font index — NULL means no bitmap available */
 static uint8 *g_fontBitmapPtrs[8] = {
     (uint8 *)g_font0_bitmaps, (uint8 *)g_font1_bitmaps, NULL, (uint8 *)g_font3_bitmaps,
     (uint8 *)g_font4_bitmaps, (uint8 *)g_font5_bitmaps, NULL, NULL};
-static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+static uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+/* Modern font replacements are deliberately media-first. BDF carries both
+ * glyph bitmaps and advance widths; PNG atlas fallback carries bitmap pixels
+ * only and reuses the existing width table so no JSON sidecar is required. */
+static uint8 *g_fontReplacementBitmaps[8] = {NULL};
+static uint8 *g_fontReplacementWidths[8] = {NULL};
+static uint8 g_fontReplacementTried[8] = {0};
+
+static int parseBdfHexByte(const char *text) {
+    char *end = NULL;
+    long value = strtol(text, &end, 16);
+    if (end == text || value < 0 || value > 0xff) return -1;
+    return (int)value;
+}
+
+static void compareReplacementFontWithBuiltin(uint16 fontIdx,
+                                              const uint8 *newBitmap,
+                                              const uint8 *newWidths,
+                                              int newHeight,
+                                              int newWidth,
+                                              const char *replacementPath) {
+    const uint8 *oldBitmap;
+    const uint8 *oldWidths;
+    int oldHeight;
+    int oldWidth;
+    char label[32];
+
+    if (!assetCompareEnabled() || fontIdx >= 8 || !newBitmap || !newWidths) return;
+    oldBitmap = g_fontBitmapPtrs[fontIdx];
+    oldWidths = g_fontWidthTables[fontIdx];
+    oldHeight = g_fontBitmapRowSize[fontIdx];
+    oldWidth = g_fontMaxWidths[fontIdx];
+    if (!oldBitmap || !oldWidths || oldHeight <= 0 || oldWidth <= 0) {
+        LogWarn(("asset replacement compare: no built-in font data available for font %u", (unsigned)fontIdx));
+        return;
+    }
+
+    SDL_snprintf(label, sizeof(label), "font %u", (unsigned)fontIdx);
+    assetCompareFont96(
+        label,
+        oldBitmap,
+        oldWidths,
+        oldHeight,
+        oldWidth,
+        newBitmap,
+        newWidths,
+        newHeight,
+        newWidth,
+        replacementPath
+    );
+}
+
+static int loadReplacementFontPng(uint16 fontIdx, const char *replacementPath) {
+    SDL_Surface *src;
+    SDL_Surface *rgba = NULL;
+    int fontWidth;
+    int fontHeight;
+    int cellStrideX;
+    int cellStrideY;
+    uint8 *newBitmap;
+    uint8 *newWidths;
+    const uint8 *oldWidths;
+    int i, row, col;
+
+    if (fontIdx >= 8 || !replacementPath) return 0;
+    fontWidth = g_fontMaxWidths[fontIdx];
+    fontHeight = g_fontHeightsArr[fontIdx];
+    oldWidths = g_fontWidthTables[fontIdx];
+    if (fontWidth <= 0 || fontWidth > 8 || fontHeight <= 0 || fontHeight > 32 || !oldWidths) {
+        return 0;
+    }
+
+    src = SDL_LoadPNG(replacementPath);
+    if (!src) {
+        LogWarn(("asset replacement: failed to load PNG font atlas %s (%s)", replacementPath, SDL_GetError()));
+        return 0;
+    }
+
+    cellStrideX = fontWidth + 1;
+    cellStrideY = fontHeight + 1;
+    if (src->w < 16 * cellStrideX - 1 || src->h < 6 * cellStrideY - 1) {
+        LogWarn(("asset replacement: rejected PNG font atlas %u at %s; size %dx%d too small", (unsigned)fontIdx, replacementPath, src->w, src->h));
+        SDL_DestroySurface(src);
+        return 0;
+    }
+
+    if (src->format != SDL_PIXELFORMAT_INDEX8) {
+        rgba = SDL_ConvertSurface(src, SDL_PIXELFORMAT_RGBA32);
+        if (!rgba) {
+            SDL_DestroySurface(src);
+            return 0;
+        }
+    }
+
+    newBitmap = (uint8 *)SDL_calloc((size_t)96, (size_t)fontHeight);
+    newWidths = (uint8 *)SDL_malloc(96);
+    if (!newBitmap || !newWidths) {
+        SDL_free(newBitmap);
+        SDL_free(newWidths);
+        if (rgba) SDL_DestroySurface(rgba);
+        SDL_DestroySurface(src);
+        return 0;
+    }
+    memcpy(newWidths, oldWidths, 96);
+
+    if (rgba) {
+        if (SDL_MUSTLOCK(rgba)) SDL_LockSurface(rgba);
+    } else if (SDL_MUSTLOCK(src)) {
+        SDL_LockSurface(src);
+    }
+
+    for (i = 0; i < 96; i++) {
+        int x0 = (i % 16) * cellStrideX;
+        int y0 = (i / 16) * cellStrideY;
+        for (row = 0; row < fontHeight; row++) {
+            uint8 bits = 0;
+            for (col = 0; col < fontWidth; col++) {
+                int lit = 0;
+                if (rgba) {
+                    const uint8 *px = (const uint8 *)rgba->pixels + (size_t)(y0 + row) * rgba->pitch + (x0 + col) * 4;
+                    lit = px[3] != 0 && (px[0] || px[1] || px[2]);
+                } else {
+                    const uint8 *px = (const uint8 *)src->pixels + (size_t)(y0 + row) * src->pitch + (x0 + col);
+                    lit = *px != 0;
+                }
+                if (lit) bits |= (uint8)(0x80u >> col);
+            }
+            newBitmap[(i * fontHeight) + row] = bits;
+        }
+    }
+
+    if (rgba) {
+        if (SDL_MUSTLOCK(rgba)) SDL_UnlockSurface(rgba);
+        SDL_DestroySurface(rgba);
+    } else if (SDL_MUSTLOCK(src)) {
+        SDL_UnlockSurface(src);
+    }
+    SDL_DestroySurface(src);
+
+    compareReplacementFontWithBuiltin(fontIdx, newBitmap, newWidths, fontHeight, fontWidth, replacementPath);
+    SDL_free(g_fontReplacementBitmaps[fontIdx]);
+    SDL_free(g_fontReplacementWidths[fontIdx]);
+    g_fontReplacementBitmaps[fontIdx] = newBitmap;
+    g_fontReplacementWidths[fontIdx] = newWidths;
+    g_fontBitmapPtrs[fontIdx] = newBitmap;
+    g_fontWidthTables[fontIdx] = newWidths;
+    g_fontHeightsArr[fontIdx] = (uint8)fontHeight;
+    g_fontMaxWidths[fontIdx] = (uint8)fontWidth;
+    g_fontBitmapRowSize[fontIdx] = (uint8)fontHeight;
+
+    LogInfo(("asset replacement: loaded font %u from PNG atlas %s", (unsigned)fontIdx, replacementPath));
+    return 1;
+}
+
+static void tryLoadReplacementFont(uint16 fontIdx) {
+    char legacyFontName[32];
+    char replacementPath[512];
+    char pngReplacementPath[512];
+    int hasPngReplacement;
+    FILE *fp;
+    char line[256];
+    uint8 rows[96][32];
+    uint8 widths[96];
+    uint8 seen[96];
+    int current = -1;
+    int inBitmap = 0;
+    int bitmapRow = 0;
+    int fontHeight = -1;
+    int fontWidth = -1;
+    int seenCount = 0;
+    uint8 *newBitmap;
+    uint8 *newWidths;
+    int i, row;
+
+    if (fontIdx >= 8 || g_fontReplacementTried[fontIdx]) return;
+    g_fontReplacementTried[fontIdx] = 1;
+
+    snprintf(legacyFontName, sizeof(legacyFontName), "font_%u", (unsigned)fontIdx);
+    hasPngReplacement = findReplacementAssetPath(legacyFontName, ".png", pngReplacementPath, sizeof(pngReplacementPath));
+    if (!findReplacementAssetPath(legacyFontName, ".bdf", replacementPath, sizeof(replacementPath))) {
+        if (hasPngReplacement) {
+            (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
+        }
+        return;
+    }
+
+    fp = fopen(replacementPath, "rb");
+    if (!fp) {
+        if (hasPngReplacement) {
+            LogWarn(("asset replacement: failed to open BDF font %u at %s; trying PNG atlas %s", (unsigned)fontIdx, replacementPath, pngReplacementPath));
+            (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
+        }
+        return;
+    }
+    memset(rows, 0, sizeof(rows));
+    memset(widths, 0, sizeof(widths));
+    memset(seen, 0, sizeof(seen));
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        int valueA, valueB;
+        if (sscanf(line, "ENCODING %d", &valueA) == 1) {
+            current = (valueA >= 0x20 && valueA < 0x80) ? valueA - 0x20 : -1;
+            bitmapRow = 0;
+            inBitmap = 0;
+            continue;
+        }
+        if (current >= 0 && sscanf(line, "DWIDTH %d", &valueA) == 1) {
+            widths[current] = (uint8)((valueA < 0) ? 0 : (valueA > 255 ? 255 : valueA));
+            continue;
+        }
+        if (current >= 0 && sscanf(line, "BBX %d %d", &valueA, &valueB) == 2) {
+            if (valueA <= 0 || valueA > 8 || valueB <= 0 || valueB > 32) {
+                current = -1;
+                continue;
+            }
+            if (fontWidth < 0) fontWidth = valueA;
+            if (fontHeight < 0) fontHeight = valueB;
+            if (fontWidth != valueA || fontHeight != valueB) {
+                current = -1;
+            }
+            continue;
+        }
+        if (current >= 0 && strncmp(line, "BITMAP", 6) == 0) {
+            inBitmap = 1;
+            bitmapRow = 0;
+            continue;
+        }
+        if (current >= 0 && inBitmap && strncmp(line, "ENDCHAR", 7) == 0) {
+            if (fontHeight > 0 && bitmapRow == fontHeight && !seen[current]) {
+                seen[current] = 1;
+                seenCount++;
+            }
+            inBitmap = 0;
+            current = -1;
+            continue;
+        }
+        if (current >= 0 && inBitmap && fontHeight > 0 && bitmapRow < fontHeight) {
+            int byteValue = parseBdfHexByte(line);
+            if (byteValue >= 0) {
+                rows[current][bitmapRow++] = (uint8)byteValue;
+            }
+        }
+    }
+    fclose(fp);
+
+    if (fontHeight <= 0 || fontWidth <= 0 || seenCount != 96) {
+        LogWarn(("asset replacement: rejected BDF font %u at %s; expected 96 complete glyphs", (unsigned)fontIdx, replacementPath));
+        if (hasPngReplacement) {
+            (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
+        }
+        return;
+    }
+    for (i = 0; i < 96; i++) {
+        if (widths[i] == 0) {
+            LogWarn(("asset replacement: rejected BDF font %u at %s; glyph 0x%02x has invalid advance width 0", (unsigned)fontIdx, replacementPath, i + 0x20));
+            if (hasPngReplacement) {
+                (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
+            }
+            return;
+        }
+    }
+
+    newBitmap = (uint8 *)SDL_malloc((size_t)96 * (size_t)fontHeight);
+    newWidths = (uint8 *)SDL_malloc(96);
+    if (!newBitmap || !newWidths) {
+        SDL_free(newBitmap);
+        SDL_free(newWidths);
+        if (hasPngReplacement) {
+            LogWarn(("asset replacement: failed to allocate BDF font %u from %s; trying PNG atlas %s", (unsigned)fontIdx, replacementPath, pngReplacementPath));
+            (void)loadReplacementFontPng(fontIdx, pngReplacementPath);
+        }
+        return;
+    }
+
+    for (i = 0; i < 96; i++) {
+        newWidths[i] = widths[i];
+        for (row = 0; row < fontHeight; row++) {
+            newBitmap[(i * fontHeight) + row] = rows[i][row];
+        }
+    }
+
+    compareReplacementFontWithBuiltin(fontIdx, newBitmap, newWidths, fontHeight, fontWidth, replacementPath);
+    SDL_free(g_fontReplacementBitmaps[fontIdx]);
+    SDL_free(g_fontReplacementWidths[fontIdx]);
+    g_fontReplacementBitmaps[fontIdx] = newBitmap;
+    g_fontReplacementWidths[fontIdx] = newWidths;
+    g_fontBitmapPtrs[fontIdx] = newBitmap;
+    g_fontWidthTables[fontIdx] = newWidths;
+    g_fontHeightsArr[fontIdx] = (uint8)fontHeight;
+    g_fontMaxWidths[fontIdx] = (uint8)fontWidth;
+    g_fontBitmapRowSize[fontIdx] = (uint8)fontHeight;
+
+    LogInfo((
+        "asset replacement: loaded font %u from BDF %s",
+        (unsigned)fontIdx,
+        replacementPath
+    ));
+}
+
+#ifdef DEBUG
+static int copyFontTables(uint16 fontIdx, const uint8 *bitmap, const uint8 *widths,
+                          int height, int maxWidth, uint8 *bitmapOut, size_t bitmapOutSize,
+                          uint8 *widthsOut, size_t widthsOutSize,
+                          int *heightOut, int *maxWidthOut) {
+    size_t bitmapSize;
+    if (!bitmap || !widths || height <= 0 || maxWidth <= 0) return 0;
+    bitmapSize = (size_t)96 * (size_t)height;
+    (void)fontIdx;
+    if (bitmapOut && bitmapOutSize < bitmapSize) return 0;
+    if (widthsOut && widthsOutSize < 96u) return 0;
+    if (bitmapOut) memcpy(bitmapOut, bitmap, bitmapSize);
+    if (widthsOut) memcpy(widthsOut, widths, 96);
+    if (heightOut) *heightOut = height;
+    if (maxWidthOut) *maxWidthOut = maxWidth;
+    return 1;
+}
+
+int gfx_testCopyEffectiveFont(uint16 fontIdx, uint8 *bitmapOut, size_t bitmapOutSize,
+                              uint8 *widthsOut, size_t widthsOutSize,
+                              int *heightOut, int *maxWidthOut) {
+    if (fontIdx >= 8) return 0;
+    tryLoadReplacementFont(fontIdx);
+    return copyFontTables(fontIdx, g_fontBitmapPtrs[fontIdx], g_fontWidthTables[fontIdx],
+                          g_fontBitmapRowSize[fontIdx], g_fontMaxWidths[fontIdx],
+                          bitmapOut, bitmapOutSize, widthsOut, widthsOutSize,
+                          heightOut, maxWidthOut);
+}
+
+int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut, size_t bitmapOutSize,
+                            uint8 *widthsOut, size_t widthsOutSize,
+                            int *heightOut, int *maxWidthOut) {
+    if (fontIdx >= 8) return 0;
+    return copyFontTables(fontIdx, g_fontBitmapPtrs[fontIdx], g_fontWidthTables[fontIdx],
+                          g_fontBitmapRowSize[fontIdx], g_fontMaxWidths[fontIdx],
+                          bitmapOut, bitmapOutSize, widthsOut, widthsOutSize,
+                          heightOut, maxWidthOut);
+}
+#endif
 
 /* ---- Shared glyph engine (slots 0x01-0x06) ----
  * MGRAPHIC has one core blitter (0x04 @0x4ab) that the string slots fall into
@@ -634,6 +998,7 @@ static void drawStringCore(int16 *params, const char *string,
     y = (int)params[5];
     color = (int)params[2];
     fontIdx = (uint16)params[6] & 7;
+    tryLoadReplacementFont(fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -1211,6 +1576,10 @@ int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
     if (fontIdx >= 8) return 8;
     /* Chars >= 0x80 are inline color escapes - no glyph, no width */
     if (ch >= 0x80) return 0;
+    /* Font replacements are authoritative for both drawing and layout. Load
+     * BDF/PNG before width lookup so centred/right-aligned text uses the same
+     * metrics the glyph renderer will use later. */
+    tryLoadReplacementFont(fontIdx);
     wt = g_fontWidthTables[fontIdx];
     if (!wt || ch < 0x20) return 8;
     return wt[ch - 0x20];

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -57,6 +57,7 @@ static void cleanupReplacementFonts(void);
 static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL);
 static void invalidateTtfTextOverlayRecords(void);
 static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint);
+static int replacementTtfStringAdvance(uint16 fontIdx, const char *text);
 #endif
 
 /* Bring up the SDL window and renderer. The 320x200 logical surface is stretched
@@ -801,27 +802,8 @@ static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
 }
 
 static int ttfTextOverlayRecordWidth(const TtfTextOverlayRecord *record) {
-    int charIdx;
-    int drawnChars;
-    int width = 0;
     if (!record || !record->text) return 0;
-    for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
-        uint32 codepoint;
-        uint8 ch = (uint8)record->text[charIdx];
-        int byteCount = 1;
-        if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
-            codepoint = ch;
-            byteCount = 1;
-        }
-        if (byteCount == 1 && (ch & 0x80)) {
-            charIdx++;
-            continue;
-        }
-        width += replacementTtfAdvance(record->fontIdx, codepoint);
-        charIdx += byteCount;
-        drawnChars++;
-    }
-    return width;
+    return replacementTtfStringAdvance(record->fontIdx, record->text);
 }
 
 static void removeTtfTextOverlayRecord(int index) {
@@ -1006,21 +988,90 @@ static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
     return advance > 0 ? advance : 1;
 }
 
-static float replacementTtfAdvanceScaled(uint16 fontIdx, uint32 codepoint, float scaleX, float scaleY) {
+static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
+                                      float targetScaleX, float targetScaleY,
+                                      float *layoutScaleX, float *layoutScaleY) {
     FT_Face face;
-    int advance;
-    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 8.0f * scaleX;
-    if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
-        return (float)g_fontWidthTables[fontIdx][codepoint - 0x20] * scaleX;
-    }
-    if (codepoint >= 0x80) return (float)replacementTtfUnicodeAdvance(fontIdx) * scaleX;
+    const uint8 *legacyWidths;
+    int ch;
+    int legacyAdvance = 0;
+    int ftAdvance = 0;
+    float targetHeight;
+    float ftHeight;
+
+    *layoutScaleX = 1.0f;
+    *layoutScaleY = 1.0f;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return;
     face = g_fontReplacementTtfFaces[fontIdx];
-    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)SDL_max(1, (int)((float)g_fontHeightsArr[fontIdx] * scaleY + 0.5f))) != 0) {
-        return 8.0f * scaleX;
+    legacyWidths = g_fontWidthTables[fontIdx];
+    if (!legacyWidths) return;
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)SDL_max(1, pixelSize)) != 0) return;
+
+    /* Calibrate the scalable face once per rendered font size against the whole
+     * printable ASCII width table. This keeps all TTF/OTF lines for a font at a
+     * single consistent scale while still matching the old menu footprint. */
+    for (ch = 0x20; ch < 0x80; ch++) {
+        legacyAdvance += legacyWidths[ch - 0x20];
+        if (FT_Load_Glyph(face, FT_Get_Char_Index(face, (FT_ULong)ch), FT_LOAD_DEFAULT) == 0) {
+            ftAdvance += (int)(face->glyph->advance.x >> 6);
+        }
     }
-    if (FT_Load_Char(face, (FT_ULong)codepoint, FT_LOAD_DEFAULT) != 0) return 8.0f * scaleX;
-    advance = (int)((face->glyph->advance.x + 32) >> 6);
-    return (float)(advance > 0 ? advance : 1);
+    if (ftAdvance > 0) {
+        *layoutScaleX = ((float)legacyAdvance * targetScaleX) / (float)ftAdvance;
+    }
+
+    targetHeight = (float)g_fontHeightsArr[fontIdx] * targetScaleY;
+    ftHeight = face->size ? (float)(face->size->metrics.height >> 6) : (float)pixelSize;
+    if (ftHeight > 0.0f) {
+        *layoutScaleY = targetHeight / ftHeight;
+    }
+}
+
+static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
+    FT_Face face;
+    FT_UInt previousGlyphIndex = 0;
+    float layoutScaleX;
+    float layoutScaleY;
+    float x = 0.0f;
+    int charIdx;
+    int drawnChars;
+
+    if (!text || fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    face = g_fontReplacementTtfFaces[fontIdx];
+    replacementTtfLayoutScale(fontIdx, replacementTtfPixelSize(fontIdx), 1.0f, 1.0f,
+                              &layoutScaleX, &layoutScaleY);
+    (void)layoutScaleY;
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return 0;
+
+    for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)text[charIdx];
+        int byteCount = 1;
+        FT_UInt glyphIndex;
+        FT_Vector kerning;
+
+        if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            charIdx++;
+            continue;
+        }
+        glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
+        if (previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+            if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
+                x += (float)(kerning.x >> 6) * layoutScaleX;
+            }
+        }
+        if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT) == 0) {
+            x += (float)(face->glyph->advance.x >> 6) * layoutScaleX;
+        }
+        previousGlyphIndex = glyphIndex;
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    return (int)(x + 0.5f);
 }
 
 static uint8 blendReplacementTtfPixel(uint8 dstColor, uint8 srcColor, uint8 coverage) {
@@ -1167,7 +1218,6 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
     TtfTextOverlayRecord *record;
     int charIdx;
     int drawnChars;
-    int x;
     int color;
     uint16 fontIdx;
     int i;
@@ -1221,7 +1271,6 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
     record->clipT = clipT;
     record->clipB = clipB;
 
-    x = record->x;
     color = record->color;
     for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < 256;) {
         uint32 codepoint;
@@ -1236,11 +1285,10 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
             charIdx++;
             continue;
         }
-        x += replacementTtfAdvance(fontIdx, codepoint);
         charIdx += byteCount;
         drawnChars++;
     }
-    params[4] = (int16)x;
+    params[4] = (int16)(record->x + replacementTtfStringAdvance(fontIdx, string));
     params[2] = (int16)color;
     return 1;
 }
@@ -1305,12 +1353,16 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
     float cellY;
     float cellHeight;
     float baseline;
+    float layoutScaleX;
+    float layoutScaleY;
     SDL_FRect clip;
 
     if (!record || !record->text || record->fontIdx >= 8 || !g_fontReplacementTtfFaces[record->fontIdx]) return;
     face = g_fontReplacementTtfFaces[record->fontIdx];
     pixelSize = SDL_max(1, (int)((float)g_fontHeightsArr[record->fontIdx] * m->scaleY + 0.5f));
     if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)pixelSize) != 0) return;
+    replacementTtfLayoutScale(record->fontIdx, pixelSize, m->scaleX, m->scaleY,
+                              &layoutScaleX, &layoutScaleY);
     pal = gfx_getPalette();
     if (!pal) return;
     c = pal->colors[record->color & 0xff];
@@ -1333,11 +1385,6 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
         FT_Bitmap *bitmap;
         float gx;
         float gy;
-        float targetAdvance;
-        float inkWidth;
-        float inkHeight;
-        float pixelScaleX;
-        float pixelScaleY;
 
         if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
             codepoint = ch;
@@ -1345,48 +1392,27 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
         }
         if (byteCount == 1 && (ch & 0x80)) {
             c = pal->colors[ch & 0x7f];
-            previousGlyphIndex = 0;
             charIdx++;
             continue;
         }
         glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
-        if ((codepoint < 0x20 || codepoint >= 0x80) && previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+        if (previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
             if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
-                x += (float)(kerning.x >> 6);
+                x += (float)(kerning.x >> 6) * layoutScaleX;
             }
         }
         if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_RENDER) == 0) {
             glyph = face->glyph;
             bitmap = &glyph->bitmap;
-            targetAdvance = replacementTtfAdvanceScaled(record->fontIdx, codepoint, m->scaleX, m->scaleY);
-            inkWidth = (float)bitmap->width;
-            inkHeight = (float)bitmap->rows;
-            pixelScaleX = 1.0f;
-            pixelScaleY = 1.0f;
-            gx = x + (float)glyph->bitmap_left;
-            if (inkWidth > 0.0f && targetAdvance > 0.0f) {
-                /* Replacement TTF glyphs must stay inside the original fixed
-                 * bitmap-font cell. This is required for Unicode letters too:
-                 * Cyrillic glyphs from common TTF faces are much wider/taller
-                 * than the DOS 8-pixel menu font and otherwise land outside the
-                 * visible row or collide with following text. */
-                pixelScaleX = targetAdvance / inkWidth;
-                if (pixelScaleX > 1.0f) pixelScaleX = 1.0f;
-                gx = x + (targetAdvance - inkWidth * pixelScaleX) * 0.5f;
-            }
-            if (inkHeight > 0.0f && cellHeight > 0.0f) {
-                pixelScaleY = cellHeight / inkHeight;
-                if (pixelScaleY > 1.0f) pixelScaleY = 1.0f;
-            }
-            gy = baseline - (float)glyph->bitmap_top * pixelScaleY;
+            gx = x + (float)glyph->bitmap_left * layoutScaleX;
+            gy = baseline - (float)glyph->bitmap_top * layoutScaleY;
             if (gy < cellY) gy = cellY;
-            /* Do not bottom-clamp descenders: q/g/ф need to hang below the
-             * baseline or the whole glyph is pushed upward relative to x-height
-             * letters. The row-level clip still keeps text inside the viewport. */
-            if (useGL) renderTtfTextOverlayGlyphGL(bitmap, gx, gy, pixelScaleX, pixelScaleY, c.r, c.g, c.b, clip);
-            else renderTtfTextOverlayGlyphSDL(renderer, bitmap, gx, gy, pixelScaleX, pixelScaleY, c.r, c.g, c.b, clip);
+            if (useGL) renderTtfTextOverlayGlyphGL(bitmap, gx, gy, layoutScaleX, layoutScaleY, c.r, c.g, c.b, clip);
+            else renderTtfTextOverlayGlyphSDL(renderer, bitmap, gx, gy, layoutScaleX, layoutScaleY, c.r, c.g, c.b, clip);
         }
-        x += replacementTtfAdvanceScaled(record->fontIdx, codepoint, m->scaleX, m->scaleY);
+        if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT) == 0) {
+            x += (float)(face->glyph->advance.x >> 6) * layoutScaleX;
+        }
         previousGlyphIndex = glyphIndex;
         charIdx += byteCount;
         drawnChars++;
@@ -2566,6 +2592,37 @@ int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
     wt = g_fontWidthTables[fontIdx];
     if (!wt || codepoint < 0x20) return 8;
     return wt[codepoint - 0x20];
+}
+
+int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx) {
+    int width = 0;
+    int charIdx;
+    int drawnChars;
+    if (!text) return 0;
+    if (fontIdx >= 8) return 0;
+    tryLoadReplacementFont(fontIdx);
+#ifdef F15_HAVE_FREETYPE
+    if (g_fontReplacementTtfFaces[fontIdx]) {
+        return replacementTtfStringAdvance(fontIdx, text);
+    }
+#endif
+    for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)text[charIdx];
+        int byteCount = 1;
+        if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            charIdx++;
+            continue;
+        }
+        width += gfx_getGlyphAdvance(codepoint, fontIdx);
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    return width;
 }
 
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -32,6 +32,15 @@
  * in gfx.h. */
 #define INITIAL_WINDOW_WIDTH 1280
 #define INITIAL_WINDOW_HEIGHT 800
+#define VGA_PAGE_HEIGHT 200
+
+/* The 3D HUD draws missile ammo at y=190 with the original bitmap font. Runtime
+ * TTF glyphs can extend below the old bitmap cell, so bottom-HUD overlay records
+ * need a small clip relaxation while still staying inside the native 320x200
+ * page. Keep this named because the threshold is a DOS-screen coordinate, not a
+ * renderer pixel value. */
+#define HUD_BOTTOM_TTF_CLIP_Y 188
+#define HUD_BOTTOM_TTF_EXTRA_LINES 2.0f
 
 /* Fixed fire colour-cycle rate, independent of render frame rate. The original
  * stepped the cycle once per rendered frame; we pin it at 15 Hz so the pulse
@@ -663,6 +672,7 @@ typedef struct TtfTextOverlayRecord {
 } TtfTextOverlayRecord;
 static TtfTextOverlayRecord g_ttfTextOverlayRecords[512];
 static int g_ttfTextOverlayCount;
+static int g_ttfTextOverlayGeneration;
 #endif
 
 typedef struct ReplacementFontGlyph {
@@ -804,6 +814,35 @@ static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
 static int ttfTextOverlayRecordWidth(const TtfTextOverlayRecord *record) {
     if (!record || !record->text) return 0;
     return replacementTtfStringAdvance(record->fontIdx, record->text);
+}
+
+static int ttfTextOverlayRecordsOverlap(const TtfTextOverlayRecord *a,
+                                        int x, int y, int width, int height,
+                                        int margin) {
+    int ax1, ay1, ax2, ay2;
+    int bx1, by1, bx2, by2;
+    if (!a || width <= 0 || height <= 0) return 0;
+    ax1 = a->x - margin;
+    ay1 = a->y - margin;
+    ax2 = a->x + ttfTextOverlayRecordWidth(a) + margin - 1;
+    ay2 = a->y + g_fontHeightsArr[a->fontIdx] + margin - 1;
+    bx1 = x - margin;
+    by1 = y - margin;
+    bx2 = x + width + margin - 1;
+    by2 = y + height + margin - 1;
+    return ax2 >= bx1 && ax1 <= bx2 && ay2 >= by1 && ay1 <= by2;
+}
+
+static int ttfTextOverlaySameDynamicRow(const TtfTextOverlayRecord *a,
+                                        int x, int y, int width, int height) {
+    int dy;
+    if (!a) return 0;
+    dy = a->y - y;
+    if (dy < 0) dy = -dy;
+    /* Only treat one-pixel HUD jitter as a replacement. Menu rows are retained
+     * text and can share wide clip windows; deleting by broad overlap there can
+     * remove neighboring labels such as the TODAY'S MISSION header. */
+    return dy <= 1 && ttfTextOverlayRecordsOverlap(a, x, y, width, height, 1);
 }
 
 static void removeTtfTextOverlayRecord(int index) {
@@ -1037,6 +1076,26 @@ static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
     int drawnChars;
 
     if (!text || fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    if (fontIdx == 0) {
+        int width = 0;
+        for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+            uint32 codepoint;
+            uint8 ch = (uint8)text[charIdx];
+            int byteCount = 1;
+            if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
+                codepoint = ch;
+                byteCount = 1;
+            }
+            if (byteCount == 1 && (ch & 0x80)) {
+                charIdx++;
+                continue;
+            }
+            width += replacementTtfAdvance(fontIdx, codepoint);
+            charIdx += byteCount;
+            drawnChars++;
+        }
+        return width;
+    }
     face = g_fontReplacementTtfFaces[fontIdx];
     replacementTtfLayoutScale(fontIdx, replacementTtfPixelSize(fontIdx), 1.0f, 1.0f,
                               &layoutScaleX, &layoutScaleY);
@@ -1221,38 +1280,57 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
     int color;
     uint16 fontIdx;
     int i;
+    int newX;
+    int newY;
+    int newWidth;
+    int newHeight;
+    int recordIndex;
 
     if (!params || !string) return 0;
     fontIdx = (uint16)params[6] & 7;
     if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    newX = (int)params[4];
+    newY = (int)params[5];
+    newWidth = replacementTtfStringAdvance(fontIdx, string);
+    newHeight = g_fontHeightsArr[fontIdx];
 
-    record = NULL;
-    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+    recordIndex = -1;
+    for (i = g_ttfTextOverlayCount - 1; i >= 0; i--) {
         TtfTextOverlayRecord *candidate = &g_ttfTextOverlayRecords[i];
-        if (candidate->x == (int)params[4] &&
-            candidate->y == (int)params[5] &&
-            candidate->fontIdx == fontIdx &&
-            candidate->clipL == clipL &&
-            candidate->clipR == clipR &&
-            candidate->clipT == clipT &&
-            candidate->clipB == clipB) {
-            record = candidate;
-            break;
+        if (candidate->fontIdx == fontIdx &&
+            candidate->clipL == clipL && candidate->clipR == clipR &&
+            candidate->clipT == clipT && candidate->clipB == clipB &&
+            candidate->x == newX && candidate->y == newY) {
+            recordIndex = i;
+            continue;
+        }
+        /* Dynamic HUD values are often cleared/redrawn with a one-pixel anchor
+         * shift as their width changes. Exact-position keys leave the old TTF
+         * overlay on screen, because it was never baked into the page being
+         * cleared. Treat near/overlapping same-font text in the same clip window
+         * as a replacement candidate. */
+        if (candidate->fontIdx == fontIdx &&
+            candidate->clipL == clipL && candidate->clipR == clipR &&
+            candidate->clipT == clipT && candidate->clipB == clipB &&
+            ttfTextOverlaySameDynamicRow(candidate, newX, newY, newWidth, newHeight)) {
+            removeTtfTextOverlayRecord(i);
+            if (recordIndex > i) recordIndex--;
         }
     }
 
     if (string[0] == '\0') {
-        if (record) {
-            removeTtfTextOverlayRecord((int)(record - g_ttfTextOverlayRecords));
+        if (recordIndex >= 0) {
+            removeTtfTextOverlayRecord(recordIndex);
         }
         return 1;
     }
 
-    if (!record) {
+    if (recordIndex < 0) {
         if (g_ttfTextOverlayCount >= (int)(sizeof(g_ttfTextOverlayRecords) / sizeof(g_ttfTextOverlayRecords[0]))) return 0;
         record = &g_ttfTextOverlayRecords[g_ttfTextOverlayCount++];
         memset(record, 0, sizeof(*record));
     } else {
+        record = &g_ttfTextOverlayRecords[recordIndex];
         SDL_free(record->text);
         record->text = NULL;
     }
@@ -1262,8 +1340,8 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
         record->x = 0;
         return 0;
     }
-    record->x = (int)params[4];
-    record->y = (int)params[5];
+    record->x = newX;
+    record->y = newY;
     record->color = (int)params[2];
     record->fontIdx = fontIdx;
     record->clipL = clipL;
@@ -1288,7 +1366,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
         charIdx += byteCount;
         drawnChars++;
     }
-    params[4] = (int16)(record->x + replacementTtfStringAdvance(fontIdx, string));
+    params[4] = (int16)(record->x + newWidth);
     params[2] = (int16)color;
     return 1;
 }
@@ -1353,6 +1431,7 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
     float cellY;
     float cellHeight;
     float baseline;
+    float ascender;
     float layoutScaleX;
     float layoutScaleY;
     SDL_FRect clip;
@@ -1369,11 +1448,22 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
     x = (float)m->offX + (float)record->x * m->scaleX;
     cellY = (float)m->offY + (float)record->y * m->scaleY;
     cellHeight = (float)g_fontHeightsArr[record->fontIdx] * m->scaleY;
-    baseline = cellY + cellHeight * 0.88f;
+    ascender = face->size ? (float)(face->size->metrics.ascender >> 6) * layoutScaleY : cellHeight;
+    baseline = cellY + ascender;
     clip.x = (float)m->offX + (float)record->clipL * m->scaleX;
     clip.y = (float)m->offY + (float)record->clipT * m->scaleY;
     clip.w = (float)(record->clipR - record->clipL + 1) * m->scaleX;
     clip.h = (float)(record->clipB - record->clipT + 1) * m->scaleY;
+    if (record->fontIdx == 0 && record->y >= HUD_BOTTOM_TTF_CLIP_Y) {
+        float maxBottom = (float)m->offY + (float)VGA_PAGE_HEIGHT * m->scaleY;
+        float wantedBottom =
+            ((float)record->y + (float)g_fontHeightsArr[record->fontIdx] +
+             HUD_BOTTOM_TTF_EXTRA_LINES) *
+                m->scaleY +
+            (float)m->offY;
+        if (wantedBottom > clip.y + clip.h) clip.h = wantedBottom - clip.y;
+        if (clip.y + clip.h > maxBottom) clip.h = maxBottom - clip.y;
+    }
 
     for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
         uint32 codepoint;
@@ -1385,6 +1475,8 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
         FT_Bitmap *bitmap;
         float gx;
         float gy;
+        float glyphScaleX;
+        float glyphScaleY;
 
         if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
             codepoint = ch;
@@ -1404,13 +1496,38 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
         if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_RENDER) == 0) {
             glyph = face->glyph;
             bitmap = &glyph->bitmap;
-            gx = x + (float)glyph->bitmap_left * layoutScaleX;
-            gy = baseline - (float)glyph->bitmap_top * layoutScaleY;
+            glyphScaleX = layoutScaleX;
+            glyphScaleY = layoutScaleY;
+            if (record->fontIdx == 0) {
+                float targetAdvance = (float)replacementTtfAdvance(record->fontIdx, codepoint) * m->scaleX;
+                /* HUD font_0 is position-sensitive: original glyph cells are
+                 * anchored at the exact (x,y) page coordinate. FreeType natural
+                 * bearings make speed/altitude labels drift by pixels compared
+                 * with the bitmap HUD. Keep high-resolution rasterization, but fit
+                 * each glyph into the old cell width so digits/letters do not
+                 * collide or overflow the tiny legacy clear rectangles. */
+                if (bitmap->width > 0 && targetAdvance > 1.0f) {
+                    float fitScale = (targetAdvance * 0.82f) / (float)bitmap->width;
+                    if (fitScale > 0.0f && fitScale < glyphScaleX) glyphScaleX = fitScale;
+                }
+                gx = x;
+                if (glyph->bitmap_top > 0 &&
+                    (float)bitmap->rows * glyphScaleY < cellHeight * 0.8f) {
+                    gy = baseline - (float)glyph->bitmap_top * glyphScaleY;
+                } else {
+                    gy = cellY;
+                }
+            } else {
+                gx = x + (float)glyph->bitmap_left * layoutScaleX;
+                gy = baseline - (float)glyph->bitmap_top * layoutScaleY;
+            }
             if (gy < cellY) gy = cellY;
-            if (useGL) renderTtfTextOverlayGlyphGL(bitmap, gx, gy, layoutScaleX, layoutScaleY, c.r, c.g, c.b, clip);
-            else renderTtfTextOverlayGlyphSDL(renderer, bitmap, gx, gy, layoutScaleX, layoutScaleY, c.r, c.g, c.b, clip);
+            if (useGL) renderTtfTextOverlayGlyphGL(bitmap, gx, gy, glyphScaleX, glyphScaleY, c.r, c.g, c.b, clip);
+            else renderTtfTextOverlayGlyphSDL(renderer, bitmap, gx, gy, glyphScaleX, glyphScaleY, c.r, c.g, c.b, clip);
         }
-        if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT) == 0) {
+        if (record->fontIdx == 0) {
+            x += (float)replacementTtfAdvance(record->fontIdx, codepoint) * m->scaleX;
+        } else if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT) == 0) {
             x += (float)(face->glyph->advance.x >> 6) * layoutScaleX;
         }
         previousGlyphIndex = glyphIndex;
@@ -1924,9 +2041,11 @@ static void drawStringCore(int16 *params, const char *string,
     bitmaps = g_fontBitmapPtrs[fontIdx];
     widthTab = g_fontWidthTables[fontIdx];
 
-    /* On a GL flight frame, submit each lit glyph pixel as a native point (drawn
-     * over the composited frame at window resolution) instead of baking it into the
-     * shared 320x200 page. Software (retained) keeps writing the page directly. */
+    /* On a GL flight frame, legacy bitmap glyphs submit lit pixels as vector
+     * points over the composited frame. Runtime TTF/OTF replacements are different:
+     * they must be recorded and rasterized by the present-time overlay at the final
+     * window size. Rendering them here would create a tiny antialiased 320x200-page
+     * glyph that then gets enlarged with the game frame. */
     submit = r2d_vectorActive();
 
     /* The page is backed by an SDL surface (same buffer the pic decoder and
@@ -1939,7 +2058,7 @@ static void drawStringCore(int16 *params, const char *string,
     surfH = surf->h;
 
 #ifdef F15_HAVE_FREETYPE
-    if (!submit && fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
+    if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
         (void)recordTtfTextOverlayAndAdvance(params, string, clipL, clipR, clipT, clipB);
         return;
     }

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -67,6 +67,13 @@ int gfx_paletteGeneration(void);
  * software present's shake shift. */
 int gfx_getShakeOffset(void);
 
+/* Draw recorded runtime TTF/OTF text after the legacy page has been scaled to
+ * the window. This keeps text positions in original 320x200 coordinates while
+ * rasterizing glyphs at native/window resolution. */
+void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH);
+void gfx_clearTtfTextOverlay(void);
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2);
+
 #ifdef DEBUG
 /* Test-time asset validation seam: load any BDF/PNG replacement through the
  * same font path used by gfx_setFont/gfx_drawString, then copy the effective

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -59,12 +59,25 @@ struct SDL_Surface *gfx_getSpriteSurface(int handle);
 struct SDL_Palette;
 struct SDL_Palette *gfx_getPalette(void);
 void gfx_paletteRGB(int idx, uint8 *r, uint8 *g, uint8 *b);
+int gfx_nearestPaletteIndexRgb8(uint8 r, uint8 g, uint8 b);
 int gfx_paletteGeneration(void);
 
 /* Current explosion screen-shake (0-3 virtual px, set by gfx_dacCycle). The GL
  * backend reads it mid-frame to offset the immediate 2D overlay, matching the
  * software present's shake shift. */
 int gfx_getShakeOffset(void);
+
+#ifdef DEBUG
+/* Test-time asset validation seam: load any BDF/PNG replacement through the
+ * same font path used by gfx_setFont/gfx_drawString, then copy the effective
+ * glyph rows and advance widths for old-vs-modern comparison. */
+int gfx_testCopyEffectiveFont(uint16 fontIdx, uint8 *bitmapOut, size_t bitmapOutSize,
+                              uint8 *widthsOut, size_t widthsOutSize,
+                              int *heightOut, int *maxWidthOut);
+int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut, size_t bitmapOutSize,
+                            uint8 *widthsOut, size_t widthsOutSize,
+                            int *heightOut, int *maxWidthOut);
+#endif
 
 /*
  * Reference structures documenting how the overlay accesses caller data.

--- a/src/input.c
+++ b/src/input.c
@@ -62,6 +62,10 @@ bool input_preferGamepad(void) { return g_lastWasGamepad && joy_connected(); }
 static uint16 keyRing[KEY_RING];
 static int ringHead = 0, ringTail = 0;
 
+#define TEXT_RING 32
+static char textRing[TEXT_RING][8];
+static int textRingHead = 0, textRingTail = 0;
+
 static void ringPush(uint16 word) {
     int next = (ringTail + 1) % KEY_RING;
     if (next == ringHead) return; /* full: drop, as the BIOS buffer would */
@@ -69,8 +73,19 @@ static void ringPush(uint16 word) {
     ringTail = next;
 }
 
+static void textRingPushUtf8(const char *text, int len) {
+    int next;
+    if (!text || len <= 0 || len >= (int)sizeof(textRing[0])) return;
+    next = (textRingTail + 1) % TEXT_RING;
+    if (next == textRingHead) return;
+    SDL_memcpy(textRing[textRingTail], text, (size_t)len);
+    textRing[textRingTail][len] = '\0';
+    textRingTail = next;
+}
+
 void input_ringReset(void) {
     ringHead = ringTail = 0;
+    textRingHead = textRingTail = 0;
     g_joyRawX = 0x80;
     g_joyRawY = 0x80;
 }
@@ -90,6 +105,28 @@ uint16 input_readKey(void) {
     word = keyRing[ringHead];
     ringHead = (ringHead + 1) % KEY_RING;
     return word;
+}
+
+int input_readMenuTextUtf8(char *out, int outSize) {
+    int len;
+    input_pumpEvents();
+    if (!out || outSize <= 0 || textRingHead == textRingTail) return 0;
+    len = (int)SDL_strlen(textRing[textRingHead]);
+    if (len >= outSize) len = outSize - 1;
+    SDL_memcpy(out, textRing[textRingHead], (size_t)len);
+    out[len] = '\0';
+    textRingHead = (textRingHead + 1) % TEXT_RING;
+    return len;
+}
+
+bool input_menuTextWaiting(void) {
+    return textRingHead != textRingTail;
+}
+
+void input_discardNextAsciiKey(uint8 ascii) {
+    if (ringHead != ringTail && (keyRing[ringHead] & 0xff) == ascii) {
+        ringHead = (ringHead + 1) % KEY_RING;
+    }
 }
 
 /* --- keyboard translation --------------------------------------------------
@@ -751,13 +788,26 @@ void input_pumpEvents(void) {
             break;
         case SDL_EVENT_TEXT_INPUT:
             /* Printable characters for menu text entry arrive here already
-             * shifted/localized; queue each ASCII byte in AL (AH = 0). Flight
-             * takes its letters as commands from biosWord instead. */
+             * shifted/localized. The BIOS key ring remains byte-oriented for
+             * legacy menu code; the text ring preserves full UTF-8 characters
+             * for modern text entry such as pilot names. */
             if (g_mode == INPUT_MODE_MENU) {
                 const char *p = ev.text.text;
                 for (; *p; ++p) {
                     unsigned char c = (unsigned char)*p;
-                    if (c >= 0x20 && c < 0x80) ringPush(c);
+                    if (c >= 0x20 && c < 0x80) {
+                        ringPush(c);
+                        textRingPushUtf8(p, 1);
+                    } else if ((c & 0xe0) == 0xc0 && (p[1] & 0xc0) == 0x80) {
+                        textRingPushUtf8(p, 2);
+                        p += 1;
+                    } else if ((c & 0xf0) == 0xe0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80) {
+                        textRingPushUtf8(p, 3);
+                        p += 2;
+                    } else if ((c & 0xf8) == 0xf0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80 && (p[3] & 0xc0) == 0x80) {
+                        textRingPushUtf8(p, 4);
+                        p += 3;
+                    }
                 }
             }
             break;

--- a/src/input.h
+++ b/src/input.h
@@ -40,6 +40,13 @@ void input_ringReset(void);  /* drop any queued keys, recentre stick */
 bool input_keyWaiting(void); /* true when a key word is queued */
 uint16 input_readKey(void);  /* blocking pop: pump + wait, then return */
 
+/* Menu text input queue. Unlike the BIOS-style key ring, this preserves the
+ * UTF-8 bytes SDL_TEXT_INPUT delivers, so text editors can accept Unicode while
+ * old menu navigation keeps using input_readKey(). Returns byte count. */
+int input_readMenuTextUtf8(char *out, int outSize);
+bool input_menuTextWaiting(void);
+void input_discardNextAsciiKey(uint8 ascii);
+
 /* --- window state, set by the pump, for callers that want to react --------- */
 bool input_quitRequested(void); /* SDL_EVENT_QUIT (window close) has been seen */
 bool input_hasFocus(void);      /* window currently has keyboard focus */

--- a/src/r3d.h
+++ b/src/r3d.h
@@ -47,6 +47,8 @@ typedef struct {
  * normal object. */
 typedef struct {
     R3DMesh mesh;
+    int shapeId;                    /* original shape slot, or -1 when unknown */
+    const char *containerLegacyName; /* e.g. current theater .3D3 or 15FLT.3D3 */
     int yaw, pitch, roll;
     int posX, posY, posZ;
     int shadow;

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -3016,8 +3016,14 @@ void r3dgl_present(SDL_Surface *page, int shakeOffset) {
      * frame's immediate HUD/MFD draws); only pure-2D screens (no 3D pass) compose it
      * here, on top of the black-cleared window. */
     if (!s_sceneRendered && !s_pageComposited) composePageBackdrop(page, shakeOffset);
+    SDL_GetWindowSizeInPixels(s_win, &win_w, &win_h);
     if (!s_sceneRendered) {
-        SDL_GetWindowSizeInPixels(s_win, &win_w, &win_h);
+        gfx_renderTtfTextOverlayOpenGL(page->w, page->h, win_w, win_h);
+    }
+    /* Runtime TTF/OTF text is deliberately kept out of the 320x200 page. Draw it
+     * after both pure-2D and live-3D frames so HUD/menu glyphs are rasterized at
+     * final window resolution instead of being baked tiny and scaled up. */
+    if (s_sceneRendered) {
         gfx_renderTtfTextOverlayOpenGL(page->w, page->h, win_w, win_h);
     }
     /* Remember whether THIS present carried a live 3D view. gfx_repaint (window

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -3010,11 +3010,16 @@ static void composePageBackdrop(SDL_Surface *page, int shakeOffset) {
 }
 
 void r3dgl_present(SDL_Surface *page, int shakeOffset) {
+    int win_w = 0, win_h = 0;
     if (!page || !s_active) return;
     /* Flight frames composed the page backdrop at the main-scene anchor (before the
      * frame's immediate HUD/MFD draws); only pure-2D screens (no 3D pass) compose it
      * here, on top of the black-cleared window. */
     if (!s_sceneRendered && !s_pageComposited) composePageBackdrop(page, shakeOffset);
+    if (!s_sceneRendered) {
+        SDL_GetWindowSizeInPixels(s_win, &win_w, &win_h);
+        gfx_renderTtfTextOverlayOpenGL(page->w, page->h, win_w, win_h);
+    }
     /* Remember whether THIS present carried a live 3D view. gfx_repaint (window
      * expose/resize) re-presents only the page — which would blank the GL 3D (it
      * lives in the framebuffer, not the page) — so on a flight frame it must instead

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -28,6 +28,7 @@
 
 #include "r3d.h"
 #include "r3d_gl.h"
+#include "r3d_replacement.h"
 #include "r2d.h"
 #include "r3dmesh.h"
 #include "gfx_impl.h"
@@ -36,8 +37,18 @@
 #include "egdata.h"
 #include "egtypes.h"
 #include "log.h"
+#include "shared/asset_compare.h"
+#include <quickdigest5.hpp>
 
+#include <stdio.h>
 #include <stdlib.h> /* qsort */
+#include <string.h>
+#include <filesystem>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
 
 /* ---- GL context / selection ------------------------------------------- */
 
@@ -195,6 +206,8 @@ static float s_vpW, s_vpH;   /* active 3D viewport size in window pixels (screen
  * original look, the later draw winning at equal depth. */
 typedef struct {
     char *model;
+    int shapeId;
+    const char *containerLegacyName;
     int16 combined[9];
     long camBase, camX, camY; /* camera-space origin axes (screen-X, screen-Y, depth) */
     int shade, colorBase, curLod;
@@ -208,6 +221,594 @@ typedef struct {
 static GlSub s_subs[GL_MAX_SUBS];
 static int s_nSub;
 static int s_subOverflow;
+
+typedef R3DReplacementPrim GlbPrim;
+typedef R3DReplacementMesh GlbMesh;
+
+static GlbMesh **s_glbCache;
+static int s_glbCacheN;
+static int s_glbCacheCap;
+
+static const char *glbShellQuote(const char *value) {
+    static char quoted[1024];
+    size_t out = 0;
+    quoted[out++] = '\'';
+    for (const char *p = value; *p && out + 5 < sizeof(quoted); p++) {
+        if (*p == '\'') {
+            memcpy(quoted + out, "'\\''", 4);
+            out += 4;
+        } else {
+            quoted[out++] = *p;
+        }
+    }
+    quoted[out++] = '\'';
+    quoted[out] = 0;
+    return quoted;
+}
+
+static uint32 rd32(const uint8 *p) {
+    return (uint32)p[0] | ((uint32)p[1] << 8) | ((uint32)p[2] << 16) | ((uint32)p[3] << 24);
+}
+
+static int32 rd32s(const uint8 *p) {
+    uint32 v = rd32(p);
+    return (int32)v;
+}
+
+static float rdf32(const uint8 *p) {
+    float v;
+    memcpy(&v, p, sizeof(v));
+    return v;
+}
+
+static void freeGlbRuntimeMesh(GlbMesh *mesh);
+static void compareGlbReplacementWithLegacy(const GlSub *r, GlbMesh *mesh);
+
+static int parseGlbRuntimeMesh(GlbMesh *mesh, const uint8 *data, size_t size) {
+    size_t pos;
+    size_t primHeaderSize;
+    int prim;
+    /* F15GLM3 is the auditable runtime-cache format:
+     *   0x00 magic "F15GLM3\0"
+     *   0x08 source GLB MD5 ASCII
+     *   0x28 primitive count
+     *   then 40-byte primitive headers:
+     *     mode, vertex_count, source_kind, source_index, source_color,
+     *     source_flags, rgba[4], followed by vertex_count vec3 float32s.
+     *
+     * The renderer only consumes mode/color/vertices. The source_* fields are
+     * intentionally parsed anyway so test/developer validation can detect stale
+     * caches that merged/reordered coplanar faces or line-only details. */
+    if (size >= 44 && memcmp(data, "F15GLM3", 7) == 0) {
+        memcpy(mesh->sourceMd5, data + 8, 32);
+        mesh->sourceMd5[32] = 0;
+        mesh->hasSourceMd5 = 1;
+        mesh->nPrims = (int)rd32(data + 40);
+        pos = 44;
+        primHeaderSize = 40;
+    } else if (size >= 44 && memcmp(data, "F15GLM2", 7) == 0) {
+        memcpy(mesh->sourceMd5, data + 8, 32);
+        mesh->sourceMd5[32] = 0;
+        mesh->hasSourceMd5 = 1;
+        mesh->nPrims = (int)rd32(data + 40);
+        pos = 44;
+        primHeaderSize = 24;
+    } else if (size >= 12 && memcmp(data, "F15GLM1", 7) == 0) {
+        mesh->sourceMd5[0] = 0;
+        mesh->hasSourceMd5 = 0;
+        mesh->nPrims = (int)rd32(data + 8);
+        pos = 12;
+        primHeaderSize = 24;
+    } else {
+        return 0;
+    }
+    if (mesh->nPrims < 0 || mesh->nPrims > 4096) goto fail;
+    mesh->prims = (GlbPrim *)SDL_calloc((size_t)mesh->nPrims, sizeof(GlbPrim));
+    if (!mesh->prims && mesh->nPrims) goto fail;
+    for (prim = 0; prim < mesh->nPrims; prim++) {
+        GlbPrim *p = &mesh->prims[prim];
+        int i;
+        if (pos + primHeaderSize > size) goto fail;
+        p->mode = (int)rd32(data + pos);
+        p->nVerts = (int)rd32(data + pos + 4);
+        if (primHeaderSize == 40) {
+            /* F15GLM3 stores source primitive identity so diagnostics can prove
+             * that cache generation preserved .3D3 draw order. Runtime drawing
+             * only needs mode/color/vertices, but these fields are cheap and keep
+             * the cache auditable after the GLB has been reduced. */
+            p->sourceKind = (int)rd32(data + pos + 8);
+            p->sourceIndex = (int)rd32s(data + pos + 12);
+            p->sourceColor = (int)rd32s(data + pos + 16);
+            p->sourceFlags = rd32(data + pos + 20);
+            p->rgba[0] = rdf32(data + pos + 24);
+            p->rgba[1] = rdf32(data + pos + 28);
+            p->rgba[2] = rdf32(data + pos + 32);
+            p->rgba[3] = rdf32(data + pos + 36);
+        } else {
+            p->sourceKind = 0;
+            p->sourceIndex = -1;
+            p->sourceColor = -1;
+            p->sourceFlags = 0;
+            p->rgba[0] = rdf32(data + pos + 8);
+            p->rgba[1] = rdf32(data + pos + 12);
+            p->rgba[2] = rdf32(data + pos + 16);
+            p->rgba[3] = rdf32(data + pos + 20);
+        }
+        pos += primHeaderSize;
+        if (p->nVerts < 0 || p->nVerts > 65536 || pos + (size_t)p->nVerts * 12 > size) goto fail;
+        /* GLMESH is a generated cache, not an extensible container. Reject
+         * malformed primitive streams instead of drawing partial geometry and
+         * hiding the cache/source mismatch from replacement diagnostics. */
+        if (p->mode != 4 && p->mode != 1 && p->mode != 0) goto fail;
+        if (p->mode == 4 && (p->nVerts % 3) != 0) goto fail;
+        if (p->mode == 1 && (p->nVerts % 2) != 0) goto fail;
+        p->xyz = (float *)SDL_malloc((size_t)p->nVerts * 3 * sizeof(float));
+        if (!p->xyz && p->nVerts) goto fail;
+        for (i = 0; i < p->nVerts * 3; i++) {
+            p->xyz[i] = rdf32(data + pos);
+            pos += 4;
+        }
+    }
+    if (pos != size) goto fail;
+    return 1;
+
+fail:
+    freeGlbRuntimeMesh(mesh);
+    return 0;
+}
+
+static void freeGlbRuntimeMesh(GlbMesh *mesh) {
+    int i;
+    if (mesh->prims) {
+        for (i = 0; i < mesh->nPrims; i++) {
+            SDL_free(mesh->prims[i].xyz);
+        }
+    }
+    SDL_free(mesh->prims);
+    mesh->prims = NULL;
+    mesh->nPrims = 0;
+    mesh->loaded = 0;
+}
+
+static int glbRuntimeMeshHasRenderablePrims(const GlbMesh *mesh) {
+    int i;
+    if (!mesh || mesh->nPrims <= 0) return 0;
+    for (i = 0; i < mesh->nPrims; i++) {
+        const GlbPrim *prim = &mesh->prims[i];
+        if (prim->nVerts > 0 && (prim->mode == 4 || prim->mode == 1 || prim->mode == 0)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static GlbMesh *allocGlbCacheSlot(void) {
+    GlbMesh **newCache;
+    GlbMesh *mesh;
+    int newCap;
+
+    if (s_glbCacheN < s_glbCacheCap) {
+        mesh = (GlbMesh *)SDL_calloc(1, sizeof(*mesh));
+        if (!mesh) return NULL;
+        s_glbCache[s_glbCacheN++] = mesh;
+        return mesh;
+    }
+
+    /* Replacement packs can contain hundreds of per-shape GLBs. The lookup table
+     * is growable, but each mesh is separately allocated so software-renderer
+     * sorted objects can safely queue R3DReplacementMesh* values for later draw:
+     * growing the pointer table must not move already returned mesh objects. */
+    newCap = s_glbCacheCap ? s_glbCacheCap * 2 : 128;
+    newCache = (GlbMesh **)SDL_realloc(s_glbCache, (size_t)newCap * sizeof(GlbMesh *));
+    if (!newCache) return NULL;
+    memset(newCache + s_glbCacheCap, 0, (size_t)(newCap - s_glbCacheCap) * sizeof(GlbMesh *));
+    s_glbCache = newCache;
+    s_glbCacheCap = newCap;
+    mesh = (GlbMesh *)SDL_calloc(1, sizeof(*mesh));
+    if (!mesh) return NULL;
+    s_glbCache[s_glbCacheN++] = mesh;
+    return mesh;
+}
+
+static uint8 *readFileBytes(const char *path, size_t *outSize) {
+    FILE *fp;
+    uint8 *data;
+    long size;
+    size_t got;
+    if (outSize) *outSize = 0;
+    fp = fopen(path, "rb");
+    if (!fp) return NULL;
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+    size = ftell(fp);
+    if (size <= 0 || size > 16 * 1024 * 1024) {
+        fclose(fp);
+        return NULL;
+    }
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+    data = (uint8 *)SDL_malloc((size_t)size);
+    if (!data) {
+        fclose(fp);
+        return NULL;
+    }
+    got = fread(data, 1, (size_t)size, fp);
+    fclose(fp);
+    if (got != (size_t)size) {
+        SDL_free(data);
+        return NULL;
+    }
+    if (outSize) *outSize = (size_t)size;
+    return data;
+}
+
+static int writeFileBytes(const char *path, const uint8 *data, size_t size) {
+    FILE *fp = fopen(path, "wb");
+    if (!fp) return 0;
+    if (fwrite(data, 1, size, fp) != size) {
+        fclose(fp);
+        return 0;
+    }
+    return fclose(fp) == 0;
+}
+
+static void glmeshCachePathForGlb(const char *glbPath, char *outPath, size_t outPathSize) {
+    fs::path source{glbPath};
+    fs::path cache = source.parent_path() / "cache" / source.filename();
+    cache.replace_extension(".glmesh");
+    snprintf(outPath, outPathSize, "%s", cache.string().c_str());
+}
+
+static void addGlbToolCandidate(std::vector<fs::path> &candidates, const fs::path &path) {
+    if (std::find(candidates.begin(), candidates.end(), path) == candidates.end()) {
+        candidates.push_back(path);
+    }
+}
+
+static std::string glbAssetToolCommand(const fs::path &assetHint) {
+    const char *tool = getenv("F15_ASSET_TOOL");
+    const char *replacementRoot = getenv("F15_REPLACEMENT_ROOT");
+    if (tool && tool[0]) return std::string(tool);
+
+    /* Runtime replacement should work from common build/run directories, not
+     * only when `python3 -m tools.f15assets.cli` can import the repository. */
+    std::vector<fs::path> candidates;
+    fs::path cursor = assetHint;
+    if (!cursor.empty() && cursor.has_filename()) cursor = cursor.parent_path();
+    while (!cursor.empty()) {
+        if (cursor.filename() == "converted_assets_all") {
+            addGlbToolCandidate(candidates, cursor.parent_path() / "tools/f15assets/cli.py");
+            break;
+        }
+        fs::path parent = cursor.parent_path();
+        if (parent == cursor) break;
+        cursor = cursor.parent_path();
+    }
+    if (replacementRoot && replacementRoot[0]) {
+        fs::path replacementPath{replacementRoot};
+        /* GLB cache generation may be triggered from an external custom pack.
+         * Try likely repo-adjacent tool paths unless F15_ASSET_TOOL explicitly
+         * names the bridge command. */
+        addGlbToolCandidate(candidates, replacementPath.parent_path() / "tools/f15assets/cli.py");
+        addGlbToolCandidate(candidates, replacementPath / "../tools/f15assets/cli.py");
+        addGlbToolCandidate(candidates, replacementPath / "tools/f15assets/cli.py");
+        addGlbToolCandidate(candidates, replacementPath / "converted_assets_all/../tools/f15assets/cli.py");
+    }
+    addGlbToolCandidate(candidates, fs::path{"tools/f15assets/cli.py"});
+    addGlbToolCandidate(candidates, fs::path{"../tools/f15assets/cli.py"});
+    addGlbToolCandidate(candidates, fs::path{"../../tools/f15assets/cli.py"});
+    for (const fs::path &candidate : candidates) {
+        if (fs::exists(candidate)) return std::string("python3 ") + glbShellQuote(candidate.string().c_str());
+    }
+    return std::string("python3 -m tools.f15assets.cli");
+}
+
+static uint8 *buildGlmeshBytesFromGlb(const char *glbPath, size_t *outSize) {
+    char command[1400];
+    std::string toolCommand;
+    FILE *pipe;
+    uint8 *data = NULL;
+    size_t size = 0, cap = 0;
+    uint8 chunk[4096];
+    size_t got;
+
+    if (outSize) *outSize = 0;
+    toolCommand = glbAssetToolCommand(fs::path{glbPath ? glbPath : ""});
+    snprintf(command, sizeof(command), "%s build-glmesh %s",
+             toolCommand.c_str(),
+             glbShellQuote(glbPath));
+    pipe = popen(command, "r");
+    if (!pipe) return NULL;
+    while ((got = fread(chunk, 1, sizeof(chunk), pipe)) > 0) {
+        if (size + got > cap) {
+            size_t newCap = cap ? cap * 2 : 8192;
+            uint8 *newData;
+            while (newCap < size + got) newCap *= 2;
+            newData = (uint8 *)SDL_realloc(data, newCap);
+            if (!newData) {
+                SDL_free(data);
+                pclose(pipe);
+                return NULL;
+            }
+            data = newData;
+            cap = newCap;
+        }
+        memcpy(data + size, chunk, got);
+        size += got;
+    }
+    if (pclose(pipe) != 0 || size == 0) {
+        SDL_free(data);
+        return NULL;
+    }
+    if (outSize) *outSize = size;
+    return data;
+}
+
+R3DReplacementMesh *r3d_replacementMesh(const char *containerLegacyName, int shapeId) {
+    char cachePath[512];
+    char glbPath[512];
+    uint8 *data = NULL;
+    size_t size = 0;
+    int i;
+    GlbMesh *mesh;
+    int hasGlb;
+    std::string glbMd5;
+
+    if (!containerLegacyName || shapeId < 0) return NULL;
+    hasGlb = findReplacementShapeModelPath(containerLegacyName, shapeId, ".glb", glbPath, sizeof(glbPath));
+    if (hasGlb) {
+        glmeshCachePathForGlb(glbPath, cachePath, sizeof(cachePath));
+    } else if (!findReplacementShapeModelPath(containerLegacyName, shapeId, ".glmesh", cachePath, sizeof(cachePath))) {
+        return NULL;
+    }
+
+    for (i = 0; i < s_glbCacheN; i++) {
+        GlbMesh *cached = s_glbCache[i];
+        if (cached && strcmp(cached->path, hasGlb ? glbPath : cachePath) == 0) {
+            return cached->loaded ? cached : NULL;
+        }
+    }
+    mesh = allocGlbCacheSlot();
+    if (!mesh) return NULL;
+    SDL_strlcpy(mesh->path, hasGlb ? glbPath : cachePath, sizeof(mesh->path));
+
+    if (hasGlb) {
+        glbMd5 = QuickDigest5::fileToHash(glbPath);
+        data = readFileBytes(cachePath, &size);
+        if (data) {
+            int parsedCache = parseGlbRuntimeMesh(mesh, data, size);
+            int hasRenderableCache = parsedCache && glbRuntimeMeshHasRenderablePrims(mesh);
+            if (parsedCache
+                && hasRenderableCache
+                && mesh->hasSourceMd5
+                && glbMd5 == mesh->sourceMd5) {
+                SDL_free(data);
+                mesh->loaded = 1;
+                LogInfo(("asset replacement: loaded GLB runtime mesh cache %s (%d primitives)", cachePath, mesh->nPrims));
+                return mesh;
+            }
+            if (parsedCache && !hasRenderableCache) {
+                LogWarn(("asset replacement: ignoring empty GLB runtime mesh cache %s; rebuilding from %s", cachePath, glbPath));
+            } else if (parsedCache && (!mesh->hasSourceMd5 || glbMd5 != mesh->sourceMd5)) {
+                LogInfo(("asset replacement: ignoring stale GLB runtime mesh cache %s; rebuilding from %s", cachePath, glbPath));
+            } else if (!parsedCache) {
+                LogWarn(("asset replacement: ignoring malformed GLB runtime mesh cache %s; rebuilding from %s", cachePath, glbPath));
+            }
+            freeGlbRuntimeMesh(mesh);
+            SDL_free(data);
+        }
+
+        data = buildGlmeshBytesFromGlb(glbPath, &size);
+        if (!data || !parseGlbRuntimeMesh(mesh, data, size) ||
+            !glbRuntimeMeshHasRenderablePrims(mesh) ||
+            !mesh->hasSourceMd5 || glbMd5 != mesh->sourceMd5) {
+            freeGlbRuntimeMesh(mesh);
+            SDL_free(data);
+            mesh->failed = 1;
+            LogWarn(("asset replacement: failed to build verified runtime mesh from %s; using legacy .3D3", glbPath));
+            return NULL;
+        }
+        fs::create_directories(fs::path(cachePath).parent_path());
+        if (!writeFileBytes(cachePath, data, size)) {
+            LogWarn(("asset replacement: built runtime mesh from %s but could not write cache %s", glbPath, cachePath));
+        }
+        SDL_free(data);
+        mesh->loaded = 1;
+        LogInfo(("asset replacement: built GLB runtime mesh cache %s from %s (%d primitives)", cachePath, glbPath, mesh->nPrims));
+        return mesh;
+    }
+
+    data = readFileBytes(cachePath, &size);
+    if (!data || !parseGlbRuntimeMesh(mesh, data, size) || !glbRuntimeMeshHasRenderablePrims(mesh)) {
+        freeGlbRuntimeMesh(mesh);
+        SDL_free(data);
+        mesh->failed = 1;
+        LogWarn(("asset replacement: failed to load standalone runtime mesh %s; using legacy .3D3", cachePath));
+        return NULL;
+    }
+    SDL_free(data);
+    mesh->loaded = 1;
+    LogInfo(("asset replacement: loaded standalone GLB runtime mesh cache %s (%d primitives)", cachePath, mesh->nPrims));
+    return mesh;
+}
+
+#ifdef DEBUG
+int r3dgl_testLoadReplacementMesh(const char *containerLegacyName, int shapeId,
+                                  int *outPrimitiveCount) {
+    GlbMesh *mesh = r3d_replacementMesh(containerLegacyName, shapeId);
+    if (outPrimitiveCount) *outPrimitiveCount = mesh ? mesh->nPrims : 0;
+    return mesh != NULL;
+}
+
+int r3dgl_testLegacyShapeRenderable(const unsigned char *legacyModel,
+                                    size_t legacyModelSize) {
+    MeshVtxPools pools;
+    Mesh legacy;
+    MeshLod *lod;
+    int i;
+
+    if (!legacyModel || legacyModelSize == 0 || legacyModelSize > WORLD3D_DATA_SIZE) {
+        return 0;
+    }
+    memset(g_world3dData, 0, WORLD3D_DATA_SIZE);
+    memcpy(g_world3dData, legacyModel, legacyModelSize);
+    fillPools(&pools);
+    if (r3dmesh_decode((const uint8 *)g_world3dData,
+                       (const uint8 *)g_world3dData + legacyModelSize,
+                       &pools, colorLut, &legacy) < 0) {
+        return 0;
+    }
+    lod = &legacy.lods[0];
+    if (lod->form == MESH_FORM_POINT) return 1;
+    if (lod->form == MESH_FORM_EDGERUN) return lod->nRunRefs > 0;
+    if (lod->form != MESH_FORM_MODEL) return 0;
+    for (i = 0; i < lod->nFaces; i++) {
+        if (lod->faces[i].nEdges >= 3 && lod->faces[i].colorByte != 0xff) return 1;
+    }
+    return lod->nLines > 0;
+}
+
+int r3dgl_testCompareReplacementMesh(const char *containerLegacyName, int shapeId,
+                                     const unsigned char *legacyModel,
+                                     size_t legacyModelSize) {
+    GlbMesh *mesh;
+    GlSub sub;
+    MeshVtxPools pools;
+    Mesh legacy;
+    MeshLod *lod;
+    int previousSourceIndex[4] = {-1, -1, -1, -1};
+    int glbTriangles = 0, glbLines = 0, glbPoints = 0;
+    int legacyTriangles = 0;
+    int legacyLines = 0;
+    int legacyPoints = 0;
+    int legacyFaceColor[256] = {0};
+    int legacyLineColor[256] = {0};
+    int legacyPointColor[256] = {0};
+    int glbFaceColor[256] = {0};
+    int glbLineColor[256] = {0};
+    int glbPointColor[256] = {0};
+    int i;
+
+    if (!legacyModel || legacyModelSize == 0 || legacyModelSize > WORLD3D_DATA_SIZE) {
+        return 0;
+    }
+    memset(g_world3dData, 0, WORLD3D_DATA_SIZE);
+    memcpy(g_world3dData, legacyModel, legacyModelSize);
+    mesh = r3d_replacementMesh(containerLegacyName, shapeId);
+    if (!mesh) return 0;
+
+    memset(&sub, 0, sizeof(sub));
+    sub.model = g_world3dData;
+    sub.shapeId = shapeId;
+    sub.containerLegacyName = containerLegacyName;
+
+    fillPools(&pools);
+    if (r3dmesh_decode((const uint8 *)sub.model,
+                       (const uint8 *)g_world3dData + legacyModelSize,
+                       &pools, colorLut, &legacy) < 0) {
+        return 0;
+    }
+    lod = &legacy.lods[0];
+
+    for (i = 0; i < mesh->nPrims; i++) {
+        const GlbPrim *prim = &mesh->prims[i];
+        if ((prim->sourceFlags & 1u) == 0u || prim->sourceKind == 0 || prim->sourceColor < 0) {
+            LogWarn(("3D test compare: shape %d primitive %d lacks source metadata/color", shapeId, i));
+            return 0;
+        }
+        if (prim->sourceKind >= 1 && prim->sourceKind <= 3) {
+            if (prim->sourceIndex < 0 || prim->sourceIndex < previousSourceIndex[prim->sourceKind]) {
+                LogWarn(("3D test compare: shape %d primitive %d has non-monotonic source index %d", shapeId, i, prim->sourceIndex));
+                return 0;
+            }
+            previousSourceIndex[prim->sourceKind] = prim->sourceIndex;
+        }
+        if ((prim->sourceKind == 1 && prim->mode != 4)
+            || (prim->sourceKind == 2 && prim->mode != 1)
+            || (prim->sourceKind == 3 && prim->mode != 0)) {
+            LogWarn(("3D test compare: shape %d primitive %d source kind/mode mismatch kind=%d mode=%d", shapeId, i, prim->sourceKind, prim->mode));
+            return 0;
+        }
+        if (prim->mode == 4) glbTriangles += prim->nVerts / 3;
+        else if (prim->mode == 1) glbLines += prim->nVerts / 2;
+        else if (prim->mode == 0) glbPoints += prim->nVerts;
+        if (prim->sourceColor >= 0 && prim->sourceColor < 256) {
+            if (prim->sourceKind == 1) glbFaceColor[prim->sourceColor] += prim->nVerts / 3;
+            else if (prim->sourceKind == 2) glbLineColor[prim->sourceColor] += prim->nVerts / 2;
+            else if (prim->sourceKind == 3) glbPointColor[prim->sourceColor] += prim->nVerts;
+        }
+    }
+
+    if (lod->form == MESH_FORM_POINT) {
+        legacyPointColor[lod->pointColor] = 1;
+        if (!(glbTriangles == 0 && glbLines == 0 && glbPoints == 1 &&
+              memcmp(legacyPointColor, glbPointColor, sizeof(legacyPointColor)) == 0)) {
+            LogWarn(("3D test compare: shape %d point mismatch glb_tri=%d glb_line=%d glb_point=%d", shapeId, glbTriangles, glbLines, glbPoints));
+            return 0;
+        }
+        return 1;
+    }
+    if (lod->form == MESH_FORM_EDGERUN) {
+        legacyPointColor[lod->pointColor] = lod->nRunRefs;
+        if (!(glbTriangles == 0 && glbLines == 0 && glbPoints == lod->nRunRefs &&
+              memcmp(legacyPointColor, glbPointColor, sizeof(legacyPointColor)) == 0)) {
+            LogWarn(("3D test compare: shape %d edgerun mismatch legacy_points=%d glb_tri=%d glb_line=%d glb_point=%d", shapeId, lod->nRunRefs, glbTriangles, glbLines, glbPoints));
+            return 0;
+        }
+        return 1;
+    }
+
+    for (i = 0; i < lod->nFaces; i++) {
+        if (lod->faces[i].nEdges >= 3 && lod->faces[i].colorByte != 0xff) {
+            int triCount = (int)lod->faces[i].nEdges - 2;
+            int k;
+            legacyTriangles += triCount;
+            legacyFaceColor[lod->faces[i].colorByte] += triCount;
+            for (k = 0; k < lod->faces[i].nEdges; k++) {
+                MeshEdge *e = &lod->edges[lod->faces[i].edge[k]];
+                if (e->va == e->vb) {
+                    legacyPoints += 1;
+                    legacyPointColor[lod->faces[i].colorByte] += 1;
+                } else {
+                    legacyLines += 1;
+                    legacyLineColor[lod->faces[i].colorByte] += 1;
+                }
+            }
+        }
+    }
+    for (i = 0; i < lod->nLines; i++) {
+        MeshEdge *e = &lod->edges[lod->lines[i].edge];
+        if (e->va == e->vb) {
+            legacyPoints += 1;
+            legacyPointColor[lod->lines[i].colorByte] += 1;
+        } else {
+            legacyLines += 1;
+            legacyLineColor[lod->lines[i].colorByte] += 1;
+        }
+    }
+
+    if (!(glbTriangles == legacyTriangles &&
+          glbLines >= lod->nLines &&
+          glbLines <= legacyLines &&
+          glbPoints == legacyPoints &&
+          memcmp(legacyFaceColor, glbFaceColor, sizeof(legacyFaceColor)) == 0 &&
+          memcmp(legacyPointColor, glbPointColor, sizeof(legacyPointColor)) == 0)) {
+        LogWarn(("3D test compare: shape %d mismatch legacy_tri=%d legacy_line=%d legacy_point=%d glb_tri=%d glb_line=%d glb_point=%d", shapeId, legacyTriangles, legacyLines, legacyPoints, glbTriangles, glbLines, glbPoints));
+        return 0;
+    }
+    for (i = 0; i < 256; i++) {
+        if (glbLineColor[i] > legacyLineColor[i]) {
+            LogWarn(("3D test compare: shape %d line color 0x%02x exceeds legacy coverage glb=%d legacy=%d", shapeId, i, glbLineColor[i], legacyLineColor[i]));
+            return 0;
+        }
+    }
+    return 1;
+}
+#endif
 
 /* World-space 3D line segments (cannon tracers, explosion sparks) submitted this
  * frame; drawn as camera-facing ribbons (z-tested + fogged) at the end of the
@@ -387,7 +988,23 @@ static void fogVertex(float x, float y, float z) {
 static const char *gl_name(void) { return "opengl1"; }
 
 static int gl_init(void) { return s_active; } /* claims iff the context came up */
-static void gl_shutdown(void) {}
+static void gl_shutdown(void) {
+    int i, j;
+    for (i = 0; i < s_glbCacheN; i++) {
+        GlbMesh *mesh = s_glbCache[i];
+        if (!mesh) continue;
+        for (j = 0; j < mesh->nPrims; j++) {
+            SDL_free(mesh->prims[j].xyz);
+        }
+        SDL_free(mesh->prims);
+        SDL_free(mesh);
+        s_glbCache[i] = NULL;
+    }
+    SDL_free(s_glbCache);
+    s_glbCache = NULL;
+    s_glbCacheN = 0;
+    s_glbCacheCap = 0;
+}
 
 static R3DMesh gl_registerMesh(R3DMesh raw) { return raw; } /* decoded per submit */
 static void gl_releaseMesh(R3DMesh mesh) { (void)mesh; }
@@ -853,6 +1470,8 @@ static void gl_submit(const R3DSubmit *o) {
 
     r = &s_subs[s_nSub];
     r->model = (char *)o->mesh;
+    r->shapeId = o->shapeId;
+    r->containerLegacyName = o->containerLegacyName;
     for (i = 0; i < 9; i++) r->combined[i] = combined[i];
     r->camBase = camBase;
     r->camX = camTransX;
@@ -965,6 +1584,188 @@ static void drawDepthPoint(float x, float y, long depth32, int colorIdx) {
     glEnd();
 }
 
+static void drawGlbReplacementSub(const GlSub *r, const GlbMesh *mesh) {
+    int primIndex, i;
+    float cm[9], scaleDiv;
+    int shift = 8 - 2 * r->curLod;
+    if (shift < 0) shift = 0;
+    scaleDiv = (float)(1 << shift);
+    for (i = 0; i < 9; i++) cm[i] = (float)r->combined[i];
+
+    for (primIndex = 0; primIndex < mesh->nPrims; primIndex++) {
+        const GlbPrim *prim = &mesh->prims[primIndex];
+        GLenum glMode;
+        if (prim->mode == 4) glMode = GL_TRIANGLES;
+        else if (prim->mode == 1) glMode = GL_LINES;
+        else if (prim->mode == 0) glMode = GL_POINTS;
+        else continue;
+
+        paintBias();
+        glColor4f(prim->rgba[0], prim->rgba[1], prim->rgba[2], prim->rgba[3]);
+        if (glMode == GL_POINTS) {
+            glPointSize(s_pixelScale > 1.0f ? s_pixelScale : 1.0f);
+        }
+        glBegin(glMode);
+        for (i = 0; i < prim->nVerts; i++) {
+            float X = prim->xyz[i * 3];
+            float Y = prim->xyz[i * 3 + 1];
+            float Z = prim->xyz[i * 3 + 2];
+            float camX = (2.0f * (cm[0] * X + cm[3] * Z + cm[6] * Y) + (float)r->camBase) / scaleDiv;
+            float camY = (2.0f * (cm[1] * X + cm[4] * Z + cm[7] * Y) + (float)r->camX) / scaleDiv;
+            float depth = (2.0f * (cm[2] * X + cm[5] * Z + cm[8] * Y) + (float)r->camY) / scaleDiv;
+            fogVertex(camX, camY, depth / 65536.0f);
+        }
+        glEnd();
+    }
+}
+
+static void compareGlbReplacementWithLegacy(const GlSub *r, GlbMesh *mesh) {
+    AssetCompare3dShapeStats stats;
+    MeshVtxPools pools;
+    Mesh legacy;
+    MeshLod *lod;
+    int glbTriangles = 0;
+    int glbLines = 0;
+    int glbPoints = 0;
+    int legacyTriangles = 0;
+    int previousSourceIndex[4] = {-1, -1, -1, -1};
+    int missingSourceMeta = 0;
+    int missingSourceColor = 0;
+    int badSourceOrder = 0;
+    int badSourceMode = 0;
+    int glbFaceColor[256] = {0};
+    int glbLineColor[256] = {0};
+    int glbPointColor[256] = {0};
+    int legacyFaceColor[256] = {0};
+    int legacyLineColor[256] = {0};
+    int legacyPointColor[256] = {0};
+    int canCompareSourceColors = 1;
+    int i;
+
+    if (!assetCompareEnabled() || !r || !mesh || mesh->compared) return;
+    mesh->compared = 1;
+
+    fillPools(&pools);
+    if (r3dmesh_decode((const uint8 *)r->model,
+                       (const uint8 *)g_world3dData + WORLD3D_DATA_SIZE,
+                       &pools, colorLut, &legacy) < 0) {
+        LogWarn(("asset replacement compare: failed to decode legacy 3D shape %d for %s", r->shapeId, mesh->path));
+        return;
+    }
+    lod = &legacy.lods[0];
+
+    for (i = 0; i < mesh->nPrims; i++) {
+        const GlbPrim *prim = &mesh->prims[i];
+        if (prim->mode == 4) glbTriangles += prim->nVerts / 3;
+        else if (prim->mode == 1) glbLines += prim->nVerts / 2;
+        else if (prim->mode == 0) glbPoints += prim->nVerts;
+        if ((prim->sourceFlags & 1u) == 0u || prim->sourceKind == 0) {
+            missingSourceMeta = 1;
+            canCompareSourceColors = 0;
+        }
+        if (prim->sourceKind != 0 && prim->sourceColor < 0) {
+            missingSourceColor = 1;
+            canCompareSourceColors = 0;
+        }
+        if (prim->sourceKind >= 1 && prim->sourceKind <= 3) {
+            if (prim->sourceIndex < 0 || prim->sourceIndex <= previousSourceIndex[prim->sourceKind]) {
+                badSourceOrder = 1;
+            }
+            previousSourceIndex[prim->sourceKind] = prim->sourceIndex;
+        }
+        /* F15GLM3 source_kind is the bridge from reduced GLMESH back to the
+         * decoded .3D3 primitive stream. Compare it with GL mode so a malformed
+         * cache cannot claim a face color while drawing it as a line or point. */
+        if ((prim->sourceKind == 1 && prim->mode != 4)
+            || (prim->sourceKind == 2 && prim->mode != 1)
+            || (prim->sourceKind == 3 && prim->mode != 0)) {
+            badSourceMode = 1;
+        }
+        if (prim->sourceColor >= 0 && prim->sourceColor < 256) {
+            if (prim->sourceKind == 1) glbFaceColor[prim->sourceColor] += prim->nVerts / 3;
+            else if (prim->sourceKind == 2) glbLineColor[prim->sourceColor] += prim->nVerts / 2;
+            else if (prim->sourceKind == 3) glbPointColor[prim->sourceColor] += prim->nVerts;
+        }
+    }
+
+    if (lod->form == MESH_FORM_POINT) {
+        legacyPointColor[lod->pointColor] = 1;
+        memset(&stats, 0, sizeof(stats));
+        stats.shapeId = r->shapeId;
+        stats.legacyForm = 1;
+        stats.legacyPoints = 1;
+        stats.glbTriangles = glbTriangles;
+        stats.glbLines = glbLines;
+        stats.glbPoints = glbPoints;
+        stats.missingSourceMeta = missingSourceMeta;
+        stats.missingSourceColor = missingSourceColor;
+        stats.badSourceOrder = badSourceOrder;
+        stats.badSourceMode = badSourceMode;
+        stats.canCompareSourceColors = canCompareSourceColors;
+        stats.legacyPointColor = legacyPointColor;
+        stats.glbPointColor = glbPointColor;
+        stats.replacementPath = mesh->path;
+        assetCompare3dShapeStats(&stats);
+        return;
+    }
+    if (lod->form == MESH_FORM_EDGERUN) {
+        legacyPointColor[lod->pointColor] = lod->nRunRefs;
+        memset(&stats, 0, sizeof(stats));
+        stats.shapeId = r->shapeId;
+        stats.legacyForm = 2;
+        stats.legacyPoints = lod->nRunRefs;
+        stats.glbTriangles = glbTriangles;
+        stats.glbLines = glbLines;
+        stats.glbPoints = glbPoints;
+        stats.missingSourceMeta = missingSourceMeta;
+        stats.missingSourceColor = missingSourceColor;
+        stats.badSourceOrder = badSourceOrder;
+        stats.badSourceMode = badSourceMode;
+        stats.canCompareSourceColors = canCompareSourceColors;
+        stats.legacyPointColor = legacyPointColor;
+        stats.glbPointColor = glbPointColor;
+        stats.replacementPath = mesh->path;
+        assetCompare3dShapeStats(&stats);
+        return;
+    }
+
+    for (i = 0; i < lod->nFaces; i++) {
+        if (lod->faces[i].nEdges >= 3) {
+            int triCount = (int)lod->faces[i].nEdges - 2;
+            legacyTriangles += triCount;
+            legacyFaceColor[lod->faces[i].colorByte] += triCount;
+        }
+    }
+    for (i = 0; i < lod->nLines; i++) {
+        legacyLineColor[lod->lines[i].colorByte] += 1;
+    }
+
+    /* Counts alone are too weak for this game's meshes: two shapes can have
+     * identical topology while a nose antenna, deck line, or coplanar face uses
+     * the wrong raw palette byte. F15GLM3 keeps sourceColor so the runtime
+     * diagnostic can compare color coverage without depending on float vertex
+     * round-tripping. */
+    memset(&stats, 0, sizeof(stats));
+    stats.shapeId = r->shapeId;
+    stats.legacyFaces = lod->nFaces;
+    stats.legacyTriangles = legacyTriangles;
+    stats.legacyLines = lod->nLines;
+    stats.glbTriangles = glbTriangles;
+    stats.glbLines = glbLines;
+    stats.glbPoints = glbPoints;
+    stats.missingSourceMeta = missingSourceMeta;
+    stats.missingSourceColor = missingSourceColor;
+    stats.badSourceOrder = badSourceOrder;
+    stats.badSourceMode = badSourceMode;
+    stats.canCompareSourceColors = canCompareSourceColors;
+    stats.legacyFaceColor = legacyFaceColor;
+    stats.legacyLineColor = legacyLineColor;
+    stats.glbFaceColor = glbFaceColor;
+    stats.glbLineColor = glbLineColor;
+    stats.replacementPath = mesh->path;
+    assetCompare3dShapeStats(&stats);
+}
+
 /* Decode + transform + draw one object (painter's order; z-buffer on, GL_LEQUAL,
  * per-draw polygon offset set by the caller). Re-decodes the mesh (cheap; avoids
  * caching across region reloads). */
@@ -992,6 +1793,13 @@ static void drawSub(const GlSub *r) {
     float snx = 0, sny = 0, snz = 0, sox = 0, soy = 0, soz = 0;
     float srvx = 0, srvy = 0, srvz = 0;
     static float vx_[R3DMESH_MAX_VERTS], vy_[R3DMESH_MAX_VERTS], vd_[R3DMESH_MAX_VERTS];
+    GlbMesh *replacement = r3d_replacementMesh(r->containerLegacyName, r->shapeId);
+
+    if (replacement) {
+        compareGlbReplacementWithLegacy(r, replacement);
+        drawGlbReplacementSub(r, replacement);
+        return;
+    }
 
     fillPools(&pools);
     if (r3dmesh_decode((const uint8 *)r->model,

--- a/src/r3d_gl.h
+++ b/src/r3d_gl.h
@@ -1,6 +1,8 @@
 #ifndef R3D_GL_H
 #define R3D_GL_H
 
+#include <stddef.h>
+
 /*
  * OpenGL 1.x backend support hooks consumed by the graphics layer (gfx_impl.c).
  *
@@ -99,5 +101,24 @@ void r3dgl_drawImageWindow(R2DImage *img);
  * 320-space boxLeftX (mapped through the 4:3 overlay letterbox) — the briefing arm
  * cels, positioned in the menu box they point into. GL only. */
 void r3dgl_drawImageWindowBoxX(R2DImage *img, float boxLeftX);
+
+#ifdef DEBUG
+/* Test-only seam for the GL replacement path. It exercises the same GLB/GLMESH
+ * runtime mesh loader used by drawSub(), without requiring a live GL context. */
+int r3dgl_testLoadReplacementMesh(const char *containerLegacyName, int shapeId,
+                                  int *outPrimitiveCount);
+/* Returns non-zero when a legacy .3D3 shape slot decodes to something the
+ * renderer would draw. Validation uses this to require replacements for real
+ * shapes while still allowing known empty/truncated table slots to be skipped. */
+int r3dgl_testLegacyShapeRenderable(const unsigned char *legacyModel,
+                                    size_t legacyModelSize);
+/* Test-only seam for the replacement comparison path. Copies a caller-provided
+ * legacy display-list into the world model buffer, loads the matching modern
+ * replacement mesh, then runs the same old-vs-new topology/color comparison
+ * that drawSub() uses before drawing a GLB replacement. */
+int r3dgl_testCompareReplacementMesh(const char *containerLegacyName, int shapeId,
+                                     const unsigned char *legacyModel,
+                                     size_t legacyModelSize);
+#endif
 
 #endif /* R3D_GL_H */

--- a/src/r3d_replacement.h
+++ b/src/r3d_replacement.h
@@ -1,0 +1,33 @@
+#ifndef R3D_REPLACEMENT_H
+#define R3D_REPLACEMENT_H
+
+#include "inttype.h"
+
+typedef struct R3DReplacementPrim {
+    int mode; /* GL-style primitive mode: 4 triangles, 1 lines, 0 points. */
+    int nVerts;
+    int sourceKind;
+    int sourceIndex;
+    int sourceColor;
+    uint32 sourceFlags;
+    float rgba[4];
+    float *xyz;
+} R3DReplacementPrim;
+
+typedef struct R3DReplacementMesh {
+    char path[512];
+    int loaded;
+    int failed;
+    int compared;
+    int hasSourceMd5;
+    char sourceMd5[33];
+    int nPrims;
+    R3DReplacementPrim *prims;
+} R3DReplacementMesh;
+
+/* Shared modern 3D replacement loader. Renderers consume only mode/color/vertex
+ * data. source* fields are strict-validation proof metadata and are optional for
+ * third-party GLBs. */
+R3DReplacementMesh *r3d_replacementMesh(const char *containerLegacyName, int shapeId);
+
+#endif /* R3D_REPLACEMENT_H */

--- a/src/r3d_sw.c
+++ b/src/r3d_sw.c
@@ -6,12 +6,16 @@
  * precompute and raw-display-list rasterizer are software-backend internals
  * (integer Q15, no FPU) for the 386+ target. */
 #include "r3d.h"
+#include "r3d_replacement.h"
 #include "eg3dmap.h"
 #include "egcode.h"
 #include "egtypes.h"
 
 void far r3d_submitLineFar(long baseXA, long camXA, long camYA,
                            long baseXB, long camXB, long camYB, int color);
+void far projectReplacementSceneObject(char far *model, R3DReplacementMesh *replacement,
+                                       int yaw, int pitch, int roll,
+                                       int posX, int posY, int posZ);
 
 static const char *sw_name(void) { return "software"; }
 
@@ -35,6 +39,15 @@ static void sw_submit(const R3DSubmit *o) {
          * only by the GPU backend's flattened shadow). */
         projectSceneShadow((char far *)o->mesh, o->yaw, o->posX, o->posY, o->posZ);
         return;
+    }
+    {
+    R3DReplacementMesh *replacement = r3d_replacementMesh(o->containerLegacyName, o->shapeId);
+    if (replacement) {
+        projectReplacementSceneObject((char far *)o->mesh, replacement,
+                                      o->yaw, o->pitch, o->roll,
+                                      o->posX, o->posY, o->posZ);
+        return;
+    }
     }
     projectSceneObject((char far *)o->mesh, o->yaw, o->pitch, o->roll,
                        o->posX, o->posY, o->posZ);

--- a/src/shared/asset_compare.c
+++ b/src/shared/asset_compare.c
@@ -1,0 +1,14 @@
+/*
+ * asset_compare.c - test-only replacement comparison switch.
+ *
+ * Old-vs-modern equivalence proof belongs in CTest/Python validation, not in a
+ * normal game run. Keep the comparison helpers linkable for existing focused
+ * tests, but never enable them from runtime environment variables.
+ */
+
+#include "asset_compare.h"
+#include <stdlib.h>
+
+int assetCompareEnabled(void) {
+    return 0;
+}

--- a/src/shared/asset_compare.c
+++ b/src/shared/asset_compare.c
@@ -9,6 +9,20 @@
 #include "asset_compare.h"
 #include <stdlib.h>
 
+#ifdef DEBUG
+static int g_assetCompareTestEnabled;
+#endif
+
 int assetCompareEnabled(void) {
+#ifdef DEBUG
+    return g_assetCompareTestEnabled;
+#else
     return 0;
+#endif
 }
+
+#ifdef DEBUG
+void assetCompareTestSetEnabled(int enabled) {
+    g_assetCompareTestEnabled = enabled != 0;
+}
+#endif

--- a/src/shared/asset_compare.h
+++ b/src/shared/asset_compare.h
@@ -12,6 +12,9 @@
 #include <stddef.h>
 
 int assetCompareEnabled(void);
+#ifdef DEBUG
+void assetCompareTestSetEnabled(int enabled);
+#endif
 void assetCompareNamedBytes(const char *label,
                             const char *matchText,
                             const char *diffText,

--- a/src/shared/asset_compare.h
+++ b/src/shared/asset_compare.h
@@ -1,0 +1,91 @@
+/*
+ * asset_compare.h - replacement comparison helpers.
+ *
+ * Asset loaders should load modern media/table formats. Equivalence proof is
+ * run by tests/validation tooling, not by normal gameplay. The helpers remain
+ * isolated here so comparison policy does not leak into individual loaders.
+ */
+#ifndef F15_ASSET_COMPARE_H
+#define F15_ASSET_COMPARE_H
+
+#include "../inttype.h"
+#include <stddef.h>
+
+int assetCompareEnabled(void);
+void assetCompareNamedBytes(const char *label,
+                            const char *matchText,
+                            const char *diffText,
+                            const char *replacementValueName,
+                            const uint8 *legacyData,
+                            size_t legacySize,
+                            const uint8 *replacementData,
+                            size_t replacementSize,
+                            const char *replacementPath);
+void assetCompareStructuredBytes(const char *filename,
+                                 const uint8 *legacyData,
+                                 size_t legacySize,
+                                 const uint8 *replacementData,
+                                 size_t replacementSize,
+                                 const char *replacementPath);
+void assetCompareIndexedPixels2D(const char *label,
+                                 const uint8 *legacyPixels,
+                                 int legacyPitch,
+                                 const uint8 *replacementPixels,
+                                 int replacementPitch,
+                                 int width,
+                                 int height,
+                                 const char *replacementPath);
+void assetCompareRgbPalettes(const char *label,
+                             const uint8 *legacyRgb,
+                             int legacyCount,
+                             const uint8 *replacementRgb,
+                             int replacementCount,
+                             const char *replacementPath);
+void assetCompareFont96(const char *label,
+                        const uint8 *legacyBitmap,
+                        const uint8 *legacyWidths,
+                        int legacyHeight,
+                        int legacyWidth,
+                        const uint8 *replacementBitmap,
+                        const uint8 *replacementWidths,
+                        int replacementHeight,
+                        int replacementWidth,
+                        const char *replacementPath);
+void assetCompareSoundCueRange(const char *cueId,
+                               uint16 legacyStart,
+                               uint16 legacyEndInclusive,
+                               int legacySampleRate,
+                               const uint8 *legacyBlob,
+                               size_t legacyBlobSize,
+                               const uint8 *replacementSamples,
+                               size_t replacementSampleSize,
+                               int replacementSampleRate,
+                               const char *replacementPath);
+
+typedef struct AssetCompare3dShapeStats {
+    int shapeId;
+    int legacyForm;
+    int legacyFaces;
+    int legacyTriangles;
+    int legacyLines;
+    int legacyPoints;
+    int glbTriangles;
+    int glbLines;
+    int glbPoints;
+    int missingSourceMeta;
+    int missingSourceColor;
+    int badSourceOrder;
+    int badSourceMode;
+    int canCompareSourceColors;
+    const int *legacyFaceColor;
+    const int *legacyLineColor;
+    const int *legacyPointColor;
+    const int *glbFaceColor;
+    const int *glbLineColor;
+    const int *glbPointColor;
+    const char *replacementPath;
+} AssetCompare3dShapeStats;
+
+void assetCompare3dShapeStats(const AssetCompare3dShapeStats *stats);
+
+#endif /* F15_ASSET_COMPARE_H */

--- a/src/shared/asset_compare_3d.c
+++ b/src/shared/asset_compare_3d.c
@@ -1,0 +1,90 @@
+/*
+ * asset_compare_3d.c - renderer-independent 3D replacement diagnostics.
+ */
+
+#include "asset_compare.h"
+#include "../log.h"
+
+enum {
+    ASSET_COMPARE_3D_FORM_POINT = 1,
+    ASSET_COMPARE_3D_FORM_EDGERUN = 2
+};
+
+static void compareColorCoverage(const char *label,
+                                 int shapeId,
+                                 const int *legacy,
+                                 const int *replacement,
+                                 const char *replacementPath) {
+    int i;
+
+    if (!legacy || !replacement) return;
+    for (i = 0; i < 256; i++) {
+        if (legacy[i] != replacement[i]) {
+            LogWarn((
+                "asset replacement compare: shape %d GLB %s color coverage differs at raw color 0x%02x "
+                "(legacy=%d glb=%d, source=%s)",
+                shapeId,
+                label,
+                i,
+                legacy[i],
+                replacement[i],
+                replacementPath ? replacementPath : ""
+            ));
+            return;
+        }
+    }
+}
+
+void assetCompare3dShapeStats(const AssetCompare3dShapeStats *stats) {
+    if (!assetCompareEnabled() || !stats) return;
+
+    if (stats->missingSourceMeta) {
+        LogWarn(("asset replacement compare: shape %d runtime mesh cache lacks order-sensitive source metadata; custom GLB can still render, but original .3D3 order/color proof is unavailable", stats->shapeId));
+    } else if (stats->missingSourceColor) {
+        LogWarn(("asset replacement compare: shape %d runtime mesh cache lacks raw source color metadata; custom GLB can still render, but original .3D3 color proof is unavailable", stats->shapeId));
+    } else if (stats->badSourceOrder) {
+        LogWarn(("asset replacement compare: shape %d runtime mesh cache source primitive order is not monotonic; coplanar faces or line details may render differently", stats->shapeId));
+    } else if (stats->badSourceMode) {
+        LogWarn(("asset replacement compare: shape %d runtime mesh cache source primitive kind does not match GL draw mode; regenerate cache from GLB", stats->shapeId));
+    }
+
+    if (stats->legacyForm == ASSET_COMPARE_3D_FORM_POINT) {
+        if (stats->glbPoints == 1 && stats->glbTriangles == 0 && stats->glbLines == 0) {
+            LogInfo(("asset replacement compare: shape %d GLB point form matches legacy point form", stats->shapeId));
+        } else {
+            LogWarn(("asset replacement compare: shape %d GLB primitive form differs from legacy point (tri=%d line=%d point=%d, source=%s)",
+                     stats->shapeId, stats->glbTriangles, stats->glbLines, stats->glbPoints, stats->replacementPath ? stats->replacementPath : ""));
+        }
+        if (stats->canCompareSourceColors) {
+            compareColorCoverage("point", stats->shapeId, stats->legacyPointColor, stats->glbPointColor, stats->replacementPath);
+        }
+        return;
+    }
+
+    if (stats->legacyForm == ASSET_COMPARE_3D_FORM_EDGERUN) {
+        if (stats->glbPoints == stats->legacyPoints && stats->glbTriangles == 0 && stats->glbLines == 0) {
+            LogInfo(("asset replacement compare: shape %d GLB point run count matches legacy (%d)", stats->shapeId, stats->legacyPoints));
+        } else {
+            LogWarn(("asset replacement compare: shape %d GLB point run differs (legacy_points=%d glb_tri=%d glb_line=%d glb_point=%d, source=%s)",
+                     stats->shapeId, stats->legacyPoints, stats->glbTriangles, stats->glbLines, stats->glbPoints, stats->replacementPath ? stats->replacementPath : ""));
+        }
+        if (stats->canCompareSourceColors) {
+            compareColorCoverage("point-run", stats->shapeId, stats->legacyPointColor, stats->glbPointColor, stats->replacementPath);
+        }
+        return;
+    }
+
+    if (stats->glbTriangles == stats->legacyTriangles && stats->glbLines == stats->legacyLines) {
+        LogInfo(("asset replacement compare: shape %d GLB topology matches legacy (legacy_faces=%d legacy_tri=%d legacy_lines=%d)",
+                 stats->shapeId, stats->legacyFaces, stats->legacyTriangles, stats->legacyLines));
+    } else {
+        LogWarn(("asset replacement compare: shape %d GLB topology differs (legacy_faces=%d legacy_tri=%d legacy_lines=%d glb_tri=%d glb_line=%d, source=%s)",
+                 stats->shapeId, stats->legacyFaces, stats->legacyTriangles, stats->legacyLines,
+                 stats->glbTriangles, stats->glbLines, stats->replacementPath ? stats->replacementPath : ""));
+    }
+
+    if (stats->canCompareSourceColors) {
+        compareColorCoverage("face", stats->shapeId, stats->legacyFaceColor, stats->glbFaceColor, stats->replacementPath);
+        compareColorCoverage("line", stats->shapeId, stats->legacyLineColor, stats->glbLineColor, stats->replacementPath);
+    }
+}

--- a/src/shared/asset_compare_bytes.c
+++ b/src/shared/asset_compare_bytes.c
@@ -1,0 +1,92 @@
+/*
+ * asset_compare_bytes.c - byte-stream replacement diagnostics.
+ */
+
+#include "asset_compare.h"
+#include "../log.h"
+
+void assetCompareNamedBytes(const char *label,
+                            const char *matchText,
+                            const char *diffText,
+                            const char *replacementValueName,
+                            const uint8 *legacyData,
+                            size_t legacySize,
+                            const uint8 *replacementData,
+                            size_t replacementSize,
+                            const char *replacementPath) {
+    size_t commonSize;
+    size_t firstDiff;
+
+    if (!assetCompareEnabled()) return;
+    if (!label || !legacyData || !replacementData) return;
+    if (!matchText) matchText = "replacement bytes match legacy bytes";
+    if (!diffText) diffText = "replacement differs";
+    if (!replacementValueName) replacementValueName = "replacement";
+
+    if (legacySize == replacementSize) {
+        size_t i;
+        int same = 1;
+        for (i = 0; i < legacySize; i++) {
+            if (legacyData[i] != replacementData[i]) {
+                same = 0;
+                break;
+            }
+        }
+        if (same) {
+            LogInfo(("asset replacement compare: %s %s (%zu bytes)", label, matchText, replacementSize));
+            return;
+        }
+    }
+
+    commonSize = legacySize < replacementSize ? legacySize : replacementSize;
+    firstDiff = 0;
+    while (firstDiff < commonSize && legacyData[firstDiff] == replacementData[firstDiff]) {
+        firstDiff++;
+    }
+    if (firstDiff < commonSize) {
+        LogWarn((
+            "asset replacement compare: %s %s at byte %zu "
+            "(legacy=0x%02x %s=0x%02x, legacy_size=%zu %s_size=%zu, replacement=%s)",
+            label,
+            diffText,
+            firstDiff,
+            (unsigned int)legacyData[firstDiff],
+            replacementValueName,
+            (unsigned int)replacementData[firstDiff],
+            legacySize,
+            replacementValueName,
+            replacementSize,
+            replacementPath ? replacementPath : ""
+        ));
+    } else {
+        LogWarn((
+            "asset replacement compare: %s %s length differs "
+            "(legacy_size=%zu %s_size=%zu, replacement=%s)",
+            label,
+            diffText,
+            legacySize,
+            replacementValueName,
+            replacementSize,
+            replacementPath ? replacementPath : ""
+        ));
+    }
+}
+
+void assetCompareStructuredBytes(const char *filename,
+                                 const uint8 *legacyData,
+                                 size_t legacySize,
+                                 const uint8 *replacementData,
+                                 size_t replacementSize,
+                                 const char *replacementPath) {
+    assetCompareNamedBytes(
+        filename,
+        "JSON rebuild matches legacy bytes",
+        "JSON rebuild differs",
+        "replacement",
+        legacyData,
+        legacySize,
+        replacementData,
+        replacementSize,
+        replacementPath
+    );
+}

--- a/src/shared/asset_compare_font.c
+++ b/src/shared/asset_compare_font.c
@@ -1,0 +1,72 @@
+/*
+ * asset_compare_font.c - bitmap font replacement diagnostics.
+ */
+
+#include "asset_compare.h"
+#include "../log.h"
+
+void assetCompareFont96(const char *label,
+                        const uint8 *legacyBitmap,
+                        const uint8 *legacyWidths,
+                        int legacyHeight,
+                        int legacyWidth,
+                        const uint8 *replacementBitmap,
+                        const uint8 *replacementWidths,
+                        int replacementHeight,
+                        int replacementWidth,
+                        const char *replacementPath) {
+    int i;
+    int row;
+
+    if (!assetCompareEnabled()) return;
+    if (!label || !legacyBitmap || !legacyWidths || !replacementBitmap || !replacementWidths) return;
+    if (legacyHeight <= 0 || legacyWidth <= 0 || replacementHeight <= 0 || replacementWidth <= 0) return;
+
+    if (replacementHeight != legacyHeight || replacementWidth != legacyWidth) {
+        LogWarn((
+            "asset replacement compare: %s metrics differ "
+            "(builtin=%dx%d replacement=%dx%d, source=%s)",
+            label,
+            legacyWidth,
+            legacyHeight,
+            replacementWidth,
+            replacementHeight,
+            replacementPath ? replacementPath : ""
+        ));
+        return;
+    }
+
+    for (i = 0; i < 96; i++) {
+        if (replacementWidths[i] != legacyWidths[i]) {
+            LogWarn((
+                "asset replacement compare: %s width differs for glyph 0x%02x "
+                "(builtin=%u replacement=%u, source=%s)",
+                label,
+                i + 0x20,
+                (unsigned)legacyWidths[i],
+                (unsigned)replacementWidths[i],
+                replacementPath ? replacementPath : ""
+            ));
+            return;
+        }
+        for (row = 0; row < legacyHeight; row++) {
+            uint8 legacyByte = legacyBitmap[(i * legacyHeight) + row];
+            uint8 replacementByte = replacementBitmap[(i * replacementHeight) + row];
+            if (replacementByte != legacyByte) {
+                LogWarn((
+                    "asset replacement compare: %s bitmap differs for glyph 0x%02x row %d "
+                    "(builtin=0x%02x replacement=0x%02x, source=%s)",
+                    label,
+                    i + 0x20,
+                    row,
+                    (unsigned)legacyByte,
+                    (unsigned)replacementByte,
+                    replacementPath ? replacementPath : ""
+                ));
+                return;
+            }
+        }
+    }
+
+    LogInfo(("asset replacement compare: %s replacement matches built-in glyph rows and widths", label));
+}

--- a/src/shared/asset_compare_image.c
+++ b/src/shared/asset_compare_image.c
@@ -1,0 +1,92 @@
+/*
+ * asset_compare_image.c - indexed image and palette replacement diagnostics.
+ */
+
+#include "asset_compare.h"
+#include "../log.h"
+
+void assetCompareIndexedPixels2D(const char *label,
+                                 const uint8 *legacyPixels,
+                                 int legacyPitch,
+                                 const uint8 *replacementPixels,
+                                 int replacementPitch,
+                                 int width,
+                                 int height,
+                                 const char *replacementPath) {
+    int x;
+    int y;
+
+    if (!assetCompareEnabled()) return;
+    if (!label || !legacyPixels || !replacementPixels || width <= 0 || height <= 0) return;
+
+    for (y = 0; y < height; y++) {
+        const uint8 *legacyRow = legacyPixels + (size_t)y * (size_t)legacyPitch;
+        const uint8 *replacementRow = replacementPixels + (size_t)y * (size_t)replacementPitch;
+        for (x = 0; x < width; x++) {
+            if (legacyRow[x] != replacementRow[x]) {
+                LogWarn((
+                    "asset replacement compare: %s PNG pixels differ at %d,%d "
+                    "(legacy=0x%02x png=0x%02x, png=%s)",
+                    label,
+                    x,
+                    y,
+                    (unsigned int)legacyRow[x],
+                    (unsigned int)replacementRow[x],
+                    replacementPath ? replacementPath : ""
+                ));
+                return;
+            }
+        }
+    }
+
+    LogInfo(("asset replacement compare: %s PNG pixels match legacy decode in %dx%d surface", label, width, height));
+}
+
+void assetCompareRgbPalettes(const char *label,
+                             const uint8 *legacyRgb,
+                             int legacyCount,
+                             const uint8 *replacementRgb,
+                             int replacementCount,
+                             const char *replacementPath) {
+    int i;
+    int commonCount;
+
+    if (!assetCompareEnabled()) return;
+    if (!label || !legacyRgb || !replacementRgb || legacyCount <= 0 || replacementCount <= 0) return;
+
+    commonCount = legacyCount < replacementCount ? legacyCount : replacementCount;
+    for (i = 0; i < commonCount; i++) {
+        const uint8 *legacy = legacyRgb + i * 3;
+        const uint8 *replacement = replacementRgb + i * 3;
+        if (legacy[0] != replacement[0] || legacy[1] != replacement[1] || legacy[2] != replacement[2]) {
+            LogWarn((
+                "asset replacement compare: %s PNG palette differs at index %d "
+                "(legacy=%02x,%02x,%02x png=%02x,%02x,%02x, png=%s)",
+                label,
+                i,
+                (unsigned int)legacy[0],
+                (unsigned int)legacy[1],
+                (unsigned int)legacy[2],
+                (unsigned int)replacement[0],
+                (unsigned int)replacement[1],
+                (unsigned int)replacement[2],
+                replacementPath ? replacementPath : ""
+            ));
+            return;
+        }
+    }
+
+    if (legacyCount != replacementCount) {
+        LogWarn((
+            "asset replacement compare: %s PNG palette entry count differs "
+            "(legacy=%d png=%d, png=%s)",
+            label,
+            legacyCount,
+            replacementCount,
+            replacementPath ? replacementPath : ""
+        ));
+        return;
+    }
+
+    LogInfo(("asset replacement compare: %s PNG embedded palette matches active legacy DAC (%d entries)", label, replacementCount));
+}

--- a/src/shared/asset_compare_sound.c
+++ b/src/shared/asset_compare_sound.c
@@ -1,0 +1,59 @@
+/*
+ * asset_compare_sound.c - digitized cue WAV replacement diagnostics.
+ */
+
+#include "asset_compare.h"
+#include "../log.h"
+
+#include <stdio.h>
+
+void assetCompareSoundCueRange(const char *cueId,
+                               uint16 legacyStart,
+                               uint16 legacyEndInclusive,
+                               int legacySampleRate,
+                               const uint8 *legacyBlob,
+                               size_t legacyBlobSize,
+                               const uint8 *replacementSamples,
+                               size_t replacementSampleSize,
+                               int replacementSampleRate,
+                               const char *replacementPath) {
+    size_t start;
+    size_t end;
+    char label[128];
+
+    if (!assetCompareEnabled() || !cueId || !replacementSamples) return;
+    if (legacySampleRate > 0 && replacementSampleRate > 0 && legacySampleRate != replacementSampleRate) {
+        LogWarn((
+            "asset replacement compare: cue %s WAV sample rate differs "
+            "(legacy=%d wav=%d, replacement=%s)",
+            cueId,
+            legacySampleRate,
+            replacementSampleRate,
+            replacementPath ? replacementPath : ""
+        ));
+    }
+    if (!legacyBlob || legacyBlobSize == 0) {
+        LogWarn(("asset replacement compare: no legacy F15DGTL.BIN available for cue WAV %s", replacementPath));
+        return;
+    }
+
+    start = (size_t)legacyStart;
+    end = (size_t)legacyEndInclusive + 1u;
+    if (start >= end || end > legacyBlobSize) {
+        LogWarn(("asset replacement compare: legacy cue range invalid for %s", cueId));
+        return;
+    }
+
+    snprintf(label, sizeof(label), "cue %s", cueId);
+    assetCompareNamedBytes(
+        label,
+        "WAV samples match legacy range",
+        "WAV differs",
+        "wav",
+        legacyBlob + start,
+        end - start,
+        replacementSamples,
+        replacementSampleSize,
+        replacementPath
+    );
+}

--- a/src/shared/common.h
+++ b/src/shared/common.h
@@ -36,10 +36,17 @@ void mystrcpy(char *dest, const char *source);
 void loadPic(const char *filename, int segment);
 void openShowPic(const char *filename, int page);
 void showPicFile(SDL_IOStream *handle, int pageNum);
+int loadReplacementPngToPage(const char *filename, int page);
+int loadReplacementPngToHiResTitle(const char *filename);
 
 /* functions provided by file_io.c / file_*.inc - case-insensitive asset I/O */
 SDL_IOStream *openFile(const char *filename, int mode);
 SDL_IOStream *createFile(const char *filename, int attr);
+int findReplacementAssetPath(const char *legacyFilename, const char *modernExt,
+                             char *outPath, size_t outPathSize);
+int findReplacementShapeModelPath(const char *containerLegacyFilename, int shapeId,
+                                  const char *modernExt, char *outPath,
+                                  size_t outPathSize);
 void fileClose(SDL_IOStream *handle);
 size_t fileRead(void *ptr, size_t size, size_t count, SDL_IOStream *handle);
 size_t fileWrite(const void *ptr, size_t size, size_t count, SDL_IOStream *handle);

--- a/src/shared/file_io.c
+++ b/src/shared/file_io.c
@@ -3,6 +3,7 @@
  */
 
 #include "inttype.h"
+#include "asset_compare.h"
 #include "log.h"
 #include <SDL3/SDL.h>
 #include <quickdigest5.hpp>
@@ -14,10 +15,14 @@
 #include <filesystem>
 #include <algorithm>
 #include <vector>
+#include <cstdio>
+#include <memory>
+#include <system_error>
 
 using namespace std;
 namespace fs = std::filesystem;
 fs::path gamePath = ".";
+static vector<unique_ptr<vector<uint8>>> g_replacementIoBuffers;
 
 /* Sets the directory to read game assets from, default is current dir */
 bool setGamePath(const char* path) {
@@ -58,10 +63,582 @@ static string resolveCasePath(const char *filename, const bool require = false) 
     return require ? "" : filePath.string();
 }
 
+static string upperString(string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+        [](unsigned char c){ return std::toupper(c); });
+    return value;
+}
+
+static string replacementDirForLegacy(const fs::path &legacy) {
+    string stem = upperString(legacy.stem().string());
+    if (stem == "LB") return "LIBYA";
+    if (stem == "PG") return "GULF";
+    return stem;
+}
+
+static string lowerString(string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+        [](unsigned char c){ return std::tolower(c); });
+    return value;
+}
+
+static fs::path caseMappedPath(fs::path path, string (*mapper)(string)) {
+    fs::path out;
+    for (const fs::path &part : path) {
+        out /= mapper(part.string());
+    }
+    return out;
+}
+
+static string shellQuote(const string &value) {
+    string out = "'";
+    for (char c : value) {
+        if (c == '\'') out += "'\\''";
+        else out += c;
+    }
+    out += "'";
+    return out;
+}
+
+static void addReplacementCandidate(vector<fs::path> &candidates, const fs::path &path) {
+    if (std::find(candidates.begin(), candidates.end(), path) == candidates.end()) {
+        candidates.push_back(path);
+    }
+}
+
+static string defaultAssetToolCommand(const fs::path &assetHint) {
+    const char *tool = getenv("F15_ASSET_TOOL");
+    const char *replacementRoot = getenv("F15_REPLACEMENT_ROOT");
+    if (tool && tool[0]) return string(tool);
+
+    /* Prefer a script path when the repo/tools folder is near the current
+     * working directory. The module form below only works when the repository
+     * root is already on Python's import path. */
+    vector<fs::path> candidates;
+    fs::path cursor = assetHint;
+    if (!cursor.empty() && cursor.has_filename()) cursor = cursor.parent_path();
+    while (!cursor.empty()) {
+        if (cursor.filename() == "converted_assets_all") {
+            addReplacementCandidate(candidates, cursor.parent_path() / "tools/f15assets/cli.py");
+            break;
+        }
+        fs::path parent = cursor.parent_path();
+        if (parent == cursor) break;
+        cursor = cursor.parent_path();
+    }
+    if (replacementRoot && replacementRoot[0]) {
+        fs::path replacementPath{replacementRoot};
+        /* Explicit replacement roots often live outside the repo. Try likely
+         * repo-adjacent tool paths before falling back to module import; packaged
+         * builds can always set F15_ASSET_TOOL to bypass this heuristic. */
+        addReplacementCandidate(candidates, replacementPath.parent_path() / "tools/f15assets/cli.py");
+        addReplacementCandidate(candidates, replacementPath / "../tools/f15assets/cli.py");
+        addReplacementCandidate(candidates, replacementPath / "tools/f15assets/cli.py");
+        addReplacementCandidate(candidates, replacementPath / "converted_assets_all/../tools/f15assets/cli.py");
+    }
+    addReplacementCandidate(candidates, fs::path{"tools/f15assets/cli.py"});
+    addReplacementCandidate(candidates, fs::path{"../tools/f15assets/cli.py"});
+    addReplacementCandidate(candidates, fs::path{"../../tools/f15assets/cli.py"});
+    for (const fs::path &candidate : candidates) {
+        if (fs::exists(candidate)) return string("python3 ") + shellQuote(candidate.string());
+    }
+    return string("python3 -m tools.f15assets.cli");
+}
+
+static vector<fs::path> replacementSearchRoots(void) {
+    vector<fs::path> roots;
+    const char *replacementRootEnv = getenv("F15_REPLACEMENT_ROOT");
+    static int warnedInvalidReplacementRoot = 0;
+    /* Explicit custom-pack root. This keeps original DOS assets in gamePath
+     * while loading modern replacements from an external converted tree. The
+     * env var may point either at converted_assets_all itself or at a parent
+     * containing it; missing directories are ignored. The remaining roots
+     * preserve older workflows: converted_assets_all beside the game path,
+     * converted_assets_all in the current working directory, then direct
+     * gamePath/current-directory replacement files. */
+    if (replacementRootEnv && replacementRootEnv[0]) {
+        fs::path replacementRoot{replacementRootEnv};
+        std::error_code ec;
+        int addedExplicitRoot = 0;
+        if (fs::is_directory(replacementRoot, ec)) {
+            addReplacementCandidate(roots, replacementRoot);
+            addedExplicitRoot = 1;
+        }
+        ec.clear();
+        if (fs::is_directory(replacementRoot / "converted_assets_all", ec)) {
+            addReplacementCandidate(roots, replacementRoot / "converted_assets_all");
+            addedExplicitRoot = 1;
+        }
+        if (!addedExplicitRoot && !warnedInvalidReplacementRoot) {
+            warnedInvalidReplacementRoot = 1;
+            LogWarn(("asset replacement: F15_REPLACEMENT_ROOT does not name an existing replacement directory: %s", replacementRootEnv));
+        }
+    }
+    addReplacementCandidate(roots, gamePath / "converted_assets_all");
+    addReplacementCandidate(roots, fs::path{"converted_assets_all"});
+    addReplacementCandidate(roots, gamePath);
+    addReplacementCandidate(roots, fs::path{"."});
+    return roots;
+}
+
+static vector<fs::path> recursiveReplacementSearchRoots(void) {
+    vector<fs::path> roots;
+    const char *replacementRootEnv = getenv("F15_REPLACEMENT_ROOT");
+
+    /* Recursive fallback is useful for converted asset trees that preserve
+     * campaign/theater subdirectories, but it must not walk arbitrary gamePath
+     * or process-current directories. Those roots can be large repos/home dirs
+     * and may contain unrelated same-named files. */
+    if (replacementRootEnv && replacementRootEnv[0]) {
+        fs::path replacementRoot{replacementRootEnv};
+        std::error_code ec;
+        if (fs::is_directory(replacementRoot, ec)) {
+            addReplacementCandidate(roots, replacementRoot);
+        }
+        ec.clear();
+        if (fs::is_directory(replacementRoot / "converted_assets_all", ec)) {
+            addReplacementCandidate(roots, replacementRoot / "converted_assets_all");
+        }
+    }
+    addReplacementCandidate(roots, gamePath / "converted_assets_all");
+    addReplacementCandidate(roots, fs::path{"converted_assets_all"});
+    return roots;
+}
+
+static void addRecursiveReplacementCandidates(vector<fs::path> &candidates,
+                                              const fs::path &root,
+                                              const string &filename) {
+    std::error_code ec;
+    const string filenameLower = lowerString(filename);
+    if (!fs::is_directory(root, ec)) return;
+    /* convert-all preserves campaign/theater subdirectories below
+     * converted_assets_all. Keep direct candidates first, then use this bounded
+     * fallback so runtime loading can find recursive conversion output. */
+    for (const fs::directory_entry &entry : fs::recursive_directory_iterator(root, ec)) {
+        if (ec) break;
+        if (!entry.is_regular_file(ec)) continue;
+        if (lowerString(entry.path().filename().string()) == filenameLower) {
+            addReplacementCandidate(candidates, entry.path());
+        }
+    }
+}
+
+/* Resolve a modern replacement asset next to converted exports.
+ *
+ * `legacyFilename` is the original game filename ("LB.3D3", "Libya.wld",
+ * "TITLE.PIC"). `modernExt` is the preferred modern extension, including dot
+ * (".glb", ".json", ".png", ".wav"). The media file is authoritative when it
+ * overlaps JSON sidecar metadata.
+ */
+int findReplacementAssetPath(const char *legacyFilename, const char *modernExt,
+                             char *outPath, size_t outPathSize) {
+    if (!legacyFilename || !modernExt || !outPath || outPathSize == 0) return 0;
+
+    fs::path legacy{legacyFilename};
+    const string stem = upperString(legacy.stem().string());
+    const string ext = upperString(legacy.extension().string());
+    const string dir = replacementDirForLegacy(legacy);
+    const string modern = modernExt;
+    const fs::path legacyParent = legacy.parent_path();
+
+    vector<fs::path> candidates;
+    vector<fs::path> replacementRoots = replacementSearchRoots();
+    vector<fs::path> recursiveRoots = recursiveReplacementSearchRoots();
+
+    const string nameWithLegacyExt = stem + ext + modern;
+    const string nameWithoutLegacyExt = stem + modern;
+    const string lowerNameWithLegacyExt = lowerString(nameWithLegacyExt);
+    const string lowerNameWithoutLegacyExt = lowerString(nameWithoutLegacyExt);
+
+    if (!legacyParent.empty()) {
+        vector<fs::path> scopedParents;
+        addReplacementCandidate(scopedParents, legacyParent);
+        addReplacementCandidate(scopedParents, caseMappedPath(legacyParent, upperString));
+        addReplacementCandidate(scopedParents, caseMappedPath(legacyParent, lowerString));
+        for (const fs::path &root : replacementRoots) {
+            for (const fs::path &scopedParent : scopedParents) {
+                const fs::path scopedRoot = root / scopedParent;
+                if (stem.rfind("VOICE_CUE_", 0) == 0 && modern == ".wav") {
+                    addReplacementCandidate(candidates, scopedRoot / "sounds" / (lowerString(stem) + ".wav"));
+                }
+                if (stem.rfind("FONT_", 0) == 0 && (modern == ".bdf" || modern == ".png")) {
+                    addReplacementCandidate(candidates, scopedRoot / "fonts" / (lowerString(stem) + modern));
+                }
+                addReplacementCandidate(candidates, scopedRoot / dir / nameWithLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / dir / lowerNameWithLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / dir / nameWithoutLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / dir / lowerNameWithoutLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / nameWithLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / lowerNameWithLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / nameWithoutLegacyExt);
+                addReplacementCandidate(candidates, scopedRoot / lowerNameWithoutLegacyExt);
+            }
+        }
+    }
+    for (const fs::path &root : replacementRoots) {
+        if (stem.rfind("VOICE_CUE_", 0) == 0 && modern == ".wav") {
+            addReplacementCandidate(candidates, root / "sounds" / (lowerString(stem) + ".wav"));
+        }
+        if (stem.rfind("FONT_", 0) == 0 && (modern == ".bdf" || modern == ".png")) {
+            addReplacementCandidate(candidates, root / "fonts" / (lowerString(stem) + modern));
+        }
+        addReplacementCandidate(candidates, root / dir / nameWithLegacyExt);
+        addReplacementCandidate(candidates, root / dir / lowerNameWithLegacyExt);
+        addReplacementCandidate(candidates, root / dir / nameWithoutLegacyExt);
+        addReplacementCandidate(candidates, root / dir / lowerNameWithoutLegacyExt);
+        addReplacementCandidate(candidates, root / nameWithLegacyExt);
+        addReplacementCandidate(candidates, root / lowerNameWithLegacyExt);
+        addReplacementCandidate(candidates, root / nameWithoutLegacyExt);
+        addReplacementCandidate(candidates, root / lowerNameWithoutLegacyExt);
+    }
+    for (const fs::path &root : recursiveRoots) {
+        addRecursiveReplacementCandidates(candidates, root, nameWithLegacyExt);
+        addRecursiveReplacementCandidates(candidates, root, nameWithoutLegacyExt);
+    }
+
+    for (const fs::path &candidate : candidates) {
+        if (!fs::exists(candidate)) continue;
+        const string resolved = candidate.string();
+        std::snprintf(outPath, outPathSize, "%s", resolved.c_str());
+        return 1;
+    }
+
+    outPath[0] = 0;
+    return 0;
+}
+
+/* Resolve an editable per-shape 3D replacement exported beside a .3D3/.WLD group.
+ *
+ * The converter writes shape files as `shape_###.glb` or
+ * `shape_###_<derived label>.glb` directly in the extensionless asset directory
+ * (for example `converted_assets_all/VN/shape_049_SAM_Radar.glb`).  The label is
+ * only for humans; the stable lookup key is the original shape slot number.
+ */
+int findReplacementShapeModelPath(const char *containerLegacyFilename, int shapeId,
+                                  const char *modernExt, char *outPath,
+                                  size_t outPathSize) {
+    if (!containerLegacyFilename || !modernExt || !outPath || outPathSize == 0) return 0;
+    if (shapeId < 0 || shapeId > 999) return 0;
+
+    fs::path legacy{containerLegacyFilename};
+    const string dir = replacementDirForLegacy(legacy);
+    const string lowerDir = lowerString(dir);
+    const string modern = modernExt;
+    const fs::path legacyParent = legacy.parent_path();
+    char exactName[32];
+    string lowerExactName;
+    char prefix[32];
+    std::snprintf(exactName, sizeof(exactName), "shape_%03d%s", shapeId, modern.c_str());
+    lowerExactName = lowerString(exactName);
+    std::snprintf(prefix, sizeof(prefix), "shape_%03d_", shapeId);
+    vector<fs::path> replacementRoots = replacementSearchRoots();
+    vector<fs::path> recursiveRoots = recursiveReplacementSearchRoots();
+
+    vector<fs::path> roots;
+    if (!legacyParent.empty()) {
+        vector<fs::path> scopedParents;
+        addReplacementCandidate(scopedParents, legacyParent);
+        addReplacementCandidate(scopedParents, caseMappedPath(legacyParent, upperString));
+        addReplacementCandidate(scopedParents, caseMappedPath(legacyParent, lowerString));
+        for (const fs::path &root : replacementRoots) {
+            for (const fs::path &scopedParent : scopedParents) {
+                addReplacementCandidate(roots, root / scopedParent / dir);
+                addReplacementCandidate(roots, root / scopedParent / lowerDir);
+                addReplacementCandidate(roots, root / scopedParent);
+            }
+        }
+    }
+    for (const fs::path &root : replacementRoots) {
+        addReplacementCandidate(roots, root / dir);
+        addReplacementCandidate(roots, root / lowerDir);
+        addReplacementCandidate(roots, root);
+    }
+    for (const fs::path &convertedRoot : recursiveRoots) {
+        std::error_code ec;
+        if (!fs::is_directory(convertedRoot, ec)) continue;
+        for (const fs::directory_entry &entry : fs::recursive_directory_iterator(convertedRoot, ec)) {
+            if (ec) break;
+            if (!entry.is_directory(ec)) continue;
+            if (lowerString(entry.path().filename().string()) == lowerDir) {
+                addReplacementCandidate(roots, entry.path());
+            }
+        }
+    }
+
+    for (const fs::path &root : roots) {
+        if (modern == ".glmesh") {
+            const fs::path cached = root / "cache" / exactName;
+            if (fs::exists(cached)) {
+                const string resolved = cached.string();
+                std::snprintf(outPath, outPathSize, "%s", resolved.c_str());
+                return 1;
+            }
+        }
+        const fs::path exact = root / exactName;
+        if (fs::exists(exact)) {
+            const string resolved = exact.string();
+            std::snprintf(outPath, outPathSize, "%s", resolved.c_str());
+            return 1;
+        }
+        const fs::path lowerExact = root / lowerExactName;
+        if (fs::exists(lowerExact)) {
+            const string resolved = lowerExact.string();
+            std::snprintf(outPath, outPathSize, "%s", resolved.c_str());
+            return 1;
+        }
+    }
+
+    for (const fs::path &root : roots) {
+        std::error_code ec;
+        vector<fs::path> scanRoots;
+        addReplacementCandidate(scanRoots, root);
+        if (modern == ".glmesh") addReplacementCandidate(scanRoots, root / "cache");
+        for (const fs::path &scanRoot : scanRoots) {
+            if (!fs::is_directory(scanRoot, ec)) continue;
+            for (const fs::directory_entry &entry : fs::directory_iterator(scanRoot, ec)) {
+                if (ec) break;
+                if (!entry.is_regular_file(ec)) continue;
+                const fs::path path = entry.path();
+                const string filename = path.filename().string();
+                const string lowerFilename = lowerString(filename);
+                if (lowerFilename != lowerExactName && lowerFilename.rfind(lowerString(prefix), 0) != 0) continue;
+                if (lowerString(path.extension().string()) != lowerString(modern)) continue;
+                const string resolved = path.string();
+                std::snprintf(outPath, outPathSize, "%s", resolved.c_str());
+                return 1;
+            }
+        }
+    }
+
+    outPath[0] = 0;
+    return 0;
+}
+
+static const char *preferredModernExtForLegacy(const char *filename) {
+    if (!filename) return NULL;
+    fs::path legacy{filename};
+    const string ext = upperString(legacy.extension().string());
+    if (ext == ".3D3") return ".glb";
+    if (ext == ".PIC" || ext == ".SPR") return ".png";
+    if (ext == ".WLD" || ext == ".3DT" || ext == ".3DG") return ".json";
+    return NULL;
+}
+
+static const char *structuredFormatForLegacy(const char *filename) {
+    if (!filename) return NULL;
+    fs::path legacy{filename};
+    const string ext = upperString(legacy.extension().string());
+    if (ext == ".WLD") return "WLD";
+    if (ext == ".3D3") return "3D3";
+    if (ext == ".3DT") return "3DT";
+    if (ext == ".3DG") return "3DG";
+    return NULL;
+}
+
+static unique_ptr<vector<uint8>> readHostFileBytes(const string &path, size_t maxBytes) {
+    FILE *fp = fopen(path.c_str(), "rb");
+    unique_ptr<vector<uint8>> data;
+    unsigned char chunk[4096];
+    size_t got;
+
+    if (!fp) return nullptr;
+    data = make_unique<vector<uint8>>();
+    while ((got = fread(chunk, 1, sizeof(chunk), fp)) > 0) {
+        data->insert(data->end(), chunk, chunk + got);
+        if (data->size() > maxBytes) {
+            fclose(fp);
+            return nullptr;
+        }
+    }
+    if (ferror(fp)) {
+        fclose(fp);
+        return nullptr;
+    }
+    fclose(fp);
+    return data;
+}
+
+static int structuredJsonHasProperty(const char *path, const char *key) {
+    unique_ptr<vector<uint8>> data;
+    string text;
+    size_t pos = 0;
+
+    if (!path || !key) return 0;
+    data = readHostFileBytes(path, 1024 * 1024);
+    if (!data) return 0;
+    text.assign((const char *)data->data(), data->size());
+    /* This is only a cheap bridge gate, not JSON parsing. For .3D3, default
+     * minimized sidecars are metadata-only and must not invoke build-binary;
+     * full bridge dumps include the quoted "model_data" property. The Python
+     * tool remains the authority for parsing and rebuilding actual JSON. */
+    while ((pos = text.find(key, pos)) != string::npos) {
+        size_t scan = pos + strlen(key);
+        while (scan < text.size() && isspace((unsigned char)text[scan])) scan++;
+        if (scan < text.size() && text[scan] == ':') return 1;
+        pos++;
+    }
+    return 0;
+}
+
+static void compareStructuredReplacementWithLegacy(const char *filename,
+                                                   const vector<uint8> &replacementData,
+                                                   const char *replacementPath) {
+    unique_ptr<vector<uint8>> legacyData;
+    string legacyPath;
+
+    if (!assetCompareEnabled()) return;
+
+    legacyPath = resolveCasePath(filename, true);
+    if (legacyPath.empty()) {
+        LogWarn(("asset replacement compare: legacy file missing for %s; replacement=%s", filename, replacementPath));
+        return;
+    }
+    legacyData = readHostFileBytes(legacyPath, 1024 * 1024);
+    if (!legacyData) {
+        LogWarn(("asset replacement compare: failed to read legacy file %s for %s", legacyPath.c_str(), filename));
+        return;
+    }
+    assetCompareStructuredBytes(
+        filename,
+        legacyData->data(),
+        legacyData->size(),
+        replacementData.data(),
+        replacementData.size(),
+        replacementPath
+    );
+}
+
+static SDL_IOStream *openStructuredJsonReplacement(const char *filename) {
+    char replacementPath[512];
+    const char *fmt = structuredFormatForLegacy(filename);
+    string command;
+    FILE *pipe;
+    unique_ptr<vector<uint8>> data;
+    unsigned char chunk[4096];
+    size_t got;
+    int status;
+
+    if (!fmt) return NULL;
+    if (!findReplacementAssetPath(filename, ".json", replacementPath, sizeof(replacementPath))) {
+        return NULL;
+    }
+    if (strcmp(fmt, "3D3") == 0 && !structuredJsonHasProperty(replacementPath, "\"model_data\"")) {
+        LogInfo((
+            "asset replacement: found minimized .3D3 JSON index for %s at %s; "
+            "geometry uses GLB and the .3D3 byte stream remains the table/fallback source",
+            filename,
+            replacementPath
+        ));
+        return NULL;
+    }
+
+    /* WLD/3DT/3DG and full .3D3 dumps are structured legacy byte streams, not
+     * media files, so JSON is the editable modern source. Until the game has
+     * native JSON importers, rebuild the exact legacy byte stream here and feed
+     * it to the proven old loader. */
+    command = defaultAssetToolCommand(fs::path{replacementPath});
+    command += " build-binary ";
+    command += shellQuote(replacementPath);
+    command += " --format ";
+    command += fmt;
+
+    pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+        LogWarn(("asset replacement: failed to run JSON importer for %s; using legacy binary", filename));
+        return NULL;
+    }
+
+    data = make_unique<vector<uint8>>();
+    while ((got = fread(chunk, 1, sizeof(chunk), pipe)) > 0) {
+        data->insert(data->end(), chunk, chunk + got);
+        if (data->size() > 1024 * 1024) {
+            LogWarn(("asset replacement: JSON importer output too large for %s; using legacy binary", filename));
+            pclose(pipe);
+            return NULL;
+        }
+    }
+    status = pclose(pipe);
+    if (status != 0 || data->empty()) {
+        LogWarn(("asset replacement: JSON importer failed for %s from %s; using legacy binary", filename, replacementPath));
+        return NULL;
+    }
+
+    compareStructuredReplacementWithLegacy(filename, *data, replacementPath);
+
+    SDL_IOStream *io = SDL_IOFromConstMem(data->data(), data->size());
+    if (!io) {
+        LogWarn(("asset replacement: failed to open rebuilt JSON bytes for %s; using legacy binary", filename));
+        return NULL;
+    }
+    g_replacementIoBuffers.push_back(std::move(data));
+    LogInfo(("asset replacement: loaded %s from JSON %s (%zu bytes)", filename, replacementPath, g_replacementIoBuffers.back()->size()));
+    return io;
+}
+
+static void logPreferredReplacementIfPresent(const char *filename) {
+    char replacementPath[512];
+    const char *modernExt = preferredModernExtForLegacy(filename);
+    fs::path legacy{filename ? filename : ""};
+    const string ext = filename ? upperString(legacy.extension().string()) : "";
+    if (!modernExt) return;
+    if (ext == ".PIC" || ext == ".SPR" || ext == ".WLD" || ext == ".3DT" || ext == ".3DG") {
+        return;
+    }
+    if (!findReplacementAssetPath(filename, modernExt, replacementPath, sizeof(replacementPath))) return;
+    if (ext == ".3D3") {
+        LogInfo((
+            "asset replacement: found overview GLB for %s at %s; "
+            "per-shape GLB replacement is handled by the OpenGL renderer and "
+            "the active .3D3 stream remains available for shape slots/comparison",
+            filename,
+            replacementPath
+        ));
+    }
+}
+
+static int hasRequiredModernReplacement(const char *filename) {
+    char replacementPath[512];
+    fs::path legacy{filename ? filename : ""};
+    const string ext = filename ? upperString(legacy.extension().string()) : "";
+
+    if (!filename) return 0;
+    if (ext == ".PIC" || ext == ".SPR") {
+        return findReplacementAssetPath(filename, ".png", replacementPath, sizeof(replacementPath));
+    }
+    if (ext == ".WLD" || ext == ".3DT" || ext == ".3DG") {
+        return findReplacementAssetPath(filename, ".json", replacementPath, sizeof(replacementPath));
+    }
+    if (ext == ".3D3") {
+        if (!findReplacementAssetPath(filename, ".json", replacementPath, sizeof(replacementPath))) {
+            return 0;
+        }
+        if (structuredJsonHasProperty(replacementPath, "\"model_data\"")) {
+            return 1;
+        }
+        LogWarn((
+            "asset replacement: %s has only minimized .3D3 JSON; original .3D3 is still required for shape tables",
+            filename
+        ));
+        return 0;
+    }
+    if (upperString(legacy.filename().string()) == "F15DGTL.BIN") {
+        return findReplacementAssetPath("voice_cue_000_sample0", ".wav", replacementPath, sizeof(replacementPath)) &&
+               findReplacementAssetPath("voice_cue_001_sample4", ".wav", replacementPath, sizeof(replacementPath)) &&
+               findReplacementAssetPath("voice_cue_002_sample2_variant0", ".wav", replacementPath, sizeof(replacementPath)) &&
+               findReplacementAssetPath("voice_cue_003_sample2_variant1", ".wav", replacementPath, sizeof(replacementPath)) &&
+               findReplacementAssetPath("voice_cue_004_sample2_variant2", ".wav", replacementPath, sizeof(replacementPath));
+    }
+    return 0;
+}
+
 /* Open an asset for reading. Returns the stream, or NULL on failure. */
 SDL_IOStream *openFile(const char *filename, int mode) {
     (void)mode; /* the resident open service only distinguished read vs. write;
                  * every openFile caller in the game opens an asset for reading */
+    if (SDL_IOStream *replacement = openStructuredJsonReplacement(filename)) {
+        return replacement;
+    }
+    logPreferredReplacementIfPresent(filename);
     return SDL_IOFromFile(resolveCasePath(filename).c_str(), "rb");
 }
 
@@ -190,6 +767,10 @@ bool verifyGameAssets() {
     for (const Asset &a : assets) {
         const string pathStr = resolveCasePath(a.filename.c_str(), true);
         if (pathStr.empty()) {
+            if (hasRequiredModernReplacement(a.filename.c_str())) {
+                LogInfo(("asset verification: using modern replacement for missing legacy asset %s", a.filename.c_str()));
+                continue;
+            }
             const string msg = "Could not find asset file " + a.filename
                 + " in game directory: " + gamePath.string();
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Initialization failed",
@@ -197,6 +778,10 @@ bool verifyGameAssets() {
             return false;
         }
         if (QuickDigest5::fileToHash(pathStr) != a.md5) {
+            if (hasRequiredModernReplacement(a.filename.c_str())) {
+                LogInfo(("asset verification: using modern replacement instead of checksum-mismatched legacy asset %s", pathStr.c_str()));
+                continue;
+            }
             const string msg = "Checksum mismatch for asset file " + pathStr
                 + ": expected " + a.md5;
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Initialization failed",

--- a/src/shared/filepic.c
+++ b/src/shared/filepic.c
@@ -10,6 +10,8 @@
 SDL_IOStream *openFile(const char *name, int mode);
 void fileClose(SDL_IOStream *handle);
 void decodePic(SDL_IOStream *handle, int segment);
+int loadReplacementPngToPage(const char *filename, int page);
+int loadReplacementPngToSprite(const char *filename, int segment);
 
 void mystrcpy(char *dest, const char *source) {
     do {
@@ -29,6 +31,9 @@ void closeFileWrapper(SDL_IOStream *handle) /* Original: CloseFile(fh). */
 void openShowPic(const char *filename, int page) /* Original chain: OpenFile + show/decode + CloseFile. Open, draw PIC to page, then close. */
 {
     SDL_IOStream *fileHandle;
+    if (loadReplacementPngToPage(filename, page)) {
+        return;
+    }
     fileHandle = openFileWrapper(filename, 0);
     showPicFile(fileHandle, page);
     closeFileWrapper(fileHandle);
@@ -36,6 +41,9 @@ void openShowPic(const char *filename, int page) /* Original chain: OpenFile + s
 
 void loadPic(const char *filename, int segment) { /* Original chain: OpenFile + DecodePic(InSeg, OutSeg) + CloseFile. Load PIC into segment. */
     SDL_IOStream *handle;
+    if (loadReplacementPngToSprite(filename, segment)) {
+        return;
+    }
     handle = openFileWrapper(filename, 0);
     decodePic(handle, segment);
     closeFileWrapper(handle);

--- a/src/shared/picimpl.c
+++ b/src/shared/picimpl.c
@@ -28,6 +28,7 @@ extern void fileClose(SDL_IOStream *io);
 /* Hi-res title surface + present (gfx_impl.c). */
 extern SDL_Surface *gfx_getHiResSurface(void);
 extern void gfx_presentHiRes(void);
+extern void gfx_clearTtfTextOverlay(void) __attribute__((weak));
 
 /* Pic decode work data */
 extern uint8 picDecodedRowBuf[320];
@@ -707,6 +708,7 @@ int loadReplacementPngToSprite(const char *filename, int segment) {
 void showPicFile(SDL_IOStream *handle, int page) {
     if (!handle) return;
     (void)page; /* all pages are the single back buffer */
+    if (gfx_clearTtfTextOverlay) gfx_clearTtfTextOverlay();
     /* Decode straight into the back buffer; the decoder overwrites every row. */
     picDecodeToSurface(handle, gfx_getCurPageSurface());
 }
@@ -746,6 +748,7 @@ void picBlit(SDL_IOStream *handle, int pageIndex) {
     (void)pageIndex;
     if (!handle) return;
 
+    if (gfx_clearTtfTextOverlay) gfx_clearTtfTextOverlay();
     dst = gfx_getHiResSurface();
     if (!dst) return;
     base = (uint8 *)dst->pixels;

--- a/src/shared/picimpl.c
+++ b/src/shared/picimpl.c
@@ -6,16 +6,24 @@
  */
 
 #include "inttype.h"
+#include "asset_compare.h"
+#include "common.h"
+#include "../gfx.h"
+#include "../log.h"
 #include <SDL3/SDL.h>
+#include <stdlib.h>
 
 /* Page backbuffers (gfx_impl.c): the decoder writes palette indices into these
  * 320x200 8-bit surfaces instead of the old fake DOS page segments. */
 extern SDL_Surface *gfx_getCurPageSurface(void);
 extern SDL_Surface *gfx_getPageSurface(int page);
 extern SDL_Surface *gfx_getSpriteSurface(int handle);
+extern SDL_Palette *gfx_getPalette(void);
 
 /* SDL-backed raw read from a file handle (file_io.c). */
 extern int fileReadRaw(SDL_IOStream *handle, void *dst, int count);
+extern SDL_IOStream *openFile(const char *filename, int mode);
+extern void fileClose(SDL_IOStream *io);
 
 /* Hi-res title surface + present (gfx_impl.c). */
 extern SDL_Surface *gfx_getHiResSurface(void);
@@ -303,6 +311,30 @@ static void picDecodeToSurface(SDL_IOStream *handle, SDL_Surface *dst) {
     }
 }
 
+static void picDecodeTitle640ToSurface(SDL_IOStream *handle, SDL_Surface *dst) {
+    uint8 *dstBase;
+    int dstPitch;
+    int row, col;
+
+    if (!dst) return;
+    dstBase = (uint8 *)dst->pixels;
+    dstPitch = dst->pitch;
+    SDL_memset(dstBase, 0, (size_t)dstPitch * dst->h);
+
+    picDecodeInit(handle);
+    for (row = 0; row < 700; row++) {
+        int y = row >> 1;
+        int xoff = (row & 1) ? 320 : 0;
+        uint8 *rowp;
+        picDecodeNextRow();
+        if (y >= dst->h || xoff >= dst->w) continue;
+        rowp = dstBase + (size_t)y * dstPitch + xoff;
+        for (col = 0; col < 320 && xoff + col < dst->w; col++) {
+            rowp[col] = picDecodedRowBuf[col] & 0x0F;
+        }
+    }
+}
+
 /* Defensive scratch target for a decode whose segment has no registered sprite
  * buffer. Live loads (loadPic / loadPicFromFile) always pass an allocated handle
  * that resolves to a real surface, so this only guards an unregistered-segment
@@ -312,6 +344,364 @@ static SDL_Surface *picScratchSurface(void) {
     if (!scratch)
         scratch = SDL_CreateSurface(320, 200, SDL_PIXELFORMAT_INDEX8);
     return scratch;
+}
+
+static uint8 pngRgb8ToDac6(uint8 value) {
+    return (uint8)((value * 63 + 127) / 255);
+}
+
+static void pngApplyEmbeddedPalette(SDL_Surface *src) {
+    SDL_Palette *pal = SDL_GetSurfacePalette(src);
+    uint8 dac[256 * 3];
+    int i;
+
+    if (!pal || pal->ncolors <= 0) return;
+    for (i = 0; i < pal->ncolors && i < 256; i++) {
+        dac[i * 3] = pngRgb8ToDac6(pal->colors[i].r);
+        dac[i * 3 + 1] = pngRgb8ToDac6(pal->colors[i].g);
+        dac[i * 3 + 2] = pngRgb8ToDac6(pal->colors[i].b);
+    }
+    gfx_setDacRange(0, (uint16)((pal->ncolors < 256) ? pal->ncolors : 256), dac);
+}
+
+static int pngNearestPaletteIndex(uint8 r, uint8 g, uint8 b) {
+    SDL_Palette *pal = gfx_getPalette();
+    int best = 0;
+    int bestDist = 0x7fffffff;
+    int i;
+
+    if (!pal || pal->ncolors <= 0) return 0;
+    for (i = 0; i < pal->ncolors && i < 256; i++) {
+        int dr = (int)r - (int)pal->colors[i].r;
+        int dg = (int)g - (int)pal->colors[i].g;
+        int db = (int)b - (int)pal->colors[i].b;
+        int dist = dr * dr + dg * dg + db * db;
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = i;
+            if (dist == 0) break;
+        }
+    }
+    return best;
+}
+
+static void pngCopyIndexed(SDL_Surface *src, SDL_Surface *dst) {
+    int x, y;
+
+    if (src->w <= 0 || src->h <= 0 || dst->w <= 0 || dst->h <= 0) return;
+    SDL_memset(dst->pixels, 0, (size_t)dst->pitch * dst->h);
+    for (y = 0; y < dst->h; y++) {
+        const int sy = (int)(((int64)y * src->h) / dst->h);
+        const uint8 *srcRow = (const uint8 *)src->pixels + (size_t)sy * src->pitch;
+        uint8 *dstRow = (uint8 *)dst->pixels + (size_t)y * dst->pitch;
+        for (x = 0; x < dst->w; x++) {
+            const int sx = (int)(((int64)x * src->w) / dst->w);
+            dstRow[x] = srcRow[sx];
+        }
+    }
+}
+
+static int pngCopyTruecolor(SDL_Surface *src, SDL_Surface *dst) {
+    SDL_Surface *rgba = SDL_ConvertSurface(src, SDL_PIXELFORMAT_RGBA32);
+    int x, y;
+
+    if (!rgba) return 0;
+    if (rgba->w <= 0 || rgba->h <= 0 || dst->w <= 0 || dst->h <= 0) {
+        SDL_DestroySurface(rgba);
+        return 0;
+    }
+    if (SDL_MUSTLOCK(rgba)) SDL_LockSurface(rgba);
+    if (SDL_MUSTLOCK(dst)) SDL_LockSurface(dst);
+    SDL_memset(dst->pixels, 0, (size_t)dst->pitch * dst->h);
+    for (y = 0; y < dst->h; y++) {
+        const int sy = (int)(((int64)y * rgba->h) / dst->h);
+        const uint8 *srcRow = (const uint8 *)rgba->pixels + (size_t)sy * rgba->pitch;
+        uint8 *dstRow = (uint8 *)dst->pixels + (size_t)y * dst->pitch;
+        for (x = 0; x < dst->w; x++) {
+            const int sx = (int)(((int64)x * rgba->w) / dst->w);
+            const uint8 *px = srcRow + sx * 4;
+            dstRow[x] = (uint8)pngNearestPaletteIndex(px[0], px[1], px[2]);
+        }
+    }
+    if (SDL_MUSTLOCK(dst)) SDL_UnlockSurface(dst);
+    if (SDL_MUSTLOCK(rgba)) SDL_UnlockSurface(rgba);
+    SDL_DestroySurface(rgba);
+    return 1;
+}
+
+static uint8 dac6ToRgb8(uint8 v) {
+    v = (uint8)((v & 0x3f) << 2);
+    return (uint8)(v | (v >> 6));
+}
+
+static void comparePngPaletteWithLegacyDac(const char *filename,
+                                           SDL_Surface *pngSurface,
+                                           const SDL_Color *legacyColors,
+                                           int legacyColorCount,
+                                           const char *replacementPath) {
+    SDL_Palette *pngPalette;
+    uint8 legacyRgb[256 * 3];
+    uint8 pngRgb[256 * 3];
+    int i;
+
+    if (!assetCompareEnabled() || !filename || !pngSurface || !legacyColors) return;
+    if (pngSurface->format != SDL_PIXELFORMAT_INDEX8) return;
+    pngPalette = SDL_GetSurfacePalette(pngSurface);
+    if (!pngPalette || pngPalette->ncolors <= 0) {
+        LogWarn(("asset replacement compare: %s indexed PNG has no embedded palette (%s)", filename, replacementPath));
+        return;
+    }
+
+    for (i = 0; i < legacyColorCount && i < 256; i++) {
+        legacyRgb[i * 3] = legacyColors[i].r;
+        legacyRgb[i * 3 + 1] = legacyColors[i].g;
+        legacyRgb[i * 3 + 2] = legacyColors[i].b;
+    }
+    for (i = 0; i < pngPalette->ncolors && i < 256; i++) {
+        pngRgb[i * 3] = dac6ToRgb8(pngRgb8ToDac6(pngPalette->colors[i].r));
+        pngRgb[i * 3 + 1] = dac6ToRgb8(pngRgb8ToDac6(pngPalette->colors[i].g));
+        pngRgb[i * 3 + 2] = dac6ToRgb8(pngRgb8ToDac6(pngPalette->colors[i].b));
+    }
+    assetCompareRgbPalettes(filename, legacyRgb, legacyColorCount, pngRgb, pngPalette->ncolors, replacementPath);
+}
+
+static void compareReplacementPngWithLegacy(const char *filename,
+                                            SDL_Surface *replacementDst,
+                                            SDL_Surface *pngSurface,
+                                            const SDL_Color *legacyColors,
+                                            int legacyColorCount,
+                                            const char *replacementPath,
+                                            int pngW,
+                                            int pngH) {
+    SDL_IOStream *legacyIo;
+    SDL_Surface *legacySurface;
+
+    if (!assetCompareEnabled() || !filename || !replacementDst) return;
+
+    legacySurface = SDL_CreateSurface(replacementDst->w, replacementDst->h, SDL_PIXELFORMAT_INDEX8);
+    if (!legacySurface) {
+        LogWarn(("asset replacement compare: failed to allocate PIC compare surface for %s", filename));
+        return;
+    }
+    legacyIo = openFile(filename, 0);
+    if (!legacyIo) {
+        LogWarn(("asset replacement compare: failed to open legacy PIC/SPR %s for PNG %s", filename, replacementPath));
+        SDL_DestroySurface(legacySurface);
+        return;
+    }
+    picDecodeToSurface(legacyIo, legacySurface);
+    fileClose(legacyIo);
+    comparePngPaletteWithLegacyDac(filename, pngSurface, legacyColors, legacyColorCount, replacementPath);
+
+    /* The loader copies into fixed-size page/sprite surfaces. Report source PNG
+     * dimensions separately because a smaller PNG is zero-filled into the target
+     * and may otherwise look like a generic pixel mismatch. */
+    if (pngW != replacementDst->w || pngH != replacementDst->h) {
+        LogWarn((
+            "asset replacement compare: %s PNG source size differs from target surface "
+            "(target=%dx%d png=%dx%d, png=%s)",
+            filename,
+            replacementDst->w,
+            replacementDst->h,
+            pngW,
+            pngH,
+            replacementPath
+        ));
+    } else {
+        if (SDL_MUSTLOCK(legacySurface)) SDL_LockSurface(legacySurface);
+        if (SDL_MUSTLOCK(replacementDst)) SDL_LockSurface(replacementDst);
+        assetCompareIndexedPixels2D(
+            filename,
+            (const uint8 *)legacySurface->pixels,
+            legacySurface->pitch,
+            (const uint8 *)replacementDst->pixels,
+            replacementDst->pitch,
+            legacySurface->w < replacementDst->w ? legacySurface->w : replacementDst->w,
+            legacySurface->h < replacementDst->h ? legacySurface->h : replacementDst->h,
+            replacementPath
+        );
+        if (SDL_MUSTLOCK(replacementDst)) SDL_UnlockSurface(replacementDst);
+        if (SDL_MUSTLOCK(legacySurface)) SDL_UnlockSurface(legacySurface);
+    }
+    SDL_DestroySurface(legacySurface);
+}
+
+static void compareReplacementTitle640PngWithLegacy(const char *filename,
+                                                    SDL_Surface *replacementDst,
+                                                    SDL_Surface *pngSurface,
+                                                    const SDL_Color *legacyColors,
+                                                    int legacyColorCount,
+                                                    const char *replacementPath,
+                                                    int pngW,
+                                                    int pngH) {
+    SDL_IOStream *legacyIo;
+    SDL_Surface *legacySurface;
+
+    if (!assetCompareEnabled() || !filename || !replacementDst) return;
+
+    legacySurface = SDL_CreateSurface(replacementDst->w, replacementDst->h, SDL_PIXELFORMAT_INDEX8);
+    if (!legacySurface) {
+        LogWarn(("asset replacement compare: failed to allocate TITLE640 compare surface for %s", filename));
+        return;
+    }
+    legacyIo = openFile(filename, 0);
+    if (!legacyIo) {
+        LogWarn(("asset replacement compare: failed to open legacy TITLE640 %s for PNG %s", filename, replacementPath));
+        SDL_DestroySurface(legacySurface);
+        return;
+    }
+    picDecodeTitle640ToSurface(legacyIo, legacySurface);
+    fileClose(legacyIo);
+
+    comparePngPaletteWithLegacyDac(filename, pngSurface, legacyColors, legacyColorCount, replacementPath);
+    if (pngW != replacementDst->w || pngH != replacementDst->h) {
+        LogWarn((
+            "asset replacement compare: %s PNG source size differs from hi-res title surface "
+            "(target=%dx%d png=%dx%d, png=%s)",
+            filename,
+            replacementDst->w,
+            replacementDst->h,
+            pngW,
+            pngH,
+            replacementPath
+        ));
+    }
+    if (SDL_MUSTLOCK(legacySurface)) SDL_LockSurface(legacySurface);
+    if (SDL_MUSTLOCK(replacementDst)) SDL_LockSurface(replacementDst);
+    assetCompareIndexedPixels2D(
+        filename,
+        (const uint8 *)legacySurface->pixels,
+        legacySurface->pitch,
+        (const uint8 *)replacementDst->pixels,
+        replacementDst->pitch,
+        legacySurface->w < replacementDst->w ? legacySurface->w : replacementDst->w,
+        legacySurface->h < replacementDst->h ? legacySurface->h : replacementDst->h,
+        replacementPath
+    );
+    if (SDL_MUSTLOCK(replacementDst)) SDL_UnlockSurface(replacementDst);
+    if (SDL_MUSTLOCK(legacySurface)) SDL_UnlockSurface(legacySurface);
+    SDL_DestroySurface(legacySurface);
+}
+
+static int loadReplacementPngToSurface(const char *filename, SDL_Surface *dst) {
+    char replacementPath[512];
+    SDL_Surface *src;
+    SDL_Color legacyColors[256];
+    SDL_Palette *activePalette;
+    int legacyColorCount = 0;
+    int ok = 0;
+
+    /* PIC/SPR replacements are media-first: the PNG itself supplies pixels and,
+     * for indexed PNGs, the palette. JSON sidecars are converter metadata and
+     * are not needed by the runtime loader. */
+    if (!filename || !dst) return 0;
+    if (!findReplacementAssetPath(filename, ".png", replacementPath, sizeof(replacementPath))) {
+        return 0;
+    }
+
+    src = SDL_LoadPNG(replacementPath);
+    if (!src) {
+        LogWarn(("asset replacement: failed to load PNG %s (%s); using legacy PIC/SPR", replacementPath, SDL_GetError()));
+        return 0;
+    }
+
+    activePalette = gfx_getPalette();
+    if (activePalette && activePalette->ncolors > 0) {
+        legacyColorCount = activePalette->ncolors < 256 ? activePalette->ncolors : 256;
+        SDL_memcpy(legacyColors, activePalette->colors, (size_t)legacyColorCount * sizeof(legacyColors[0]));
+    }
+
+    if (src->format == SDL_PIXELFORMAT_INDEX8) {
+        SDL_Palette *srcPalette = SDL_GetSurfacePalette(src);
+        if (!srcPalette || srcPalette->ncolors <= 0) {
+            LogWarn(("asset replacement: rejected indexed PNG %s without embedded palette; using legacy PIC/SPR", replacementPath));
+            SDL_DestroySurface(src);
+            return 0;
+        }
+        if (SDL_MUSTLOCK(src)) SDL_LockSurface(src);
+        if (SDL_MUSTLOCK(dst)) SDL_LockSurface(dst);
+        pngApplyEmbeddedPalette(src);
+        pngCopyIndexed(src, dst);
+        if (SDL_MUSTLOCK(dst)) SDL_UnlockSurface(dst);
+        if (SDL_MUSTLOCK(src)) SDL_UnlockSurface(src);
+        ok = 1;
+    } else {
+        ok = pngCopyTruecolor(src, dst);
+    }
+
+    if (ok) {
+        compareReplacementPngWithLegacy(filename, dst, src, legacyColors, legacyColorCount, replacementPath, src->w, src->h);
+        LogInfo(("asset replacement: loaded PNG %s for %s (%dx%d)", replacementPath, filename, src->w, src->h));
+    } else {
+        LogWarn(("asset replacement: could not convert PNG %s; using legacy PIC/SPR", replacementPath));
+    }
+    SDL_DestroySurface(src);
+    return ok;
+}
+
+int loadReplacementPngToPage(const char *filename, int page) {
+    (void)page;
+    return loadReplacementPngToSurface(filename, gfx_getCurPageSurface());
+}
+
+int loadReplacementPngToHiResTitle(const char *filename) {
+    char replacementPath[512];
+    SDL_Surface *dst = gfx_getHiResSurface();
+    SDL_Surface *src;
+    SDL_Color legacyColors[256];
+    SDL_Palette *activePalette;
+    int legacyColorCount = 0;
+    int ok = 0;
+
+    if (!filename || !dst) return 0;
+    if (!findReplacementAssetPath(filename, ".png", replacementPath, sizeof(replacementPath))) {
+        return 0;
+    }
+
+    src = SDL_LoadPNG(replacementPath);
+    if (!src) {
+        LogWarn(("asset replacement: failed to load hi-res title PNG %s (%s); using legacy PIC", replacementPath, SDL_GetError()));
+        return 0;
+    }
+
+    activePalette = gfx_getPalette();
+    if (activePalette && activePalette->ncolors > 0) {
+        legacyColorCount = activePalette->ncolors < 256 ? activePalette->ncolors : 256;
+        SDL_memcpy(legacyColors, activePalette->colors, (size_t)legacyColorCount * sizeof(legacyColors[0]));
+    }
+
+    if (src->format == SDL_PIXELFORMAT_INDEX8) {
+        SDL_Palette *srcPalette = SDL_GetSurfacePalette(src);
+        if (!srcPalette || srcPalette->ncolors <= 0) {
+            LogWarn(("asset replacement: rejected indexed hi-res title PNG %s without embedded palette; using legacy PIC", replacementPath));
+            SDL_DestroySurface(src);
+            return 0;
+        }
+        if (SDL_MUSTLOCK(src)) SDL_LockSurface(src);
+        if (SDL_MUSTLOCK(dst)) SDL_LockSurface(dst);
+        pngApplyEmbeddedPalette(src);
+        pngCopyIndexed(src, dst);
+        if (SDL_MUSTLOCK(dst)) SDL_UnlockSurface(dst);
+        if (SDL_MUSTLOCK(src)) SDL_UnlockSurface(src);
+        ok = 1;
+    } else {
+        ok = pngCopyTruecolor(src, dst);
+    }
+
+    if (ok) {
+        compareReplacementTitle640PngWithLegacy(filename, dst, src, legacyColors, legacyColorCount, replacementPath, src->w, src->h);
+        gfx_presentHiRes();
+        LogInfo(("asset replacement: loaded hi-res title PNG %s for %s (%dx%d)", replacementPath, filename, src->w, src->h));
+    } else {
+        LogWarn(("asset replacement: could not convert hi-res title PNG %s; using legacy PIC", replacementPath));
+    }
+    SDL_DestroySurface(src);
+    return ok;
+}
+
+int loadReplacementPngToSprite(const char *filename, int segment) {
+    SDL_Surface *dst = gfx_getSpriteSurface(segment);
+    return dst ? loadReplacementPngToSurface(filename, dst) : 0;
 }
 
 void showPicFile(SDL_IOStream *handle, int page) {

--- a/src/shared/textfmt.c
+++ b/src/shared/textfmt.c
@@ -7,6 +7,48 @@
 #include <dos.h>
 
 extern int FAR gfx_setFont(uint16 ch, uint16 font);
+extern int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx);
+
+/* Match gfx_impl.c text rendering semantics: valid UTF-8 sequences are Unicode
+ * glyphs, malformed high bytes remain the original inline colour escapes. */
+static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int16 *byteCountOut) {
+    const unsigned char *s = (const unsigned char *)text;
+    unsigned int cp;
+    int needed;
+    int i;
+
+    if (s[0] < 0x80) {
+        *codepointOut = s[0];
+        *byteCountOut = 1;
+        return 1;
+    }
+    if ((s[0] & 0xe0) == 0xc0) {
+        cp = (unsigned int)(s[0] & 0x1f);
+        needed = 2;
+        if (cp == 0) return 0; /* overlong ASCII */
+    } else if ((s[0] & 0xf0) == 0xe0) {
+        cp = (unsigned int)(s[0] & 0x0f);
+        needed = 3;
+    } else if ((s[0] & 0xf8) == 0xf0) {
+        cp = (unsigned int)(s[0] & 0x07);
+        needed = 4;
+    } else {
+        return 0;
+    }
+    for (i = 1; i < needed; i++) {
+        if ((s[i] & 0xc0) != 0x80) return 0;
+        cp = (cp << 6) | (unsigned int)(s[i] & 0x3f);
+    }
+    if ((needed == 2 && cp < 0x80) ||
+        (needed == 3 && cp < 0x800) ||
+        (needed == 4 && (cp < 0x10000 || cp > 0x10ffff)) ||
+        (cp >= 0xd800 && cp <= 0xdfff)) {
+        return 0;
+    }
+    *codepointOut = (uint32)cp;
+    *byteCountOut = (int16)needed;
+    return 1;
+}
 
 void drawStringCentered(int16 *page, const char *str, int16 startx, int16 y, int16 endx) {
     int16 width;
@@ -22,7 +64,19 @@ int16 stringWidth(int16 *page, const char *str) {
     j = page[6];
     n = 0;
     while (*l != '\0') {
-        n += gfx_setFont(*(l++), j);
+        uint32 codepoint;
+        int16 byteCount;
+        unsigned char ch = (unsigned char)*l;
+        if (!decodeUtf8Codepoint(l, &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            l++;
+            continue;
+        }
+        n += gfx_getGlyphAdvance(codepoint, j);
+        l += byteCount;
     }
     return n;
 }

--- a/src/shared/textfmt.c
+++ b/src/shared/textfmt.c
@@ -7,48 +7,7 @@
 #include <dos.h>
 
 extern int FAR gfx_setFont(uint16 ch, uint16 font);
-extern int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx);
-
-/* Match gfx_impl.c text rendering semantics: valid UTF-8 sequences are Unicode
- * glyphs, malformed high bytes remain the original inline colour escapes. */
-static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int16 *byteCountOut) {
-    const unsigned char *s = (const unsigned char *)text;
-    unsigned int cp;
-    int needed;
-    int i;
-
-    if (s[0] < 0x80) {
-        *codepointOut = s[0];
-        *byteCountOut = 1;
-        return 1;
-    }
-    if ((s[0] & 0xe0) == 0xc0) {
-        cp = (unsigned int)(s[0] & 0x1f);
-        needed = 2;
-        if (cp == 0) return 0; /* overlong ASCII */
-    } else if ((s[0] & 0xf0) == 0xe0) {
-        cp = (unsigned int)(s[0] & 0x0f);
-        needed = 3;
-    } else if ((s[0] & 0xf8) == 0xf0) {
-        cp = (unsigned int)(s[0] & 0x07);
-        needed = 4;
-    } else {
-        return 0;
-    }
-    for (i = 1; i < needed; i++) {
-        if ((s[i] & 0xc0) != 0x80) return 0;
-        cp = (cp << 6) | (unsigned int)(s[i] & 0x3f);
-    }
-    if ((needed == 2 && cp < 0x80) ||
-        (needed == 3 && cp < 0x800) ||
-        (needed == 4 && (cp < 0x10000 || cp > 0x10ffff)) ||
-        (cp >= 0xd800 && cp <= 0xdfff)) {
-        return 0;
-    }
-    *codepointOut = (uint32)cp;
-    *byteCountOut = (int16)needed;
-    return 1;
-}
+extern int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx);
 
 void drawStringCentered(int16 *page, const char *str, int16 startx, int16 y, int16 endx) {
     int16 width;
@@ -57,28 +16,7 @@ void drawStringCentered(int16 *page, const char *str, int16 startx, int16 y, int
 }
 
 int16 stringWidth(int16 *page, const char *str) {
-    int16 n;
-    const char *l;
-    int16 j;
-    l = str;
-    j = page[6];
-    n = 0;
-    while (*l != '\0') {
-        uint32 codepoint;
-        int16 byteCount;
-        unsigned char ch = (unsigned char)*l;
-        if (!decodeUtf8Codepoint(l, &codepoint, &byteCount)) {
-            codepoint = ch;
-            byteCount = 1;
-        }
-        if (byteCount == 1 && (ch & 0x80)) {
-            l++;
-            continue;
-        }
-        n += gfx_getGlyphAdvance(codepoint, j);
-        l += byteCount;
-    }
-    return n;
+    return (int16)gfx_getStringAdvanceUtf8(str, (uint16)page[6]);
 }
 
 void my_ltoa(int32 value, char *buf) {

--- a/src/stmissn.c
+++ b/src/stmissn.c
@@ -179,6 +179,9 @@ void showPic640(const char *filename) {
     intRegs[0] = MODE_640_350;
     intDispatch(IRQ_VIDEO, intRegs, intRegs);
     gfx_setDac(0);
+    if (loadReplacementPngToHiResTitle(filename)) {
+        return;
+    }
     fileHandle = openFileWrapper(filename, 0);
     picBlit(fileHandle, 0);
     closeFileWrapper(fileHandle);
@@ -366,7 +369,9 @@ int16 askRepeatMission() {
 }
 
 void checkDiskA() {
-    while ((fileHandle = openFile("F15.spr", 0)) == NULL) {
+    char replacementPath[512];
+    while ((fileHandle = openFile("F15.spr", 0)) == NULL &&
+           !findReplacementAssetPath("F15.spr", ".png", replacementPath, sizeof(replacementPath))) {
         clearBriefing();
         drawStringCentered(page1NumPtr, "Please reinsert F15 Disk A", 113, 61, 185);
         page1NumPtr[6] = FONT_SMALL; // page1Desc.font?
@@ -377,7 +382,7 @@ void checkDiskA() {
         animateArm(armPosition, armPosition);
         waitJoyKey();
     }
-    fileClose(fileHandle);
+    if (fileHandle) fileClose(fileHandle);
     clearBriefing();
 }
 

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -8,6 +8,7 @@
 #include "sttypes.h"
 #include "const.h"
 #include "gfx.h"
+#include "input.h"
 #include "slot.h"
 #include "comm.h"
 #include "offsets.h"
@@ -31,6 +32,36 @@ void loadHallfame(void);
 void saveHallfame();
 int getJoyKey();
 int readInputKey();
+
+static void redrawPilotSelectorPrompt(int16 *page) {
+    int oldBg = page[3];
+    int oldColor = page[2];
+    int oldFont = page[6];
+    page[3] = 0;
+    clearRect(page, 15, 192, 303, 197);
+    gfx_invalidateTtfTextOverlayRect(15, 190, 303, 199);
+    page[2] = COLOR_LIGHTRED;
+    page[6] = 3;
+    drawStringCentered(page, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
+    page[2] = oldColor;
+    page[6] = oldFont;
+    page[3] = oldBg;
+}
+
+static void redrawPilotNamePrompt(int16 *page) {
+    int oldBg = page[3];
+    int oldColor = page[2];
+    int oldFont = page[6];
+    page[3] = 0;
+    clearRect(page, 15, 192, 303, 197);
+    gfx_invalidateTtfTextOverlayRect(0, 190, SCREEN_MAXX, 199);
+    page[2] = COLOR_LIGHTRED;
+    page[6] = 3;
+    drawStringCentered(page, "ENTER YOUR NAME !", 15, 192, 289);
+    page[2] = oldColor;
+    page[6] = oldFont;
+    page[3] = oldBg;
+}
 
 void pilotSelect(int16 needSplash) {
     int unused;
@@ -90,8 +121,7 @@ void displayPilots(void) {
     do {
         printPilot(pilotIdx);
     } while (++pilotIdx < HALLFAME_SLOTS);
-    screenDesc.color = COLOR_WHITE;
-    drawStringCentered(pageNumPtr, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
+    redrawPilotSelectorPrompt(screenBuf);
     gfx_commitPage();
 }
 
@@ -164,6 +194,8 @@ void processPilotInput() {
             if (doFcbSearch() != 0) {
                 saveHallfame();
             }
+            redrawPilotSelectorPrompt(screenBuf);
+            gfx_commitPage();
             continue;
         case KEYCODE_UPARROW:
             selectedPilotIdx--;
@@ -232,20 +264,21 @@ void pilotToGameData(const uint8 *pilotData) {
 void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
     int blinkToggle;
     int xPos, yPos;
-    int nameLen;
+    int nameLen = 0;
     int cursorX;
     uint16 keyCode;
     int rankWidth;
     blinkToggle = 0;
     xPos = (selectedPilotIdx < PILOTS_PER_COLUMN) ? PILOT_COL_LEFT : PILOT_COL_RIGHT;
     yPos = ((selectedPilotIdx & (PILOTS_PER_COLUMN - 1)) * PILOT_ROW_HEIGHT) + PILOT_TOP_MARGIN;
+    page[2] = COLOR_WHITE;
+    page[6] = 1;
     clearRect(page, xPos, yPos, xPos + PILOT_ENTRY_WIDTH, yPos + 35);
+    gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + PILOT_ENTRY_WIDTH, yPos + 35);
     drawStringAt(page, ranks[0], xPos, yPos);
     xPos += (rankWidth = stringWidth(page, ranks[0]));
     rankWidth = PILOT_ENTRY_WIDTH - rankWidth;
-    screenBuf[3] = 0;
-    clearRect(page, 15, 192, 303, 197);
-    drawStringCentered(pageNumPtr, "\376ENTER YOUR NAME !", 15, 192, 289);
+    redrawPilotNamePrompt(page);
     misc_clearKeyFlags();
     keyCode = KEYCODE_CTRLX;
     do {
@@ -253,30 +286,52 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
         case KEYCODE_CTRLX:
             nameLen = 0;
             pilot->name[0] = '\0';
+            page[2] = COLOR_WHITE;
             clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+            gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
             drawStringAt(page, pilot->name, xPos, yPos);
             cursorX = page[4];
             break;
         case 8: // backspace
             if (nameLen > 0) {
-                nameLen--;
+                do {
+                    nameLen--;
+                } while (nameLen > 0 && (((uint8)pilot->name[nameLen] & 0xc0) == 0x80));
                 pilot->name[nameLen] = '\0';
                 // 2403 - duplicate code block coalesced with above
+                page[2] = COLOR_WHITE;
                 clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+                gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
                 drawStringAt(page, pilot->name, xPos, yPos);
                 cursorX = page[4];
             }
             break;
         default:
-            if (keyCode >= 0x20 && keyCode <= 0x7f && nameLen < a && stringWidth(page, pilot->name) <= 144) {
-                pilot->name[nameLen++] = keyCode;
-                pilot->name[nameLen] = '\0';
-                clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
-                drawStringAt(page, pilot->name, xPos, yPos);
-                cursorX = page[4];
+            {
+                char utf8[8];
+                int utf8Len = input_readMenuTextUtf8(utf8, sizeof(utf8));
+                if (utf8Len == 1 && (uint8)utf8[0] >= 0x20 && (uint8)utf8[0] < 0x80) {
+                    input_discardNextAsciiKey((uint8)utf8[0]);
+                }
+                if (utf8Len == 0 && keyCode >= 0x20 && keyCode <= 0x7f) {
+                    utf8[0] = (char)keyCode;
+                    utf8[1] = '\0';
+                    utf8Len = 1;
+                }
+                if (utf8Len > 0 && nameLen + utf8Len < a && stringWidth(page, pilot->name) <= 144) {
+                    memcpy(&pilot->name[nameLen], utf8, (size_t)utf8Len);
+                    nameLen += utf8Len;
+                    pilot->name[nameLen] = '\0';
+                    page[2] = COLOR_WHITE;
+                    clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+                    gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
+                    drawStringAt(page, pilot->name, xPos, yPos);
+                    cursorX = page[4];
+                }
             }
             break;
         }
+        redrawPilotNamePrompt(page);
         gfx_commitPage();
         while (getJoyKey() == 0) {
             waitMdaCgaStatus(3);
@@ -284,6 +339,7 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
                             pilotNameInputColors[blinkToggle], pilotNameInputColors[blinkToggle ^ 1]);
             blinkToggle ^= 1;
             page[3] = pilotNameInputColors[blinkToggle];
+            redrawPilotNamePrompt(page);
             gfx_commitPage();
         }
         keyCode = readInputKey();
@@ -293,6 +349,7 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
         if (keyCode == KEYCODE_ENTER) {
             screenBuf[3] = 0;
             clearRect(page, 15, 192, 303, 197);
+            gfx_invalidateTtfTextOverlayRect(0, 188, SCREEN_MAXX, SCREEN_MAXY);
             return;
         }
     } while (true);
@@ -332,7 +389,7 @@ int getJoyKey() {
         restoreCbreakHandler();
         exit(0);
     }
-    return misc_checkKeyBuf() == 0;
+    return misc_checkKeyBuf() == 0 || input_menuTextWaiting();
 }
 
 /* ---- merged from stinkey.c ---- */
@@ -347,7 +404,7 @@ int readInputKey() {
             goto checkKey;
         }
     }
-    key = misc_getKey();
+    key = input_menuTextWaiting() ? 0 : misc_getKey();
 checkKey:
     if (key == KEYCODE_ALTQ || cbreakHit != 0) {
         cleanup();

--- a/tests/asset_compare_behavior_tests.cpp
+++ b/tests/asset_compare_behavior_tests.cpp
@@ -1,9 +1,12 @@
 #include "shared/asset_compare.h"
 #include "gfx_impl.h"
 
+#include <SDL3/SDL.h>
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 namespace {
 
@@ -30,12 +33,40 @@ void fillColorCoverage(int *values, int color, int count) {
     values[color & 0xff] = count;
 }
 
+struct CapturedLog {
+    int calls = 0;
+    SDL_LogPriority priority = SDL_LOG_PRIORITY_INVALID;
+    std::string message;
+};
+
+CapturedLog g_log;
+
+void captureLog(void *, int, SDL_LogPriority priority, const char *message) {
+    g_log.calls++;
+    if (priority > g_log.priority) g_log.priority = priority;
+    if (!g_log.message.empty()) g_log.message += "\n";
+    g_log.message += message ? message : "";
+}
+
+void resetLogCapture() {
+    g_log = CapturedLog{};
+}
+
+void requireLogContains(SDL_LogPriority priority, const char *needle, const char *message) {
+    require(g_log.calls > 0, message);
+    require(g_log.priority == priority, message);
+    require(g_log.message.find(needle) != std::string::npos, message);
+}
+
 } // namespace
 
 int eg3drast_testReplacementColorFromMaterial(float r, float g, float b, int sourceColor);
 int eg3drast_testReplacementLineNearClip(long aDepth, long bDepth);
 
 int main() {
+    SDL_SetLogOutputFunction(captureLog, nullptr);
+    SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_VERBOSE);
+
 #if !defined(_WIN32)
     unsetenv("F15_COMPARE_REPLACEMENTS");
 #endif
@@ -48,8 +79,15 @@ int main() {
     require(!assetCompareEnabled(),
             "assetCompareEnabled ignores runtime environment variables");
 
+#ifdef DEBUG
+    assetCompareTestSetEnabled(1);
+#endif
+    require(assetCompareEnabled(),
+            "test-only compare switch enables deterministic comparison branches");
+
     const uint8 legacyBytes[] = {1, 2, 3, 4};
     const uint8 modernBytes[] = {1, 2, 3, 4};
+    resetLogCapture();
     assetCompareNamedBytes("bytes",
                            "modern bytes match",
                            "modern bytes differ",
@@ -59,15 +97,49 @@ int main() {
                            modernBytes,
                            sizeof(modernBytes),
                            "bytes.replacement");
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "modern bytes match",
+                       "matching byte comparison logs success");
+
+    const uint8 differentBytes[] = {1, 9, 3, 4};
+    resetLogCapture();
+    assetCompareNamedBytes("bytes",
+                           "modern bytes match",
+                           "modern bytes differ",
+                           "modern",
+                           legacyBytes,
+                           sizeof(legacyBytes),
+                           differentBytes,
+                           sizeof(differentBytes),
+                           "bytes.replacement");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "modern bytes differ at byte 1",
+                       "byte comparison logs first differing offset");
+
+    resetLogCapture();
+    assetCompareNamedBytes("bytes",
+                           "modern bytes match",
+                           "modern bytes differ",
+                           "modern",
+                           legacyBytes,
+                           sizeof(legacyBytes),
+                           legacyBytes,
+                           sizeof(legacyBytes) - 1,
+                           "bytes.replacement");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "length differs",
+                       "byte comparison logs length mismatch");
+
+    resetLogCapture();
     assetCompareStructuredBytes("VN.WLD",
                                 legacyBytes,
                                 sizeof(legacyBytes),
                                 modernBytes,
                                 sizeof(modernBytes),
                                 "VN/VN.WLD.json");
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "JSON rebuild matches legacy bytes",
+                       "structured byte comparison uses JSON-specific success text");
 
     const uint8 legacyPixels[] = {1, 2, 3, 4};
     const uint8 modernPixels[] = {1, 2, 3, 4};
+    resetLogCapture();
     assetCompareIndexedPixels2D("TITLE.PIC",
                                 legacyPixels,
                                 kImageWidth,
@@ -76,15 +148,54 @@ int main() {
                                 kImageWidth,
                                 kImageHeight,
                                 "TITLE.png");
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "PNG pixels match",
+                       "matching image comparison logs success");
+
+    const uint8 differentPixels[] = {1, 2, 9, 4};
+    resetLogCapture();
+    assetCompareIndexedPixels2D("TITLE.PIC",
+                                legacyPixels,
+                                kImageWidth,
+                                differentPixels,
+                                kImageWidth,
+                                kImageWidth,
+                                kImageHeight,
+                                "TITLE.png");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "PNG pixels differ at 0,1",
+                       "image comparison logs first differing pixel");
 
     const uint8 legacyRgb[kPaletteEntries * 3] = {0, 0, 0, 63, 31, 0};
     const uint8 modernRgb[kPaletteEntries * 3] = {0, 0, 0, 63, 31, 0};
+    resetLogCapture();
     assetCompareRgbPalettes("TITLE.PIC",
                             legacyRgb,
                             kPaletteEntries,
                             modernRgb,
                             kPaletteEntries,
                             "TITLE.png");
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "PNG embedded palette matches",
+                       "matching palette comparison logs success");
+
+    const uint8 differentRgb[kPaletteEntries * 3] = {0, 0, 0, 63, 30, 0};
+    resetLogCapture();
+    assetCompareRgbPalettes("TITLE.PIC",
+                            legacyRgb,
+                            kPaletteEntries,
+                            differentRgb,
+                            kPaletteEntries,
+                            "TITLE.png");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "PNG palette differs at index 1",
+                       "palette comparison logs first differing entry");
+
+    resetLogCapture();
+    assetCompareRgbPalettes("TITLE.PIC",
+                            legacyRgb,
+                            kPaletteEntries,
+                            legacyRgb,
+                            kPaletteEntries - 1,
+                            "TITLE.png");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "palette entry count differs",
+                       "palette comparison logs entry-count mismatch");
 
     uint8 legacyFontBitmap[kFontGlyphs * kFontHeight] = {};
     uint8 modernFontBitmap[kFontGlyphs * kFontHeight] = {};
@@ -94,6 +205,7 @@ int main() {
         legacyFontBitmap[i] = modernFontBitmap[i] = static_cast<uint8>(i & 0xff);
         legacyFontWidths[i] = modernFontWidths[i] = kFontWidth;
     }
+    resetLogCapture();
     assetCompareFont96("font_3",
                        legacyFontBitmap,
                        legacyFontWidths,
@@ -104,9 +216,58 @@ int main() {
                        kFontHeight,
                        kFontWidth,
                        "fonts/font_3.bdf");
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "replacement matches built-in glyph rows",
+                       "matching font comparison logs success");
+
+    modernFontWidths[10] = kFontWidth - 1;
+    resetLogCapture();
+    assetCompareFont96("font_3",
+                       legacyFontBitmap,
+                       legacyFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       modernFontBitmap,
+                       modernFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       "fonts/font_3.bdf");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "width differs for glyph",
+                       "font comparison logs glyph width mismatch");
+    modernFontWidths[10] = kFontWidth;
+
+    modernFontBitmap[20] ^= 0x10;
+    resetLogCapture();
+    assetCompareFont96("font_3",
+                       legacyFontBitmap,
+                       legacyFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       modernFontBitmap,
+                       modernFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       "fonts/font_3.bdf");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "bitmap differs for glyph",
+                       "font comparison logs glyph bitmap mismatch");
+    modernFontBitmap[20] ^= 0x10;
+
+    resetLogCapture();
+    assetCompareFont96("font_3",
+                       legacyFontBitmap,
+                       legacyFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       modernFontBitmap,
+                       modernFontWidths,
+                       kFontHeight + 1,
+                       kFontWidth,
+                       "fonts/font_3.bdf");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "metrics differ",
+                       "font comparison logs metric mismatch");
 
     const uint8 legacySound[] = {9, 8, 7, 6};
     const uint8 modernSound[] = {9, 8, 7, 6};
+    resetLogCapture();
     assetCompareSoundCueRange("voice_cue_000_sample0",
                               0,
                               sizeof(legacySound) - 1,
@@ -117,6 +278,36 @@ int main() {
                               sizeof(modernSound),
                               kCueRate,
                               "sounds/voice_cue_000_sample0.wav");
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "WAV samples match legacy range",
+                       "matching sound cue comparison logs success");
+
+    resetLogCapture();
+    assetCompareSoundCueRange("voice_cue_000_sample0",
+                              0,
+                              sizeof(legacySound) - 1,
+                              kCueRate,
+                              legacySound,
+                              sizeof(legacySound),
+                              modernSound,
+                              sizeof(modernSound),
+                              kCueRate + 1,
+                              "sounds/voice_cue_000_sample0.wav");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "WAV sample rate differs",
+                       "sound comparison logs sample-rate mismatch before byte proof");
+
+    resetLogCapture();
+    assetCompareSoundCueRange("voice_cue_000_sample0",
+                              3,
+                              1,
+                              kCueRate,
+                              legacySound,
+                              sizeof(legacySound),
+                              modernSound,
+                              sizeof(modernSound),
+                              kCueRate,
+                              "sounds/voice_cue_000_sample0.wav");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "legacy cue range invalid",
+                       "sound comparison logs invalid legacy cue range");
 
     int legacyFaceColor[256];
     int legacyLineColor[256];
@@ -146,7 +337,31 @@ int main() {
     stats.glbLineColor = glbLineColor;
     stats.glbPointColor = glbPointColor;
     stats.replacementPath = "15FLT/shape_010.glb";
+    resetLogCapture();
     assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "GLB topology matches legacy",
+                       "matching 3D topology logs success");
+
+    stats.glbLines = 2;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "GLB topology differs",
+                       "3D comparison logs topology mismatch");
+    stats.glbLines = 1;
+
+    stats.missingSourceMeta = 1;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "lacks order-sensitive source metadata",
+                       "3D comparison logs missing source metadata");
+    stats.missingSourceMeta = 0;
+
+    glbLineColor[13] = 2;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "line color coverage differs",
+                       "3D comparison logs color coverage mismatch");
+    glbLineColor[13] = 1;
 
     uint8 r = 0, g = 0, b = 0;
     gfx_paletteRGB(12, &r, &g, &b);
@@ -164,6 +379,11 @@ int main() {
 #if !defined(_WIN32)
     unsetenv("F15_COMPARE_REPLACEMENTS");
 #endif
+#ifdef DEBUG
+    assetCompareTestSetEnabled(0);
+#endif
+    SDL_SetLogOutputFunction(nullptr, nullptr);
+    SDL_ResetLogPriorities();
     std::cout << "asset_compare_behavior_tests passed\n";
     return 0;
 }

--- a/tests/asset_compare_behavior_tests.cpp
+++ b/tests/asset_compare_behavior_tests.cpp
@@ -1,0 +1,169 @@
+#include "shared/asset_compare.h"
+#include "gfx_impl.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+namespace {
+
+enum AssetCompareTestConstant : int {
+    kPaletteEntries = 2,
+    kImageWidth = 2,
+    kImageHeight = 2,
+    kFontGlyphs = 96,
+    kFontHeight = 1,
+    kFontWidth = 8,
+    kCueRate = 7850,
+    kTestFailureExitCode = 1,
+};
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(kTestFailureExitCode);
+    }
+}
+
+void fillColorCoverage(int *values, int color, int count) {
+    std::memset(values, 0, sizeof(int) * 256);
+    values[color & 0xff] = count;
+}
+
+} // namespace
+
+int eg3drast_testReplacementColorFromMaterial(float r, float g, float b, int sourceColor);
+int eg3drast_testReplacementLineNearClip(long aDepth, long bDepth);
+
+int main() {
+#if !defined(_WIN32)
+    unsetenv("F15_COMPARE_REPLACEMENTS");
+#endif
+    require(!assetCompareEnabled(),
+            "assetCompareEnabled is off during normal test/runtime execution");
+
+#if !defined(_WIN32)
+    setenv("F15_COMPARE_REPLACEMENTS", "1", 1);
+#endif
+    require(!assetCompareEnabled(),
+            "assetCompareEnabled ignores runtime environment variables");
+
+    const uint8 legacyBytes[] = {1, 2, 3, 4};
+    const uint8 modernBytes[] = {1, 2, 3, 4};
+    assetCompareNamedBytes("bytes",
+                           "modern bytes match",
+                           "modern bytes differ",
+                           "modern",
+                           legacyBytes,
+                           sizeof(legacyBytes),
+                           modernBytes,
+                           sizeof(modernBytes),
+                           "bytes.replacement");
+    assetCompareStructuredBytes("VN.WLD",
+                                legacyBytes,
+                                sizeof(legacyBytes),
+                                modernBytes,
+                                sizeof(modernBytes),
+                                "VN/VN.WLD.json");
+
+    const uint8 legacyPixels[] = {1, 2, 3, 4};
+    const uint8 modernPixels[] = {1, 2, 3, 4};
+    assetCompareIndexedPixels2D("TITLE.PIC",
+                                legacyPixels,
+                                kImageWidth,
+                                modernPixels,
+                                kImageWidth,
+                                kImageWidth,
+                                kImageHeight,
+                                "TITLE.png");
+
+    const uint8 legacyRgb[kPaletteEntries * 3] = {0, 0, 0, 63, 31, 0};
+    const uint8 modernRgb[kPaletteEntries * 3] = {0, 0, 0, 63, 31, 0};
+    assetCompareRgbPalettes("TITLE.PIC",
+                            legacyRgb,
+                            kPaletteEntries,
+                            modernRgb,
+                            kPaletteEntries,
+                            "TITLE.png");
+
+    uint8 legacyFontBitmap[kFontGlyphs * kFontHeight] = {};
+    uint8 modernFontBitmap[kFontGlyphs * kFontHeight] = {};
+    uint8 legacyFontWidths[kFontGlyphs] = {};
+    uint8 modernFontWidths[kFontGlyphs] = {};
+    for (int i = 0; i < kFontGlyphs; i++) {
+        legacyFontBitmap[i] = modernFontBitmap[i] = static_cast<uint8>(i & 0xff);
+        legacyFontWidths[i] = modernFontWidths[i] = kFontWidth;
+    }
+    assetCompareFont96("font_3",
+                       legacyFontBitmap,
+                       legacyFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       modernFontBitmap,
+                       modernFontWidths,
+                       kFontHeight,
+                       kFontWidth,
+                       "fonts/font_3.bdf");
+
+    const uint8 legacySound[] = {9, 8, 7, 6};
+    const uint8 modernSound[] = {9, 8, 7, 6};
+    assetCompareSoundCueRange("voice_cue_000_sample0",
+                              0,
+                              sizeof(legacySound) - 1,
+                              kCueRate,
+                              legacySound,
+                              sizeof(legacySound),
+                              modernSound,
+                              sizeof(modernSound),
+                              kCueRate,
+                              "sounds/voice_cue_000_sample0.wav");
+
+    int legacyFaceColor[256];
+    int legacyLineColor[256];
+    int legacyPointColor[256];
+    int glbFaceColor[256];
+    int glbLineColor[256];
+    int glbPointColor[256];
+    fillColorCoverage(legacyFaceColor, 12, 1);
+    fillColorCoverage(glbFaceColor, 12, 1);
+    fillColorCoverage(legacyLineColor, 13, 1);
+    fillColorCoverage(glbLineColor, 13, 1);
+    fillColorCoverage(legacyPointColor, 14, 0);
+    fillColorCoverage(glbPointColor, 14, 0);
+
+    AssetCompare3dShapeStats stats = {};
+    stats.shapeId = 10;
+    stats.legacyFaces = 1;
+    stats.legacyTriangles = 2;
+    stats.legacyLines = 1;
+    stats.glbTriangles = 2;
+    stats.glbLines = 1;
+    stats.canCompareSourceColors = 1;
+    stats.legacyFaceColor = legacyFaceColor;
+    stats.legacyLineColor = legacyLineColor;
+    stats.legacyPointColor = legacyPointColor;
+    stats.glbFaceColor = glbFaceColor;
+    stats.glbLineColor = glbLineColor;
+    stats.glbPointColor = glbPointColor;
+    stats.replacementPath = "15FLT/shape_010.glb";
+    assetCompare3dShapeStats(&stats);
+
+    uint8 r = 0, g = 0, b = 0;
+    gfx_paletteRGB(12, &r, &g, &b);
+    const int colorFromMaterialA = eg3drast_testReplacementColorFromMaterial(
+        r / 255.0f, g / 255.0f, b / 255.0f, 1);
+    const int colorFromMaterialB = eg3drast_testReplacementColorFromMaterial(
+        r / 255.0f, g / 255.0f, b / 255.0f, 255);
+    require(colorFromMaterialA == colorFromMaterialB,
+            "software replacement renderer ignores sourceColor while using material RGB");
+    require(eg3drast_testReplacementLineNearClip(0, 65536L * 2) != 0,
+            "software replacement renderer keeps a line crossing the near plane");
+    require(eg3drast_testReplacementLineNearClip(0, 32768L) == 0,
+            "software replacement renderer rejects a line fully behind the near plane");
+
+#if !defined(_WIN32)
+    unsetenv("F15_COMPARE_REPLACEMENTS");
+#endif
+    std::cout << "asset_compare_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_compare_behavior_tests.cpp
+++ b/tests/asset_compare_behavior_tests.cpp
@@ -18,6 +18,8 @@ enum AssetCompareTestConstant : int {
     kFontHeight = 1,
     kFontWidth = 8,
     kCueRate = 7850,
+    k3dFormPoint = 1,
+    k3dFormEdgeRun = 2,
     kTestFailureExitCode = 1,
 };
 
@@ -87,6 +89,30 @@ int main() {
 
     const uint8 legacyBytes[] = {1, 2, 3, 4};
     const uint8 modernBytes[] = {1, 2, 3, 4};
+
+#ifdef DEBUG
+    assetCompareTestSetEnabled(0);
+#endif
+    resetLogCapture();
+    assetCompareNamedBytes("bytes",
+                           "modern bytes match",
+                           "modern bytes differ",
+                           "modern",
+                           legacyBytes,
+                           sizeof(legacyBytes),
+                           modernBytes,
+                           sizeof(modernBytes),
+                           "bytes.replacement");
+    require(g_log.calls == 0,
+            "disabled asset comparison is a no-op for byte comparisons");
+    resetLogCapture();
+    assetCompare3dShapeStats(nullptr);
+    require(g_log.calls == 0,
+            "disabled asset comparison is a no-op for 3D comparisons");
+#ifdef DEBUG
+    assetCompareTestSetEnabled(1);
+#endif
+
     resetLogCapture();
     assetCompareNamedBytes("bytes",
                            "modern bytes match",
@@ -309,6 +335,20 @@ int main() {
     requireLogContains(SDL_LOG_PRIORITY_WARN, "legacy cue range invalid",
                        "sound comparison logs invalid legacy cue range");
 
+    resetLogCapture();
+    assetCompareSoundCueRange("voice_cue_000_sample0",
+                              0,
+                              sizeof(legacySound) - 1,
+                              kCueRate,
+                              nullptr,
+                              0,
+                              modernSound,
+                              sizeof(modernSound),
+                              kCueRate,
+                              "sounds/voice_cue_000_sample0.wav");
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "no legacy F15DGTL.BIN available",
+                       "sound comparison logs missing legacy digitized blob");
+
     int legacyFaceColor[256];
     int legacyLineColor[256];
     int legacyPointColor[256];
@@ -356,12 +396,67 @@ int main() {
                        "3D comparison logs missing source metadata");
     stats.missingSourceMeta = 0;
 
+    stats.missingSourceColor = 1;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "lacks raw source color metadata",
+                       "3D comparison logs missing source color metadata");
+    stats.missingSourceColor = 0;
+
+    stats.badSourceOrder = 1;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "source primitive order is not monotonic",
+                       "3D comparison logs bad source order");
+    stats.badSourceOrder = 0;
+
+    stats.badSourceMode = 1;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "source primitive kind does not match",
+                       "3D comparison logs bad source draw mode");
+    stats.badSourceMode = 0;
+
     glbLineColor[13] = 2;
     resetLogCapture();
     assetCompare3dShapeStats(&stats);
     requireLogContains(SDL_LOG_PRIORITY_WARN, "line color coverage differs",
                        "3D comparison logs color coverage mismatch");
     glbLineColor[13] = 1;
+
+    stats.legacyForm = k3dFormPoint;
+    stats.glbPoints = 1;
+    stats.glbTriangles = 0;
+    stats.glbLines = 0;
+    fillColorCoverage(legacyPointColor, 14, 1);
+    fillColorCoverage(glbPointColor, 14, 1);
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "GLB point form matches legacy point form",
+                       "3D comparison logs matching point form");
+
+    stats.glbLines = 1;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "GLB primitive form differs from legacy point",
+                       "3D comparison logs point form mismatch");
+    stats.glbLines = 0;
+
+    stats.legacyForm = k3dFormEdgeRun;
+    stats.legacyPoints = 3;
+    stats.glbPoints = 3;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_INFO, "GLB point run count matches legacy",
+                       "3D comparison logs matching edgerun point count");
+
+    stats.glbPoints = 2;
+    resetLogCapture();
+    assetCompare3dShapeStats(&stats);
+    requireLogContains(SDL_LOG_PRIORITY_WARN, "GLB point run differs",
+                       "3D comparison logs edgerun point-count mismatch");
+    stats.legacyForm = 0;
+    stats.glbPoints = 0;
 
     uint8 r = 0, g = 0, b = 0;
     gfx_paletteRGB(12, &r, &g, &b);

--- a/tests/asset_runtime_loader_validation_tests.cpp
+++ b/tests/asset_runtime_loader_validation_tests.cpp
@@ -1,0 +1,373 @@
+#include "gfx.h"
+#include "gfx_impl.h"
+#include "headless.h"
+#include "r3d_gl.h"
+#include "shared/common.h"
+
+#include <SDL3/SDL.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+extern bool setGamePath(const char *path);
+extern void decodePic(SDL_IOStream *handle, int segment);
+extern void picBlit(SDL_IOStream *handle, int pageIndex);
+extern int loadReplacementPngToSprite(const char *filename, int segment);
+extern int asound_testCompareReplacementCues(void);
+extern int asound_testCompareReplacementIntroMusic(void);
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+#if !defined(F15_ASSET_TOOL_COMMAND)
+#define F15_ASSET_TOOL_COMMAND ""
+#endif
+
+namespace {
+
+struct Counts {
+    int structured = 0;
+    int images = 0;
+    int fonts = 0;
+    int sounds = 0;
+    int music = 0;
+    int shapes3d = 0;
+    int skippedNonRenderable3d = 0;
+};
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::string upperString(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return (char)std::toupper(c); });
+    return value;
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if !defined(_WIN32)
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#else
+    (void)root;
+#endif
+}
+
+bool isRuntimeStructuredAsset(const std::filesystem::path &path) {
+    const std::string ext = upperString(path.extension().string());
+    return ext == ".WLD" || ext == ".3DT" || ext == ".3DG";
+}
+
+bool isImageAsset(const std::filesystem::path &path) {
+    const std::string ext = upperString(path.extension().string());
+    const std::string name = upperString(path.filename().string());
+    /* 1.PIC..4.PIC are DEMO.EXE-only VGGA pictures. The current game runtime
+     * has no DEMO loader path to call, so comparing them through showPicFile
+     * would test the wrong legacy loader. They remain covered by the full
+     * converter validator until the DEMO loader is ported. */
+    if (name == "1.PIC" || name == "2.PIC" || name == "3.PIC" || name == "4.PIC") {
+        return false;
+    }
+    return ext == ".PIC" || ext == ".SPR";
+}
+
+bool is3d3Asset(const std::filesystem::path &path) {
+    return upperString(path.extension().string()) == ".3D3";
+}
+
+std::vector<unsigned char> readOpenFileBytes(const std::string &logicalName) {
+    SDL_IOStream *io = openFile(logicalName.c_str(), 0);
+    require(io != nullptr, "openFile failed for " + logicalName);
+
+    std::vector<unsigned char> out;
+    unsigned char chunk[4096];
+    for (;;) {
+        const size_t got = SDL_ReadIO(io, chunk, sizeof(chunk));
+        if (got > 0) {
+            out.insert(out.end(), chunk, chunk + got);
+            continue;
+        }
+        break;
+    }
+    fileClose(io);
+    require(!out.empty(), "openFile returned empty data for " + logicalName);
+    return out;
+}
+
+std::vector<unsigned char> readHostFile(const std::filesystem::path &path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::vector<unsigned char>(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+uint16_t rd16(const std::vector<unsigned char> &data, size_t off) {
+    require(off + 2 <= data.size(), "short read while parsing 3D3");
+    return (uint16_t)data[off] | ((uint16_t)data[off + 1] << 8);
+}
+
+std::vector<unsigned char> surfacePixels(SDL_Surface *surface) {
+    require(surface != nullptr, "missing SDL surface");
+    std::vector<unsigned char> out((size_t)surface->w * (size_t)surface->h);
+    if (SDL_MUSTLOCK(surface)) SDL_LockSurface(surface);
+    for (int y = 0; y < surface->h; y++) {
+        const unsigned char *row = (const unsigned char *)surface->pixels + (size_t)y * surface->pitch;
+        std::memcpy(out.data() + (size_t)y * surface->w, row, (size_t)surface->w);
+    }
+    if (SDL_MUSTLOCK(surface)) SDL_UnlockSurface(surface);
+    return out;
+}
+
+std::vector<unsigned char> activePaletteRgb() {
+    SDL_Palette *palette = gfx_getPalette();
+    std::vector<unsigned char> out(256u * 3u);
+    require(palette != nullptr && palette->ncolors > 0, "missing active palette");
+    const int count = palette->ncolors < 256 ? palette->ncolors : 256;
+    for (int i = 0; i < count; i++) {
+        out[(size_t)i * 3u] = palette->colors[i].r;
+        out[(size_t)i * 3u + 1u] = palette->colors[i].g;
+        out[(size_t)i * 3u + 2u] = palette->colors[i].b;
+    }
+    return out;
+}
+
+void clearSurface(SDL_Surface *surface) {
+    require(surface != nullptr, "missing SDL surface");
+    if (SDL_MUSTLOCK(surface)) SDL_LockSurface(surface);
+    std::memset(surface->pixels, 0, (size_t)surface->pitch * surface->h);
+    if (SDL_MUSTLOCK(surface)) SDL_UnlockSurface(surface);
+}
+
+void compareStructuredAssets(const std::filesystem::path &originalRoot,
+                             const std::filesystem::path &convertedRoot,
+                             Counts &counts) {
+    for (const auto &entry : std::filesystem::recursive_directory_iterator(originalRoot)) {
+        if (!entry.is_regular_file() || !isRuntimeStructuredAsset(entry.path())) continue;
+        const std::string logicalName = std::filesystem::relative(entry.path(), originalRoot).generic_string();
+        setReplacementRoot(nullptr);
+        const std::vector<unsigned char> legacy = readOpenFileBytes(logicalName);
+        setReplacementRoot(&convertedRoot);
+        const std::vector<unsigned char> replacement = readOpenFileBytes(logicalName);
+        setReplacementRoot(nullptr);
+        require(legacy == replacement, "runtime structured loader mismatch: " + logicalName);
+        counts.structured++;
+    }
+}
+
+void compareImageAsset(const std::filesystem::path &originalRoot,
+                       const std::filesystem::path &convertedRoot,
+                       const std::filesystem::path &assetPath,
+                       Counts &counts) {
+    const std::string logicalName = std::filesystem::relative(assetPath, originalRoot).generic_string();
+    const std::string upperName = upperString(assetPath.filename().string());
+    const bool isSpr = upperString(assetPath.extension().string()) == ".SPR";
+    const bool isTitle640 = upperName == "TITLE640.PIC";
+    SDL_Surface *surface = nullptr;
+    int spriteHandle = 0;
+
+    if (isTitle640) {
+        surface = gfx_getHiResSurface();
+    } else if (isSpr) {
+        spriteHandle = gfx_allocSpriteBuf();
+        require(spriteHandle != 0, "could not allocate sprite buffer for " + logicalName);
+        surface = gfx_getSpriteSurface(spriteHandle);
+    } else {
+        surface = gfx_getCurPageSurface();
+    }
+
+    clearSurface(surface);
+    const std::vector<unsigned char> paletteBeforeLegacy = activePaletteRgb();
+    setReplacementRoot(nullptr);
+    SDL_IOStream *legacyIo = openFile(logicalName.c_str(), 0);
+    require(legacyIo != nullptr, "failed to open legacy image " + logicalName);
+    if (isTitle640) picBlit(legacyIo, 0);
+    else if (isSpr) decodePic(legacyIo, spriteHandle);
+    else showPicFile(legacyIo, 0);
+    fileClose(legacyIo);
+    const std::vector<unsigned char> legacyPixels = surfacePixels(surface);
+    const std::vector<unsigned char> legacyPalette = activePaletteRgb();
+
+    clearSurface(surface);
+    setReplacementRoot(&convertedRoot);
+    int loaded = 0;
+    if (isTitle640) loaded = loadReplacementPngToHiResTitle(logicalName.c_str());
+    else if (isSpr) loaded = loadReplacementPngToSprite(logicalName.c_str(), spriteHandle);
+    else loaded = loadReplacementPngToPage(logicalName.c_str(), 0);
+    setReplacementRoot(nullptr);
+    require(loaded != 0, "missing or failed PNG replacement loader for " + logicalName);
+    const std::vector<unsigned char> replacementPixels = surfacePixels(surface);
+    const std::vector<unsigned char> replacementPalette = activePaletteRgb();
+
+    if (spriteHandle) gfx_freeSpriteBuf(spriteHandle);
+    require(legacyPixels == replacementPixels, "image runtime loader pixel mismatch: " + logicalName);
+    /* Some original PIC/SPR files contain only indices and rely on the caller's
+     * current DAC. Only assert runtime DAC equivalence when the legacy load
+     * actually changed palette state; embedded PNG palette correctness for all
+     * images is covered by the full validator. */
+    if (legacyPalette != paletteBeforeLegacy) {
+        require(legacyPalette == replacementPalette, "image runtime loader palette mismatch: " + logicalName);
+    }
+    counts.images++;
+}
+
+void compareImages(const std::filesystem::path &originalRoot,
+                   const std::filesystem::path &convertedRoot,
+                   Counts &counts) {
+    for (const auto &entry : std::filesystem::recursive_directory_iterator(originalRoot)) {
+        if (!entry.is_regular_file() || !isImageAsset(entry.path())) continue;
+        compareImageAsset(originalRoot, convertedRoot, entry.path(), counts);
+    }
+}
+
+void compareFonts(const std::filesystem::path &convertedRoot, Counts &counts) {
+    /* These are the built-in runtime font slots with captured bitmaps/widths.
+     * Enumerate the expected slots instead of discovering converted files, so a
+     * missing replacement cannot make the test silently skip that font. */
+    const int expectedFontIds[] = {0, 1, 3, 4, 5};
+
+    for (int fontId : expectedFontIds) {
+        char fontName[32] = {};
+        char replacementPath[512] = {};
+        unsigned char legacyBitmap[96 * 32] = {};
+        unsigned char replacementBitmap[96 * 32] = {};
+        unsigned char legacyWidths[96] = {};
+        unsigned char replacementWidths[96] = {};
+        int legacyHeight = 0, legacyWidth = 0, replacementHeight = 0, replacementWidth = 0;
+        std::snprintf(fontName, sizeof(fontName), "font_%d", fontId);
+        setReplacementRoot(&convertedRoot);
+        const int hasReplacement = findReplacementAssetPath(fontName, ".bdf", replacementPath, sizeof(replacementPath)) ||
+                                   findReplacementAssetPath(fontName, ".png", replacementPath, sizeof(replacementPath));
+        setReplacementRoot(nullptr);
+        require(hasReplacement != 0, "missing replacement font for font_" + std::to_string(fontId));
+        setReplacementRoot(nullptr);
+        require(gfx_testCopyBuiltinFont((uint16)fontId, legacyBitmap, sizeof(legacyBitmap), legacyWidths, sizeof(legacyWidths), &legacyHeight, &legacyWidth),
+                "missing built-in font " + std::to_string(fontId));
+        setReplacementRoot(&convertedRoot);
+        require(gfx_testCopyEffectiveFont((uint16)fontId, replacementBitmap, sizeof(replacementBitmap), replacementWidths, sizeof(replacementWidths), &replacementHeight, &replacementWidth),
+                "failed to load replacement font " + std::to_string(fontId));
+        setReplacementRoot(nullptr);
+        require(legacyHeight == replacementHeight && legacyWidth == replacementWidth,
+                "font metrics mismatch for font_" + std::to_string(fontId));
+        require(std::memcmp(legacyWidths, replacementWidths, sizeof(legacyWidths)) == 0,
+                "font width mismatch for font_" + std::to_string(fontId));
+        require(std::memcmp(legacyBitmap, replacementBitmap, (size_t)legacyHeight * 96u) == 0,
+                "font glyph bitmap mismatch for font_" + std::to_string(fontId));
+        counts.fonts++;
+    }
+}
+
+void compareSoundsAndMusic(const std::filesystem::path &convertedRoot, Counts &counts) {
+    setReplacementRoot(&convertedRoot);
+    require(asound_testCompareReplacementCues() != 0, "sound cue WAV loader comparison failed");
+    counts.sounds++;
+    require(asound_testCompareReplacementIntroMusic() != 0, "intro music ASOUND loader comparison failed");
+    counts.music++;
+    setReplacementRoot(nullptr);
+}
+
+void compare3d3(const std::filesystem::path &originalRoot,
+                const std::filesystem::path &convertedRoot,
+                Counts &counts) {
+    for (const auto &entry : std::filesystem::recursive_directory_iterator(originalRoot)) {
+        if (!entry.is_regular_file() || !is3d3Asset(entry.path())) continue;
+        const std::string logicalName = std::filesystem::relative(entry.path(), originalRoot).generic_string();
+        const std::vector<unsigned char> data = readHostFile(entry.path());
+        if (data.size() < 6) continue;
+        const uint16_t offsetWords = rd16(data, 2);
+        const size_t tableStart = 4;
+        const size_t tableBytes = (size_t)offsetWords * 2u;
+        if (tableStart + tableBytes + 2 > data.size()) continue;
+        const size_t modelSizePos = tableStart + tableBytes;
+        const uint16_t modelSize = rd16(data, modelSizePos);
+        const size_t modelStart = modelSizePos + 2;
+        if (modelStart + modelSize > data.size()) continue;
+
+        std::vector<uint16_t> offsets;
+        for (uint16_t i = 0; i < offsetWords; i++) offsets.push_back(rd16(data, tableStart + (size_t)i * 2u));
+        offsets.push_back(modelSize);
+
+        for (size_t shape = 0; shape + 1 < offsets.size(); shape++) {
+            if (offsets[shape] >= offsets[shape + 1] || offsets[shape + 1] > modelSize) continue;
+            char replacementPath[512] = {};
+            setReplacementRoot(&convertedRoot);
+            const int hasReplacement = findReplacementShapeModelPath(logicalName.c_str(), (int)shape, ".glb", replacementPath, sizeof(replacementPath)) ||
+                                       findReplacementShapeModelPath(logicalName.c_str(), (int)shape, ".glmesh", replacementPath, sizeof(replacementPath));
+            const unsigned char *legacyShape = data.data() + modelStart + offsets[shape];
+            const size_t legacyShapeSize = (size_t)(offsets[shape + 1] - offsets[shape]);
+            if (!hasReplacement) {
+                setReplacementRoot(nullptr);
+                if (r3dgl_testLegacyShapeRenderable(legacyShape, legacyShapeSize)) {
+                    require(false, "missing replacement for renderable 3D shape " + logicalName + " shape " + std::to_string(shape));
+                }
+                counts.skippedNonRenderable3d++;
+                continue;
+            }
+            require(r3dgl_testCompareReplacementMesh(logicalName.c_str(), (int)shape, legacyShape, legacyShapeSize) != 0,
+                    "3D runtime loader/source comparison failed for " + logicalName + " shape " + std::to_string(shape));
+            setReplacementRoot(nullptr);
+            counts.shapes3d++;
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    require(!originalRoot.empty() && std::filesystem::is_directory(originalRoot),
+            "F15_ORIGINAL_ASSETS must point at an original game asset directory");
+    require(!convertedRoot.empty() && std::filesystem::is_directory(convertedRoot),
+            "F15_CONVERTED_ASSETS must point at a converted_assets_all directory");
+
+    test_headless_init();
+    gfx_videoInit();
+    require(setGamePath(originalRoot.string().c_str()), "setGamePath failed for original assets");
+
+#if !defined(_WIN32)
+    if (std::string(F15_ASSET_TOOL_COMMAND).empty()) unsetenv("F15_ASSET_TOOL");
+    else setenv("F15_ASSET_TOOL", F15_ASSET_TOOL_COMMAND, 1);
+#endif
+
+    Counts counts;
+    compareStructuredAssets(originalRoot, convertedRoot, counts);
+    compareImages(originalRoot, convertedRoot, counts);
+    compareFonts(convertedRoot, counts);
+    compareSoundsAndMusic(convertedRoot, counts);
+    compare3d3(originalRoot, convertedRoot, counts);
+
+    gfx_videoShutdown();
+
+    require(counts.structured > 0, "no structured assets were compared");
+    require(counts.images > 0, "no images were compared");
+    require(counts.fonts > 0, "no fonts were compared");
+    require(counts.sounds > 0, "no sounds were compared");
+    require(counts.music > 0, "no music was compared");
+    require(counts.shapes3d > 0, "no 3D shapes were compared");
+
+    std::cout << "asset_runtime_loader_validation_tests compared real loaders: "
+              << "structured=" << counts.structured
+              << ", images=" << counts.images
+              << ", fonts=" << counts.fonts
+              << ", sound_groups=" << counts.sounds
+              << ", music_groups=" << counts.music
+              << ", shapes3d=" << counts.shapes3d
+              << ", skipped_non_renderable_3d=" << counts.skippedNonRenderable3d << '\n';
+    return 0;
+}

--- a/tests/eg3drast_internal_behavior_tests.cpp
+++ b/tests/eg3drast_internal_behavior_tests.cpp
@@ -12,6 +12,16 @@
 
 #include "../src/eg3drast.c"
 
+/* eg3drast.c now contains software replacement-GLB helpers that map material RGB
+ * through gfx_impl.c in normal builds. This internal harness intentionally does
+ * not link gfx_impl.c, so provide a deterministic palette stub; the tests here
+ * exercise rasterizer math, not active DAC nearest-colour search. */
+int gfx_nearestPaletteIndexRgb8(uint8 r, uint8 g, uint8 b) {
+    (void)g;
+    (void)b;
+    return r & 0x0f;
+}
+
 /* Backs egdata.c's regnStr global (defined in stdata.c, not linked here). MSVC
  * links whole objects so this reference needs a definition; unused by the test. */
 char aRegn_xxx[] = "regn.xxx";

--- a/tests/file_io_behavior_tests.cpp
+++ b/tests/file_io_behavior_tests.cpp
@@ -1,9 +1,14 @@
 #include "shared/common.h"
+#include "r3d_gl.h"
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <cstdlib>
+#include <cstring>
+#include <tuple>
+#include <utility>
 #if !defined(_WIN32)
 #include <sys/wait.h>
 #include <unistd.h>
@@ -12,6 +17,7 @@
 /* file_io helpers not surfaced through common.h. */
 extern int fileReadRaw(SDL_IOStream *io, void *dst, int count);
 extern void errorAndExit(const char *msg);
+extern bool setGamePath(const char *path);
 
 namespace {
 
@@ -36,6 +42,7 @@ enum FileIoOriginalConstant : int {
     kSingleByte = 1,
     kErrorExitStatus = 1,
     kScratchBufferBytes = 8,
+    kReplacementPathBufferBytes = 512,
 };
 
 void require(bool condition, const char *message) {
@@ -48,6 +55,131 @@ void require(bool condition, const char *message) {
 std::string readWholeFile(const std::filesystem::path &path) {
     std::ifstream in(path, std::ios::binary);
     return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+void writeBinaryFile(const std::filesystem::path &path, const std::string &bytes) {
+    if (!path.parent_path().empty()) {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    std::ofstream out(path, std::ios::binary);
+    out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+void putLe32(std::string &out, unsigned value) {
+    for (int i = 0; i < 4; i++) out.push_back(static_cast<char>((value >> (8 * i)) & 0xff));
+}
+
+void putLe16(std::string &out, unsigned value) {
+    for (int i = 0; i < 2; i++) out.push_back(static_cast<char>((value >> (8 * i)) & 0xff));
+}
+
+void putF32(std::string &out, float value) {
+    static_assert(sizeof(float) == 4, "GLMESH fixture assumes IEEE float32");
+    const unsigned char *p = reinterpret_cast<const unsigned char *>(&value);
+    out.append(reinterpret_cast<const char *>(p), 4);
+}
+
+std::string minimalGlmeshFixture() {
+    std::string out;
+    out.append("F15GLM3", 7);
+    out.push_back('\0');
+    out.append(32, '0'); // source GLB MD5 placeholder; standalone cache path does not require matching a GLB.
+    putLe32(out, 1);     // primitive count
+    putLe32(out, 1);     // GL_LINES
+    putLe32(out, 2);     // two vertices
+    putLe32(out, 2);     // source_kind=line
+    putLe32(out, 0);     // source_index
+    putLe32(out, 13);    // source_color
+    putLe32(out, 1);     // source_order_sensitive
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    return out;
+}
+
+void appendGlmeshPrimitive(std::string &out, unsigned mode, unsigned nVerts,
+                           unsigned sourceKind, unsigned sourceIndex,
+                           unsigned sourceColor) {
+    putLe32(out, mode);
+    putLe32(out, nVerts);
+    putLe32(out, sourceKind);
+    putLe32(out, sourceIndex);
+    putLe32(out, sourceColor);
+    putLe32(out, 1); // source_order_sensitive; required for strict test-time proof.
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 1.0f);
+}
+
+std::string compareableGlmeshFixture() {
+    std::string out;
+    out.append("F15GLM3", 7);
+    out.push_back('\0');
+    out.append(32, '0');
+    putLe32(out, 2); // one face primitive plus one line primitive
+
+    appendGlmeshPrimitive(out, 4, 3, 1, 0, 12);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+
+    appendGlmeshPrimitive(out, 1, 2, 2, 0, 13);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    putF32(out, 1.0f);
+    putF32(out, 0.0f);
+    putF32(out, 0.0f);
+    return out;
+}
+
+std::string compareableLegacyModelFixture() {
+    std::string out;
+    out.push_back('\0'); // render mode
+    out.push_back('\0'); // MODEL opcode: zero normals, no sort flag
+    out.push_back('\3'); // three inline vertices
+    for (const auto &[x, y, z] : {std::tuple<int, int, int>{0, 0, 0},
+                                  std::tuple<int, int, int>{1, 0, 0},
+                                  std::tuple<int, int, int>{0, 1, 0}}) {
+        putLe16(out, 0); // visibility mask
+        putLe16(out, static_cast<unsigned>(x));
+        putLe16(out, static_cast<unsigned>(y));
+        putLe16(out, static_cast<unsigned>(z));
+    }
+    out.push_back('\3'); // edges
+    for (const auto &[a, b] : {std::pair<int, int>{0, 1},
+                               std::pair<int, int>{1, 2},
+                               std::pair<int, int>{2, 0}}) {
+        putLe16(out, 0);
+        out.push_back(static_cast<char>(a));
+        out.push_back(static_cast<char>(b));
+    }
+    out.push_back('\2'); // primitive commands
+    out.push_back('\1'); // face opcode
+    out.push_back('\3'); // edge count
+    out.push_back('\0');
+    out.push_back('\1');
+    out.push_back('\2');
+    out.push_back('\14'); // raw face color 12
+    out.push_back('\0');  // line opcode
+    putLe16(out, 0);
+    out.push_back('\0');  // edge index
+    out.push_back('\15'); // raw line color 13
+    return out;
 }
 
 } // namespace
@@ -94,6 +226,167 @@ int main() {
     fileClose(output);
     require(readWholeFile(testDir / "newfile.bin") == "123", "fileWrite persisted bytes");
 
+    const auto replacementRoot = testDir / "replacement_pack";
+    const auto convertedRoot = replacementRoot / "converted_assets_all";
+    std::filesystem::create_directories(convertedRoot);
+#if !defined(_WIN32)
+    setenv("F15_REPLACEMENT_ROOT", replacementRoot.string().c_str(), 1);
+#endif
+
+    writeBinaryFile(convertedRoot / "TITLE.png", "PNG");
+    writeBinaryFile(convertedRoot / "fonts" / "font_3.bdf", "BDF");
+    writeBinaryFile(convertedRoot / "sounds" / "voice_cue_000_sample0.wav", "WAV");
+    writeBinaryFile(convertedRoot / "VN" / "shape_049_SAM_Radar.glb", "GLB");
+    writeBinaryFile(convertedRoot / "VN" / "cache" / "shape_050.glmesh", minimalGlmeshFixture());
+
+    char replacementPath[kReplacementPathBufferBytes] = {};
+    require(findReplacementAssetPath("title.pic", ".png", replacementPath, sizeof(replacementPath)) &&
+                std::filesystem::path(replacementPath).filename() == "TITLE.png",
+            "findReplacementAssetPath resolves PNG replacements from converted_assets_all");
+    require(findReplacementAssetPath("font_3", ".bdf", replacementPath, sizeof(replacementPath)) &&
+                std::filesystem::path(replacementPath).filename() == "font_3.bdf",
+            "findReplacementAssetPath resolves BDF font replacements");
+    require(findReplacementAssetPath("voice_cue_000_sample0", ".wav", replacementPath, sizeof(replacementPath)) &&
+                std::filesystem::path(replacementPath).filename() == "voice_cue_000_sample0.wav",
+            "findReplacementAssetPath resolves separate WAV cue replacements");
+    require(findReplacementShapeModelPath("vn.3d3", 49, ".glb", replacementPath, sizeof(replacementPath)) &&
+                std::filesystem::path(replacementPath).filename() == "shape_049_SAM_Radar.glb",
+            "findReplacementShapeModelPath resolves labelled per-shape GLB replacements");
+    require(findReplacementShapeModelPath("vn.3d3", 50, ".glmesh", replacementPath, sizeof(replacementPath)) &&
+                std::filesystem::path(replacementPath).filename() == "shape_050.glmesh",
+            "findReplacementShapeModelPath resolves generated cache GLMESH replacements");
+
+    writeBinaryFile(testDir / "unrelated_tree" / "UNRELATED.png", "NOT_A_REPLACEMENT");
+    require(!findReplacementAssetPath("UNRELATED.PIC", ".png", replacementPath, sizeof(replacementPath)),
+            "findReplacementAssetPath does not recursively scan arbitrary game/current directories");
+
+    int primitiveCount = 0;
+    require(r3dgl_testLoadReplacementMesh("vn.3d3", 50, &primitiveCount) &&
+                primitiveCount == 1,
+            "GL backend runtime loader parses standalone GLMESH replacement cache");
+
+    writeBinaryFile(convertedRoot / "VN" / "cache" / "shape_052.glmesh", compareableGlmeshFixture());
+    const std::string legacyModel = compareableLegacyModelFixture();
+    require(r3dgl_testCompareReplacementMesh(
+                "vn.3d3",
+                52,
+                reinterpret_cast<const unsigned char *>(legacyModel.data()),
+                legacyModel.size()),
+            "GL backend test seam compares replacement GLMESH against decoded legacy 3D shape");
+
+    for (int shape = 100; shape < 230; shape++) {
+        writeBinaryFile(convertedRoot / "VN" / "cache" /
+                            ("shape_" + std::to_string(shape) + ".glmesh"),
+                        minimalGlmeshFixture());
+        primitiveCount = 0;
+        require(r3dgl_testLoadReplacementMesh("vn.3d3", shape, &primitiveCount) &&
+                    primitiveCount == 1,
+                "GL backend replacement mesh cache grows past the old fixed-size limit");
+    }
+#if !defined(_WIN32)
+    const auto fakeTool = testDir / "fake_asset_tool.py";
+    {
+        std::ofstream tool(fakeTool);
+        tool << "#!/usr/bin/env python3\n"
+                "import hashlib\n"
+                "import struct\n"
+                "import sys\n"
+                "def put32(v):\n"
+                "    return struct.pack('<I', v)\n"
+                "def putf(v):\n"
+                "    return struct.pack('<f', v)\n"
+                "if len(sys.argv) > 1 and sys.argv[1] == 'build-glmesh':\n"
+                "    with open(sys.argv[2], 'rb') as f:\n"
+                "        source_md5 = hashlib.md5(f.read()).hexdigest().encode('ascii')\n"
+                "    # Emit the smallest renderable F15GLM3 cache. The runtime\n"
+                "    # uses this generated cache as an implementation detail for\n"
+                "    # editable GLB replacements, so tests should cover this path\n"
+                "    # separately from direct standalone .glmesh loading.\n"
+                "    out = bytearray(b'F15GLM3\\0')\n"
+                "    out.extend(source_md5)\n"
+                "    out.extend(put32(1))\n"
+                "    out.extend(put32(1))\n"
+                "    out.extend(put32(2))\n"
+                "    out.extend(put32(2))\n"
+                "    out.extend(put32(0))\n"
+                "    out.extend(put32(13))\n"
+                "    out.extend(put32(1))\n"
+                "    out.extend(putf(1.0) + putf(0.0) + putf(0.0) + putf(1.0))\n"
+                "    out.extend(putf(0.0) + putf(0.0) + putf(0.0))\n"
+                "    out.extend(putf(1.0) + putf(0.0) + putf(0.0))\n"
+                "    sys.stdout.buffer.write(out)\n"
+                "else:\n"
+                "    sys.stdout.buffer.write(b'JSONBRIDGE')\n";
+    }
+    std::filesystem::permissions(
+        fakeTool,
+        std::filesystem::perms::owner_exec | std::filesystem::perms::owner_read | std::filesystem::perms::owner_write,
+        std::filesystem::perm_options::add);
+    setenv("F15_ASSET_TOOL", fakeTool.string().c_str(), 1);
+
+    writeBinaryFile(convertedRoot / "VN" / "shape_051_Custom.glb", "GLB_SOURCE");
+    primitiveCount = 0;
+    require(r3dgl_testLoadReplacementMesh("vn.3d3", 51, &primitiveCount) &&
+                primitiveCount == 1 &&
+                std::filesystem::exists(convertedRoot / "VN" / "cache" / "shape_051_Custom.glmesh"),
+            "GL backend runtime loader builds and caches GLMESH from editable GLB replacement");
+
+    writeBinaryFile("LIBYA.WLD", "LEGACYWLD");
+    writeBinaryFile(convertedRoot / "LIBYA" / "LIBYA.WLD.json", "{\"format\":\"WLD\"}\n");
+    input = openFile("Libya.wld", kDosReadMode);
+    require(input != nullptr, "openFile opens structured JSON replacement stream");
+    char jsonBridgeBuf[16] = {};
+    require(fileReadRaw(input, jsonBridgeBuf, kReadWholeRemainingStream) == 10,
+            "openFile reads rebuilt structured JSON replacement bytes");
+    require(std::string(jsonBridgeBuf, 10) == "JSONBRIDGE",
+            "openFile prefers WLD JSON replacement over legacy file");
+    fileClose(input);
+
+    writeBinaryFile("VN.3DT", "LEGACY3DT");
+    writeBinaryFile(convertedRoot / "VN" / "VN.3DT.json", "{\"format\":\"3DT\"}\n");
+    input = openFile("VN.3DT", kDosReadMode);
+    require(input != nullptr, "openFile opens 3DT JSON replacement stream");
+    std::memset(jsonBridgeBuf, 0, sizeof(jsonBridgeBuf));
+    require(fileReadRaw(input, jsonBridgeBuf, kReadWholeRemainingStream) == 10,
+            "openFile reads rebuilt 3DT JSON replacement bytes");
+    require(std::string(jsonBridgeBuf, 10) == "JSONBRIDGE",
+            "openFile prefers 3DT JSON replacement over legacy file");
+    fileClose(input);
+
+    writeBinaryFile("VN.3DG", "LEGACY3DG");
+    writeBinaryFile(convertedRoot / "VN" / "VN.3DG.json", "{\"format\":\"3DG\"}\n");
+    input = openFile("VN.3DG", kDosReadMode);
+    require(input != nullptr, "openFile opens 3DG JSON replacement stream");
+    std::memset(jsonBridgeBuf, 0, sizeof(jsonBridgeBuf));
+    require(fileReadRaw(input, jsonBridgeBuf, kReadWholeRemainingStream) == 10,
+            "openFile reads rebuilt 3DG JSON replacement bytes");
+    require(std::string(jsonBridgeBuf, 10) == "JSONBRIDGE",
+            "openFile prefers 3DG JSON replacement over legacy file");
+    fileClose(input);
+
+    writeBinaryFile("FULL.3D3", "LEGACYFULL3D3");
+    writeBinaryFile(convertedRoot / "FULL" / "FULL.3D3.json", "{\"format\":\"3D3\",\"model_data\":[]}\n");
+    input = openFile("FULL.3D3", kDosReadMode);
+    require(input != nullptr, "openFile opens full 3D3 JSON replacement stream");
+    std::memset(jsonBridgeBuf, 0, sizeof(jsonBridgeBuf));
+    require(fileReadRaw(input, jsonBridgeBuf, kReadWholeRemainingStream) == 10,
+            "openFile reads rebuilt full 3D3 JSON replacement bytes");
+    require(std::string(jsonBridgeBuf, 10) == "JSONBRIDGE",
+            "openFile prefers full 3D3 JSON replacement when model_data is present");
+    fileClose(input);
+
+    writeBinaryFile("LB.3D3", "LEGACY3D3");
+    writeBinaryFile(convertedRoot / "LIBYA" / "LB.3D3.json", "{\"format\":\"3D3\"}\n");
+    input = openFile("LB.3D3", kDosReadMode);
+    require(input != nullptr, "openFile falls back to legacy 3D3 when JSON index is minimized");
+    char legacy3dBuf[16] = {};
+    require(fileReadRaw(input, legacy3dBuf, kReadWholeRemainingStream) == 9,
+            "openFile reads legacy 3D3 bytes when minimized JSON has no model_data");
+    require(std::string(legacy3dBuf, 9) == "LEGACY3D3",
+            "minimized 3D3 JSON does not replace the table/fallback byte stream");
+    fileClose(input);
+#endif
+
     // Null/zero-size guards: the I/O helpers reject bad streams before dereferencing.
     require(fileReadRaw(nullptr, buf, kSingleByte) == kNullStreamError,
             "fileReadRaw reports null stream");
@@ -125,6 +418,10 @@ int main() {
 #endif
 
     std::filesystem::current_path(oldCwd);
+#if !defined(_WIN32)
+    unsetenv("F15_REPLACEMENT_ROOT");
+    unsetenv("F15_ASSET_TOOL");
+#endif
     std::filesystem::remove_all(testDir);
 
     std::cout << "file_io_behavior_tests passed\n";

--- a/tests/gfx_render_behavior_tests.cpp
+++ b/tests/gfx_render_behavior_tests.cpp
@@ -16,12 +16,15 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 
 // clearRect is declared per-program (endcode.h/stcode.h) with differing arg
 // names; declare it locally to avoid pulling in a program-specific header. Word
 // 0 of the pageDesc is the page index, word 3 the fill colour.
 void clearRect(int16 *pageDesc, int16 x1, int16 y1, int16 x2, int16 y2);
+int loadReplacementPngToPage(const char *filename, int page);
 
 namespace {
 
@@ -40,6 +43,7 @@ enum GfxRenderConstant : int {
     kFont0Advance = 4,
     // gfx_setFont fallback advance for a NULL/absent table or a control char.
     kFontFallbackAdvance = 8,
+    kReplacementFontAdvance = 11,
     // A char >= 0x80 is an inline colour escape: no glyph, zero advance.
     kColorEscapeChar = 0x90,
     kFirstPrintable = 0x20,
@@ -68,6 +72,61 @@ void fillPageRaw(int page, uint8 color) {
     uint8 *px = gfx_pagePixels(page, &pitch);
     for (int y = 0; y < kLogicalHeight; y++)
         std::memset(px + (size_t)y * pitch, color, kLogicalWidth);
+}
+
+void writeReplacementBdf(const std::filesystem::path &root, int fontId) {
+    const auto fontPath = root / "converted_assets_all" / "fonts" / ("font_" + std::to_string(fontId) + ".bdf");
+    std::filesystem::create_directories(fontPath.parent_path());
+    std::ofstream out(fontPath);
+    out << "STARTFONT 2.1\n"
+           "FONT replacement\n"
+           "SIZE 5 75 75\n"
+           "FONTBOUNDINGBOX 4 5 0 0\n"
+           "STARTPROPERTIES 2\n"
+           "FONT_ASCENT 5\n"
+           "FONT_DESCENT 0\n"
+           "ENDPROPERTIES\n"
+           "CHARS 96\n";
+    for (int ch = 0x20; ch < 0x80; ch++) {
+        out << "STARTCHAR U+" << std::hex << ch << std::dec << "\n"
+            << "ENCODING " << ch << "\n"
+            << "SWIDTH 500 0\n"
+            << "DWIDTH " << kReplacementFontAdvance << " 0\n"
+            << "BBX 4 5 0 0\n"
+            << "BITMAP\n"
+            << "F0\n90\nF0\n90\nF0\n"
+            << "ENDCHAR\n";
+    }
+    out << "ENDFONT\n";
+}
+
+void writeReplacementPng(const std::filesystem::path &root) {
+    static const unsigned char kRedPng[] = {
+        137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,2,0,0,0,2,8,6,0,0,0,114,182,13,36,0,0,0,17,73,68,65,84,120,156,99,248,207,192,240,31,132,25,96,12,0,71,202,7,249,103,89,110,183,0,0,0,0,73,69,78,68,174,66,96,130
+    };
+    const auto pngPath = root / "converted_assets_all" / "TITLE.png";
+    std::filesystem::create_directories(pngPath.parent_path());
+    std::ofstream out(pngPath, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(kRedPng), sizeof(kRedPng));
+}
+
+void writeReplacementFontPng(const std::filesystem::path &root, int fontId) {
+    static const unsigned char kFontAtlasPng[] = {
+        137,80,78,71,13,10,26,10,0,0,0,13,73,72,68,82,0,0,0,111,
+        0,0,0,41,8,6,0,0,0,59,196,119,17,0,0,0,134,73,68,65,
+        84,120,218,237,215,49,14,0,16,20,68,65,247,191,52,10,18,17,250,191,
+        201,108,233,117,10,49,173,207,181,207,180,226,173,175,105,129,109,31,190,162,
+        86,188,157,7,119,212,138,55,23,17,220,60,67,217,205,82,231,11,142,10,
+        26,42,104,168,128,10,26,42,104,168,96,190,217,168,160,161,130,134,10,168,
+        224,34,80,65,67,5,67,5,84,208,80,65,67,5,13,21,80,65,67,5,
+        67,5,84,208,80,65,67,5,13,21,80,65,67,5,67,5,205,23,28,21,
+        52,84,208,80,1,21,60,81,17,109,0,253,218,112,113,4,124,59,36,0,
+        0,0,0,73,69,78,68,174,66,96,130
+    };
+    const auto pngPath = root / "converted_assets_all" / "fonts" / ("font_" + std::to_string(fontId) + ".png");
+    std::filesystem::create_directories(pngPath.parent_path());
+    std::ofstream out(pngPath, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(kFontAtlasPng), sizeof(kFontAtlasPng));
 }
 
 // ---- gfx_pagePixels + page-1 aliasing -------------------------------------
@@ -255,9 +314,23 @@ void test_setFont() {
             "a >=0x80 inline colour escape has zero advance");
     require(gfx_setFont(0x10, 0) == kFontFallbackAdvance,
             "a control char below the first printable falls back to advance 8");
-    // A real proportional font returns a positive, bounded advance for a glyph.
-    int w = gfx_setFont('W', 4);
-    require(w > 0 && w <= 32, "a proportional font returns a positive bounded advance");
+    int16 textParams[7] = {};
+    textParams[0] = 0;  // page
+    textParams[2] = 7;  // color
+    textParams[4] = 10; // x
+    textParams[5] = 10; // y
+    textParams[6] = 4;  // font id
+    gfx_drawString(textParams, "A");
+    require(gfx_setFont('A', 4) == kReplacementFontAdvance,
+            "gfx_drawString lazily installs a BDF replacement font width table");
+
+    fillPageRaw(0, 0);
+    textParams[4] = 40;
+    textParams[5] = 40;
+    textParams[6] = 5;
+    gfx_drawString(textParams, " ");
+    require(pagePixel(0, 40, 40) == 7,
+            "gfx_drawString lazily installs a PNG atlas replacement font when BDF is absent");
 }
 
 // ---- gfx_calcRowAddr / gfx_getRowOffset / blitOffset round-trip -----------
@@ -289,6 +362,16 @@ void test_dacPalette() {
     require(r == 255, "gfx_setDacRange expands 6-bit 0x3F to 8-bit 255");
     require(g == 170, "gfx_setDacRange expands 6-bit 0x2A to 8-bit 170");
     require(b == 0, "gfx_setDacRange expands 6-bit 0x00 to 8-bit 0");
+}
+
+void test_replacementPngLoader() {
+    uint8 redDac[3] = {0x3f, 0x00, 0x00};
+    gfx_setDacRange(12, 1, redDac);
+    fillPageRaw(0, 0);
+    require(loadReplacementPngToPage("TITLE.PIC", 0) != 0,
+            "loadReplacementPngToPage loads a modern PNG replacement");
+    require(pagePixel(0, 0, 0) != 0 && pagePixel(0, 1, 1) != 0,
+            "loadReplacementPngToPage writes decoded PNG pixels into the page surface");
 }
 
 // Deterministically compose a small scene into `page` using the primitives
@@ -354,6 +437,15 @@ void test_goldenInitialStateInjection() {
 } // namespace
 
 int main() {
+    const auto replacementRoot = std::filesystem::temp_directory_path() / "f15se2-ex-gfx-replacements";
+    std::filesystem::remove_all(replacementRoot);
+    writeReplacementBdf(replacementRoot, 4);
+    writeReplacementFontPng(replacementRoot, 5);
+    writeReplacementPng(replacementRoot);
+#if !defined(_WIN32)
+    setenv("F15_REPLACEMENT_ROOT", replacementRoot.string().c_str(), 1);
+#endif
+
     test_headless_init();
     gfx_videoInit();
     // The game enters the 320x200 mode before any flight drawing; this also
@@ -371,8 +463,14 @@ int main() {
     test_setFont();
     test_rowAddrAndBlitOffset();
     test_dacPalette();
+    test_replacementPngLoader();
     test_goldenComposedScene();
     test_goldenInitialStateInjection();
+
+#if !defined(_WIN32)
+    unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+    std::filesystem::remove_all(replacementRoot);
 
     std::cout << "gfx_render_behavior_tests passed\n";
     return 0;

--- a/tests/gfx_render_behavior_tests.cpp
+++ b/tests/gfx_render_behavior_tests.cpp
@@ -86,7 +86,7 @@ void writeReplacementBdf(const std::filesystem::path &root, int fontId) {
            "FONT_ASCENT 5\n"
            "FONT_DESCENT 0\n"
            "ENDPROPERTIES\n"
-           "CHARS 96\n";
+           "CHARS 99\n";
     for (int ch = 0x20; ch < 0x80; ch++) {
         out << "STARTCHAR U+" << std::hex << ch << std::dec << "\n"
             << "ENCODING " << ch << "\n"
@@ -97,6 +97,30 @@ void writeReplacementBdf(const std::filesystem::path &root, int fontId) {
             << "F0\n90\nF0\n90\nF0\n"
             << "ENDCHAR\n";
     }
+    out << "STARTCHAR U+041F\n"
+        << "ENCODING 1055\n"
+        << "SWIDTH 500 0\n"
+        << "DWIDTH " << kReplacementFontAdvance << " 0\n"
+        << "BBX 4 5 0 0\n"
+        << "BITMAP\n"
+        << "F0\n90\n90\n90\n90\n"
+        << "ENDCHAR\n";
+    out << "STARTCHAR U+00C4\n"
+        << "ENCODING 196\n"
+        << "SWIDTH 500 0\n"
+        << "DWIDTH " << kReplacementFontAdvance << " 0\n"
+        << "BBX 4 5 0 0\n"
+        << "BITMAP\n"
+        << "90\nF0\n90\nF0\n90\n"
+        << "ENDCHAR\n";
+    out << "STARTCHAR U+0141\n"
+        << "ENCODING 321\n"
+        << "SWIDTH 500 0\n"
+        << "DWIDTH " << kReplacementFontAdvance << " 0\n"
+        << "BBX 4 5 0 0\n"
+        << "BITMAP\n"
+        << "80\nA0\nC0\nA0\nF0\n"
+        << "ENDCHAR\n";
     out << "ENDFONT\n";
 }
 
@@ -127,6 +151,13 @@ void writeReplacementFontPng(const std::filesystem::path &root, int fontId) {
     std::filesystem::create_directories(pngPath.parent_path());
     std::ofstream out(pngPath, std::ios::binary);
     out.write(reinterpret_cast<const char *>(kFontAtlasPng), sizeof(kFontAtlasPng));
+}
+
+void writeInvalidReplacementBdf(const std::filesystem::path &root, int fontId) {
+    const auto fontPath = root / "converted_assets_all" / "fonts" / ("font_" + std::to_string(fontId) + ".bdf");
+    std::filesystem::create_directories(fontPath.parent_path());
+    std::ofstream out(fontPath);
+    out << "STARTFONT 2.1\nFONT invalid\nCHARS 0\nENDFONT\n";
 }
 
 // ---- gfx_pagePixels + page-1 aliasing -------------------------------------
@@ -323,6 +354,22 @@ void test_setFont() {
     gfx_drawString(textParams, "A");
     require(gfx_setFont('A', 4) == kReplacementFontAdvance,
             "gfx_drawString lazily installs a BDF replacement font width table");
+    require(gfx_setFont(0x041f, 4) == kReplacementFontAdvance,
+            "BDF replacement font exposes Unicode glyph widths");
+    require(gfx_setFont(0x00c4, 4) == kReplacementFontAdvance,
+            "BDF replacement font exposes German Unicode glyph widths");
+    require(gfx_setFont(0x0141, 4) == kReplacementFontAdvance,
+            "BDF replacement font exposes Polish Unicode glyph widths");
+
+    fillPageRaw(0, 0);
+    textParams[4] = 70;
+    textParams[5] = 70;
+    textParams[6] = 4;
+    gfx_drawString(textParams, "\xd0\x9f");
+    require(pagePixel(0, 70, 70) == 7,
+            "gfx_drawString decodes UTF-8 and draws a BDF Unicode glyph");
+    require(textParams[4] == 70 + kReplacementFontAdvance,
+            "UTF-8 BDF Unicode glyph advances by its replacement width");
 
     fillPageRaw(0, 0);
     textParams[4] = 40;
@@ -441,6 +488,7 @@ int main() {
     std::filesystem::remove_all(replacementRoot);
     writeReplacementBdf(replacementRoot, 4);
     writeReplacementFontPng(replacementRoot, 5);
+    writeInvalidReplacementBdf(replacementRoot, 5);
     writeReplacementPng(replacementRoot);
 #if !defined(_WIN32)
     setenv("F15_REPLACEMENT_ROOT", replacementRoot.string().c_str(), 1);

--- a/tests/shared_overlay_behavior_tests.cpp
+++ b/tests/shared_overlay_behavior_tests.cpp
@@ -7,10 +7,13 @@
 #include "const.h"
 #include "input.h"
 #include "headless.h"
+#include "egcode.h"
 
 #include <SDL3/SDL.h>
 
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <thread>
 
@@ -34,6 +37,7 @@ enum SharedOverlayOriginalConstant : int {
     kCtrlXAscii = 0x18,
     kPrintableTextA = 'A',
     kBlockingPushDelayMs = 5,
+    kReplacementCueSpanBytes = 0x7d9e,
     kTestFailureExitCode = 1,
 };
 
@@ -44,9 +48,41 @@ void require(bool condition, const char *message) {
     }
 }
 
+void writePcm8Wav(const std::filesystem::path &path) {
+    std::filesystem::create_directories(path.parent_path());
+    const unsigned sampleRate = 7850;
+    const unsigned dataSize = 4;
+    const unsigned riffSize = 36 + dataSize;
+    std::ofstream out(path, std::ios::binary);
+    auto put = [&](unsigned value, int bytes) {
+        for (int i = 0; i < bytes; i++) out.put(static_cast<char>((value >> (8 * i)) & 0xff));
+    };
+    out.write("RIFF", 4);
+    put(riffSize, 4);
+    out.write("WAVEfmt ", 8);
+    put(16, 4);          // PCM fmt chunk size
+    put(1, 2);           // PCM
+    put(1, 2);           // mono
+    put(sampleRate, 4);
+    put(sampleRate, 4);  // byte rate: mono 8-bit
+    put(1, 2);           // block align
+    put(8, 2);           // bits per sample
+    out.write("data", 4);
+    put(dataSize, 4);
+    const char samples[4] = {static_cast<char>(0x80), static_cast<char>(0x90), static_cast<char>(0x70), static_cast<char>(0x80)};
+    out.write(samples, sizeof(samples));
+}
+
 } // namespace
 
 int main() {
+    const auto replacementRoot = std::filesystem::temp_directory_path() / "f15se2-ex-audio-replacements";
+    std::filesystem::remove_all(replacementRoot);
+    writePcm8Wav(replacementRoot / "converted_assets_all" / "sounds" / "voice_cue_000_sample0.wav");
+#if !defined(_WIN32)
+    setenv("F15_REPLACEMENT_ROOT", replacementRoot.string().c_str(), 1);
+#endif
+
     test_headless_init();
     require(SDL_Init(SDL_INIT_EVENTS),
             "SDL event subsystem initializes for overlay keyboard behavior tests");
@@ -66,6 +102,8 @@ int main() {
             "audio_setup returns the slot-ABI success code");
     require(audio_shutdown() == kNoAudioError,
             "audio_shutdown returns the slot-ABI success code");
+    require(loadF15DgtlBin() == kReplacementCueSpanBytes,
+            "loadF15DgtlBin accepts separate WAV cue replacements without F15DGTL.BIN");
 
     misc_clearKeyFlags();
     require(misc_checkKeyBuf() == kKeyBufferEmpty,
@@ -192,6 +230,11 @@ int main() {
     delayedKey.join();
 
     SDL_QuitSubSystem(SDL_INIT_EVENTS);
+
+#if !defined(_WIN32)
+    unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+    std::filesystem::remove_all(replacementRoot);
 
     std::cout << "shared_overlay_behavior_tests passed\n";
     return 0;

--- a/tools/f15assets/CUSTOMIZATION.md
+++ b/tools/f15assets/CUSTOMIZATION.md
@@ -1,0 +1,387 @@
+# F-15 Asset Customization Guide
+
+This guide describes the practical edit workflow for converted assets. The
+rule is simple: edit the modern media file whenever it can represent the data,
+and touch JSON only for tables, ids, placement, or metadata that the media file
+cannot store.
+
+Converted metadata should be portable. Sidecars should use original asset names
+or paths relative to the converted folder, not absolute developer-machine paths.
+
+## 1. Convert the original game folder
+
+Run from the repository root:
+
+```bash
+python3 -m tools.f15assets.cli convert-all /path/to/F15_GAME converted_assets_all
+```
+
+Use your installed DOS game folder for `/path/to/F15_GAME`. The output folder is
+the folder the game replacement loader and editor tools should use.
+`convert-all` recurses through the game folder so campaign/theater subdirectory
+assets are converted too.
+Default output is minimized for customization. Use `--include-image-json`,
+`--include-3d3-model-data`, `--include-metadata`, or `--include-raw-blob` only
+when you need reverse-engineering diagnostics.
+
+To run the game with replacements stored outside the original game folder, set:
+
+```bash
+F15_REPLACEMENT_ROOT=/path/to/converted_assets_all
+```
+
+The runtime then searches that folder for PNG, JSON, BDF, WAV, GLB, and GLMESH
+replacements before falling back to the usual converted/output locations. If
+you point `F15_REPLACEMENT_ROOT` at the parent folder instead, a
+`converted_assets_all` child is also searched. A missing replacement root is
+reported once, ignored, and the usual fallback locations are still searched.
+If the game is launched from a directory where the repository `tools` folder is
+not discoverable, also set:
+
+```bash
+F15_ASSET_TOOL="python3 /path/to/f15se2-ex/tools/f15assets/cli.py"
+```
+
+That bridge command is used only when the runtime must rebuild JSON tables or
+generated GLMESH caches from editable modern files.
+
+## 2. Check replacement equivalence before editing
+
+Run this once after conversion if you want proof that the unmodified converted
+files still load like the original assets:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --allow-custom-glb-differences
+```
+
+For strict converter regression proof before editing, use:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --require-all --strict-original-proof
+```
+
+After editing PNG, WAV, font, JSON, or GLB assets, use loadability validation:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --loadability-only
+```
+For a source-free custom pack without the original game folder, the first path
+may be a missing placeholder when `--loadability-only` is used. In that mode the
+validator checks modern files directly from `converted_assets_all` and skips
+original-equivalence proof. The output path may be either the `converted_assets_all`
+folder itself or a parent folder containing it; the validator prints the
+normalized directory when it descends to the child folder. Do not combine
+source-free validation with `--require-all`; completeness checks need the
+original asset inventory. If no replacement files are found, the validator
+prints a warning so a wrong output path is visible.
+Do not combine `--loadability-only` with `--strict-original-proof` or
+`--require-source-proof`; those flags are for unmodified converter proof.
+`--loadability-only` already permits custom GLB content differences, so do not
+combine it with `--allow-custom-glb-differences`.
+
+The validator compares original loader output with converted PNG, WAV, BDF/PNG,
+JSON, GLB, and GLMESH replacement data where implemented.
+For sound-only custom packs without `F15DGTL.BIN`, validation still parses and
+checks the separate cue WAVs; it cannot prove byte-equivalence to the original
+blob because there is no original blob to compare.
+For source-free world/table packs, `--loadability-only` also rebuilds
+`*.WLD.json`, `*.3DT.json`, and `*.3DG.json` files found under the converted
+output folder even when the original binary tables are absent.
+For source-free image packs, `--loadability-only` also checks extra PNG files
+under the converted output folder for runtime-loadable dimensions and embedded
+palette requirements for indexed PNGs. Original-equivalence still requires the
+matching original `PIC`/`SPR` file.
+For source-free 3D packs, `--loadability-only` also checks extra `.glb` and
+`.glmesh` files under the converted output folder for parseability and non-empty
+renderable primitives. Exact primitive/order/color proof still requires the
+matching original `.3D3` file.
+It also sanity-checks source-free minimized `.3D3.json` index files for
+parseable slot metadata, monotonic offsets, and valid `model_data_size`.
+For source-free font packs, `--loadability-only` also parses extra
+`fonts/font_*.bdf` files and checks that glyph rows and advance widths are
+usable for all 96 runtime glyphs from U+0020 through U+007F. It also checks
+`fonts/font_*.png` atlases for the current runtime font ids whose cell
+dimensions are known. Built-in font equivalence still requires the in-repo
+captured font tables.
+
+Use equivalence checks before editing. After intentional customization,
+differences from the original asset are expected for the edited file, so
+loadability validation is the useful check for customized packs.
+The normal command treats generated `cache/*.glmesh` and GLB source proof extras
+as optional diagnostics. `--allow-custom-glb-differences` also treats intentional
+per-shape GLB geometry changes as warnings. `--strict-original-proof` requires
+generated caches and source proof metadata.
+
+Comparison is intentionally not done while playing. Use
+`validate-replacements` or CTest before editing when you need old-vs-modern
+proof; use `--loadability-only` after intentional customization.
+
+## 3. 3D models: edit GLB in Blender
+
+Authoritative file:
+
+```text
+converted_assets_all/<group>/shape_###_<name>.glb
+```
+
+Examples:
+
+```text
+converted_assets_all/15FLT/shape_010.glb
+converted_assets_all/VN/shape_049_SAM_Radar.glb
+converted_assets_all/PHOTO/shape_000.glb
+```
+
+Normal Blender workflow:
+
+1. Import the per-shape `.glb` into Blender.
+2. Edit geometry, line objects, point objects, and materials.
+3. Export back to the same `.glb` path.
+4. Keep the `shape_###` number in the filename unchanged.
+5. Start the game with the OpenGL backend; it rebuilds `cache/*.glmesh`
+   automatically if the cache is missing or stale.
+
+The filename label after `shape_###` is only for humans. Runtime lookup is
+case-tolerant and uses the stable slot number prefix.
+
+Current limitation: GLB model replacement is implemented in the OpenGL backend.
+The software 3D backend still renders the original `.3D3` stream, and the
+current loader still reads original `.3D3` bytes for shape-slot tables, PHOTO
+append ranges, comparison, and fallback. The minimized `.3D3.json` index now
+validates those slot fields, but the game does not yet use it as the runtime
+source for GLB-only/free-asset packs.
+
+Do not edit these for normal model customization:
+
+```text
+converted_assets_all/<group>/<group>.3D3.json
+converted_assets_all/<group>/cache/*.glmesh
+```
+
+`.3D3.json` is a lightweight index/manifest. It preserves shape slots and source
+container metadata, but GLB geometry and GLB primitive extras override it. Bulk
+conversion omits bulky `.3D3` `model_data` base64 by default; validation still
+compares the minimized shape offset table and `model_data_size` against the
+original `.3D3`. Request bulky `model_data` only with
+`convert-tree --include-3d3-model-data` for reverse-engineering dumps or for
+the legacy-byte-stream bridge. Those full dumps duplicate original model data
+and are not the normal customization surface.
+`cache/*.glmesh` is generated runtime data derived from GLB and can be deleted.
+Default conversion does not pre-generate it; use `--include-glmesh-cache` only
+when you want caches ahead of first runtime load. The runtime and validator
+parse these caches strictly, so malformed or stale caches are rejected instead
+of being treated as an alternate editable model source.
+
+Keep these constraints:
+
+- Preserve the shape slot number. World objects reference shape ids.
+- `PHOTO/shape_###.glb` files replace target-view photo models. The legacy
+  loader appends those models to the theater shape table, but the OpenGL
+  replacement lookup maps the appended slots back to `PHOTO/shape_###`.
+- Preserve line-only details such as antennas, masts, deck lines, runway lines, and ship rails unless you intentionally remove them.
+- Preserve coplanar faces and draw-sensitive overlaps when visual fidelity matters. The converter stores source primitive metadata so validation can detect dropped or reordered primitives.
+- Use per-shape GLBs for editing. The combined `<group>.3D3.glb` is mainly for overview and inspection.
+- GLB `extras` are diagnostic metadata, not the drawing source. If Blender or
+	  another editor strips primitive extras, the model can still render from GLB
+	  geometry/materials, but strict `validate-replacements` has less proof that
+	  source order/raw colors still match the original.
+
+When JSON is needed:
+
+- Rename or document shape slots in metadata.
+- Inspect source offsets or original shape order.
+- Debug conversion issues.
+
+When JSON is not needed:
+
+- Changing mesh vertices.
+- Changing face colors/materials.
+- Adding/removing Blender geometry inside the same shape file.
+- Re-exporting the same shape from Blender.
+
+## 4. World and mission data: edit WLD JSON
+
+Authoritative file:
+
+```text
+converted_assets_all/<world>/<world>.WLD.json
+```
+
+Use the map editor for placement edits:
+
+```text
+tools/f15assets/map_editor.html
+```
+
+World JSON is the source of truth for:
+
+- object coordinates;
+- object shape ids;
+- target flags;
+- takeoff/landing/base-like records;
+- flight-unit templates;
+- terrain and mission classification tables;
+- name strings.
+
+GLB files do not store world placement. If you move a SAM site, runway, carrier,
+or target on the theater map, edit the WLD JSON through the editor.
+
+Runtime note: the current loader rebuilds a legacy `.WLD` byte stream from this
+JSON and feeds it to the existing game loader. JSON is still the editable source
+because world data is structured table data, not a media file.
+
+## 5. Terrain tables: edit 3DT and 3DG JSON carefully
+
+Authoritative files:
+
+```text
+converted_assets_all/<group>/<file>.3DT.json
+converted_assets_all/<group>/<file>.3DG.json
+```
+
+Use these for terrain/tile placement and lookup data. These formats are numeric
+tables, not artwork. Keep record order stable unless you understand the runtime
+lookup path.
+
+Runtime note: as with WLD, the current loader rebuilds legacy bytes from JSON
+before calling the existing table loaders.
+
+## 6. Pictures and sprites: edit indexed PNG
+
+Authoritative files:
+
+```text
+converted_assets_all/<asset>.png
+```
+
+PNG is authoritative for:
+
+- pixels;
+- dimensions;
+- embedded palette.
+
+PIC/SPR JSON is only decode/index metadata and is not emitted by default by
+`convert-tree`/`convert-all`. For normal art changes, edit the PNG and keep it
+indexed/paletted when possible. Truecolor PNG can be accepted by the runtime as
+an editing convenience, but indexed PNG with an embedded palette is the safest
+self-contained replacement.
+
+Use `ctest -R asset_replacement_full_validation` or
+`python3 -m tools.f15assets.cli validate-replacements` to compare indexed PNG
+replacements against the original PIC/SPR pixel indices and active legacy DAC
+palette. This proof is intentionally a test-time check, not a runtime game mode.
+
+`TITLE640.PIC` is exported as a 640x350 PNG. It is also loaded as PNG at runtime
+when present, using the hi-res title surface rather than the normal 320x200 page
+surface.
+
+## 7. Fonts: edit BDF first, PNG atlas second
+
+Authoritative files:
+
+```text
+converted_assets_all/fonts/font_<id>.bdf
+converted_assets_all/fonts/font_<id>.png
+```
+
+Preferred workflow:
+
+1. Edit `font_<id>.bdf` for glyph shape and advance width.
+2. Use the PNG atlas for visual inspection or bitmap-only edits.
+3. Ignore JSON for normal customization; `font_<id>.json` is optional metadata
+   emitted only with `--include-metadata`.
+
+BDF is the best source for future Unicode/localization work because it can carry
+codepoints and metrics directly. Runtime loading prefers BDF before PNG, but it
+tries the PNG atlas if BDF is missing or rejected. PNG is useful for artists, but
+the current runtime PNG fallback uses existing font advance widths; it is
+bitmap-authoritative, not metric-authoritative.
+JSON cannot override BDF/PNG glyph data.
+
+## 8. Sounds: edit separate WAV cues
+
+Authoritative files:
+
+```text
+converted_assets_all/sounds/voice_cue_*.wav
+```
+
+`sounds/f15dgtl_raw.wav` is not exported by default. It is only a full-blob
+reference export when `export-sounds --include-raw-blob` is used. Customizers
+do not need it. The current runtime replacement path uses the separate
+`voice_cue_*.wav` files for playback.
+
+WAV files are authoritative for:
+
+- sample bytes;
+- sample rate;
+- channel count;
+- bit depth.
+
+Use mono unsigned 8-bit PCM for maximum compatibility with the current loader.
+The current runtime cue loader accepts mono unsigned 8-bit PCM cue WAVs and uses
+their sample bytes and RIFF sample rate as replacements for the matching ASOUND
+cue ranges. The default exported sample rate is `7850` Hz; changing a cue WAV's
+sample rate intentionally changes playback speed. JSON keeps cue ranges and
+driver metadata; do not edit JSON for normal sample replacement. Cue JSON,
+driver sidecars, and `sounds.json` are not exported by default; use
+`export-sounds --include-metadata` only when you need reverse-engineering notes.
+Rerunning the exporter without metadata/raw flags removes stale optional sound
+sidecars, leaving the cue WAVs as the normal customization files.
+`--loadability-only` also parses extra `sounds/voice_cue_*.wav` files in a
+source-free pack, but the current runtime playback path uses only the recovered
+known cue filenames exported by `export-sounds`.
+
+## 9. What the game loads first
+
+When a modern replacement exists, the runtime should prefer it:
+
+| Asset class | Preferred replacement |
+| --- | --- |
+| 3D shape | per-shape `.glb`; `cache/*.glmesh` is generated from it |
+| PIC/SPR image | `.png` |
+| WLD/3DT/3DG table | `.json` rebuilt through `build-binary` |
+| Font | `.bdf` for glyphs and metrics; `.png` atlas fallback for glyph pixels only |
+| Digitized sound cue | separate `.wav` |
+
+If a replacement is missing or invalid, the loader should fall back to the
+original game asset.
+
+## 10. Files you can usually ignore
+
+```text
+cache/*.glmesh
+default *.3D3.json for geometry-only edits; full model_data dumps only for bridge/reverse-engineering work
+*.PIC.json / *.SPR.json for pixel-only edits; request them only with --include-image-json for decoder diagnostics
+fonts/font_<id>.json for normal glyph edits; request it only with --include-metadata for glyph/index diagnostics
+optional sounds/sounds.json for sample-only edits
+```
+
+These files are useful for validation, indexing, or loader bridges, but they are
+not the normal authoring surface when the modern media file already represents
+the data.
+
+## 11. Future free custom asset packs
+
+The long-term target is a replacement pack that can contain only freely licensed
+custom assets, for example Creative Commons models, images, fonts, and sounds.
+That is a packaging goal, not the current guarantee.
+
+Current state:
+
+- Original game assets are still required as fallback data.
+- Default minimized `.3D3.json` plus per-shape GLB still need an original
+  `.3D3` byte stream for shape-slot tables and software renderer fallback. A
+  full `.3D3.json` bridge dump can replace those bytes, but it duplicates
+  original model data and is not the desired free/minimized asset path.
+- Some replacement paths still bridge through original-compatible binary layouts.
+- Runtime comparison uses original assets as the reference for equivalence.
+
+Future pack requirements:
+
+- Every loaded asset class must have a modern replacement loader.
+- Missing original assets must not be needed for supported replacement packs.
+- The pack should include license metadata for every media file.
+- Sidecars should stay portable and should not contain local absolute paths.
+- Generated caches such as `cache/*.glmesh` should be reproducible from the
+  editable source files and should not be the legal/source artifact.

--- a/tools/f15assets/CUSTOMIZATION.md
+++ b/tools/f15assets/CUSTOMIZATION.md
@@ -275,28 +275,28 @@ palette. This proof is intentionally a test-time check, not a runtime game mode.
 when present, using the hi-res title surface rather than the normal 320x200 page
 surface.
 
-## 7. Fonts: edit BDF first, PNG atlas second
+## 7. Fonts: edit TTF/OTF or BDF
 
 Authoritative files:
 
 ```text
+converted_assets_all/fonts/font_<id>.ttf
+converted_assets_all/fonts/font_<id>.otf
 converted_assets_all/fonts/font_<id>.bdf
-converted_assets_all/fonts/font_<id>.png
 ```
 
 Preferred workflow:
 
-1. Edit `font_<id>.bdf` for glyph shape and advance width.
-2. Use the PNG atlas for visual inspection or bitmap-only edits.
+1. Use `font_<id>.ttf` or `font_<id>.otf` for normal scalable-font replacement.
+2. Use `font_<id>.bdf` only when you need hand-edited pixel glyphs and metrics.
 3. Ignore JSON for normal customization; `font_<id>.json` is optional metadata
    emitted only with `--include-metadata`.
 
-BDF is the best source for future Unicode/localization work because it can carry
-codepoints and metrics directly. Runtime loading prefers BDF before PNG, but it
-tries the PNG atlas if BDF is missing or rejected. PNG is useful for artists, but
-the current runtime PNG fallback uses existing font advance widths; it is
-bitmap-authoritative, not metric-authoritative.
-JSON cannot override BDF/PNG glyph data.
+TTF/OTF is preferred for Unicode/localization because customizers can use normal
+font editors and do not need sidecar files. Runtime loads TTF/OTF first when the
+build has FreeType, then BDF, then legacy `font_<id>.png` atlases. Leave
+`font_0.*` absent to keep the original tiny HUD font. JSON cannot override font
+glyph data.
 
 ## 8. Sounds: edit separate WAV cues
 

--- a/tools/f15assets/README.md
+++ b/tools/f15assets/README.md
@@ -73,7 +73,7 @@ This produces:
 - combined `.3D3.glb` and per-shape `shape_###*.glb` for supported 3D assets.
   Generated `cache/shape_###*.glmesh` runtime caches are optional and can be
   rebuilt by the game from GLB.
-- `fonts/font_<id>.bdf` and `fonts/font_<id>.png`.
+- `fonts/font_<id>.bdf`.
 - driver-backed `sounds/voice_cue_*.wav` files. Sound metadata JSON and the
   full digitized sound blob are not exported by default.
 
@@ -119,7 +119,12 @@ python3 -m tools.f15assets.cli export-fonts . converted_assets_all/fonts
 ```
 
 Add `--include-metadata` only when you need optional `font_<id>.json` sidecars
-and `fonts.json`; runtime loading uses BDF first and PNG as fallback.
+and `fonts.json`; runtime loading uses TTF/OTF first, then BDF, then PNG.
+
+Use TrueType/OpenType fonts directly by placing `font_<id>.ttf` or
+`font_<id>.otf` in `converted_assets_all/fonts`. To replace all non-small fonts
+with a single face, copy it as `font_1.ttf`, `font_3.ttf`, `font_4.ttf`, and
+`font_5.ttf`; leave `font_0.*` absent to keep the tiny HUD font.
 
 Export digitized cue WAVs:
 
@@ -253,7 +258,7 @@ not customized asset loadability. It also supersedes
 | `*.3DT` | ordered JSON sidecar in the related world directory | Terrain object placement tables. |
 | `*.3DG` | ordered JSON sidecar in the related world directory | Terrain grid lookup data. |
 | `*.WLD` | world directory with ordered JSON sidecar | Theater/world objects, terrain grid, mission object type table, flight-unit templates, and names. |
-| fonts | BDF + PNG, optional JSON | BDF is authoritative for glyph shapes and metrics. PNG is authoritative for atlas pixels only; the current runtime PNG fallback reuses existing advance widths. JSON maps codepoints to atlas/index metadata only with `--include-metadata`. |
+| fonts | BDF, optional JSON | BDF is authoritative for glyph shapes, Unicode codepoints, and metrics. JSON maps codepoints/index metadata only with `--include-metadata`; it does not override BDF glyph data. |
 | `F15DGTL.BIN` | cue WAVs, optional JSON, optional raw WAV | `voice_cue_*.wav` files are authoritative for runtime cue replacement. Current runtime replacement accepts mono unsigned 8-bit PCM cue WAVs and uses their RIFF sample rate for playback speed. JSON keeps cue/index metadata only when `--include-metadata` is requested. The full raw blob is not needed for customization; use `--include-raw-blob` only for reverse-engineering reference. |
 | sound drivers | optional JSON sidecars | Driver executable hashes, sizes, and unresolved status are preserved only when `--include-metadata` is requested; executable bytes are not duplicated into custom asset sidecars. |
 
@@ -477,13 +482,12 @@ Current runtime implementation status:
   replacement asset's `converted_assets_all` root, then tries nearby script
   paths, then falls back to `python3 -m tools.f15assets.cli`. JSON-rebuilt byte
   equivalence is checked by `validate-replacements` and CTest.
-- Font drawing now prefers `fonts/font_<id>.bdf` when present. The loader parses
-  BDF glyph rows and advance widths, then switches rendering to the BDF-backed
-  font. If BDF is absent or rejected, `fonts/font_<id>.png` is tried as the glyph
-  bitmap atlas; PNG glyph pixels are authoritative, while advance widths
-  currently come from the existing font metrics. BDF fonts with incomplete glyphs
-  or zero advance widths are rejected. Built-in font equivalence is checked by
-  `validate-replacements` and CTest.
+- Font drawing now prefers `fonts/font_<id>.ttf` or `.otf` when present and the
+  build has FreeType. The scalable font is fitted into the same in-memory glyph
+  rows and advance-width tables used by the original renderer, so layout and
+  clipping stay compatible. If TTF/OTF is absent or unavailable, the loader
+  falls back to BDF, then PNG atlas, then built-in fonts. Built-in font
+  equivalence is checked by `validate-replacements` and CTest.
 - Runtime GLB import is implemented for the OpenGL backend through a simple
   runtime mesh bridge generated from per-shape GLBs. The backend treats `.glb`
   as the source of truth, loads `cache/*.glmesh` only when the embedded source

--- a/tools/f15assets/README.md
+++ b/tools/f15assets/README.md
@@ -4,7 +4,26 @@ Developer and customizer tools for converting original F-15 Strike Eagle II asse
 The overlapping MicroProse formats used by F-117A are partially supported too,
 including external `.PAL` palettes for `PIC` images.
 
+For a step-by-step editing workflow, see `CUSTOMIZATION.md` in this directory.
+
 These tools are forward-conversion first. They are meant to make original game assets inspectable, editable, and eventually loadable by a modernized game runtime when replacement assets are present. They do not currently promise full backward conversion into original binary formats.
+
+Longer-term packaging goal: the replacement pipeline should make it possible to
+run the game with freely licensed custom media assets only, for example CC-licensed
+models, pictures, fonts, and sounds. That is not the current runtime contract:
+today the original assets are still the authoritative fallback and are still
+needed for unsupported or incomplete replacement paths.
+
+When both a modern media file and JSON mention the same property, the media file
+wins. JSON is supplemental index/metadata only. For example, PNG dimensions and
+palette override JSON image metadata, GLB geometry/extras override `.3D3.json`,
+WAV headers/data override sound JSON, and BDF/PNG font data overrides font JSON.
+
+Validation invariant: loading an unmodified converted asset should produce the
+same in-memory game data as loading the original asset. For formats that pass
+through float/modern encodings, the result should be numerically equivalent
+within documented conversion tolerance. This comparison belongs in importer
+validation/tests or explicit diagnostics, not in normal runtime loading.
 
 ## Source and output layout
 
@@ -21,6 +40,17 @@ converted_assets_all
 ```
 
 Run commands from the repository root that contains this `tools` directory.
+At runtime, the game searches `converted_assets_all` below the game asset path
+and current directory. Set `F15_REPLACEMENT_ROOT=/path/to/converted_assets_all`
+to point the loader at an explicit converted/custom asset directory without
+copying files beside the original game assets. If `F15_REPLACEMENT_ROOT` points
+at a parent folder that contains `converted_assets_all`, that child folder is
+also searched. If it points to a missing directory, the loader ignores it and
+continues with the normal fallback locations after logging one warning. If the
+game is launched from a
+directory where `tools/f15assets/cli.py` is not discoverable, also set
+`F15_ASSET_TOOL="python3 /path/to/f15se2-ex/tools/f15assets/cli.py"` so JSON and
+GLB bridge loaders can rebuild legacy byte streams and GLMESH caches.
 
 ## Commands
 
@@ -35,10 +65,17 @@ python3 -m tools.f15assets.cli convert-all /home/xor/games/f15 converted_assets_
 This produces:
 
 - `*.png` for all supported `PIC`/`SPR` image assets.
-- `*.json` sidecars for decoded assets.
-- `*.3D3.glb` model files for Blender and other glTF tools.
-- `fonts/font_<id>.bdf`, `fonts/font_<id>.png`, and `fonts/font_<id>.json`.
-- `sounds/f15dgtl_raw.wav`, driver-backed `sounds/voice_cue_*.wav`, and sound metadata JSON.
+- `*.json` sidecars for structured/table/model metadata. Bulky PIC/SPR decode
+  JSON and font metadata JSON are skipped by default because PNG/BDF are the
+  runtime media sources.
+- extensionless asset directories for world/model groups, for example `VN/`,
+  `LIBYA/`, `15FLT/`, or `WORLD/`.
+- combined `.3D3.glb` and per-shape `shape_###*.glb` for supported 3D assets.
+  Generated `cache/shape_###*.glmesh` runtime caches are optional and can be
+  rebuilt by the game from GLB.
+- `fonts/font_<id>.bdf` and `fonts/font_<id>.png`.
+- driver-backed `sounds/voice_cue_*.wav` files. Sound metadata JSON and the
+  full digitized sound blob are not exported by default.
 
 Use a different source path if your original DOS game files are not in
 `/home/xor/games/f15`.
@@ -52,19 +89,27 @@ python3 -m tools.f15assets.cli convert-tree /home/xor/games/F117A/F117.CD conver
 Optional flags:
 
 - Add global `--pretty` before `convert-all` for pretty-printed JSON.
-- Use `convert-tree` directly if you need YAML sidecars, recursive input, or non-default model output.
+- `convert-all` recurses through the game asset folder. Its default output is
+  minimized; add `--include-image-json`, `--include-3d3-model-data`,
+  `--include-glmesh-cache`, `--include-metadata`, or `--include-raw-blob` only
+  for reverse-engineering diagnostics or prebuilt runtime caches.
+  `--include-metadata` adds optional font JSON and sound metadata.
+- Use `convert-tree` directly if you need non-default model output.
 - Use `export-sounds` directly if you need a non-default sample rate.
 
 Convert a whole asset tree:
 
 ```bash
-python3 -m tools.f15assets.cli convert-tree /home/xor/games/f15 converted_assets_all --yaml
+python3 -m tools.f15assets.cli convert-tree /home/xor/games/f15 converted_assets_all
 ```
+
+Use `convert-tree --include-image-json` only when you need lossless PIC/SPR
+decoder diagnostics such as compressed payloads and decoded pixel base64.
 
 Decode one asset:
 
 ```bash
-python3 -m tools.f15assets.cli decode /home/xor/games/f15/VN.WLD converted_assets_all/VN.WLD.json --format WLD --yaml converted_assets_all/VN.WLD.yaml
+python3 -m tools.f15assets.cli decode /home/xor/games/f15/VN.WLD converted_assets_all/VN/VN.WLD.json --format WLD
 ```
 
 Export fonts:
@@ -73,39 +118,226 @@ Export fonts:
 python3 -m tools.f15assets.cli export-fonts . converted_assets_all/fonts
 ```
 
-Export digitized sounds and driver sidecars:
+Add `--include-metadata` only when you need optional `font_<id>.json` sidecars
+and `fonts.json`; runtime loading uses BDF first and PNG as fallback.
+
+Export digitized cue WAVs:
 
 ```bash
 python3 -m tools.f15assets.cli --pretty export-sounds /home/xor/games/f15 converted_assets_all/sounds --sample-rate 7850
 ```
 
+Add `--include-raw-blob` only when you also want the full `f15dgtl_raw.wav`
+reference export for reverse engineering. Runtime replacement uses the separate
+`voice_cue_*.wav` files.
+
+Add `--include-metadata` only when you also want per-cue JSON, unresolved
+driver sidecars, and `sounds.json` for reverse-engineering notes.
+Rerunning without these flags removes stale optional sound metadata/reference
+files from the output folder, so the default sound folder contains only the cue
+WAV authoring files.
+
+Validate modern replacements against original loader output outside normal runtime:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /home/xor/games/f15 converted_assets_all
+```
+
+Rebuild full structured JSON to the original runtime binary byte stream:
+
+```bash
+python3 -m tools.f15assets.cli build-binary converted_assets_all/VN/VN.WLD.json --format WLD > /tmp/VN.WLD
+```
+
+Full `.3D3.json` files with `model_data` can also be rebuilt for the old loader
+bridge. Default minimized `.3D3.json` omits `model_data`, so it is validation
+and index metadata only.
+
+Expand a per-shape GLB to the simple runtime mesh stream used by the OpenGL backend:
+
+```bash
+python3 -m tools.f15assets.cli build-glmesh converted_assets_all/VN/shape_049_SAM_Radar.glb > converted_assets_all/VN/cache/shape_049_SAM_Radar.glmesh
+```
+
+`*.glmesh` files are strict generated caches, not hand-editing sources. The
+runtime and validator reject unsupported primitive modes, bad line/triangle
+vertex counts, stale source checksums, empty meshes, and trailing unread bytes.
+Delete a cache after editing the matching `.glb`; the game can rebuild it.
+
+The validator currently compares original `PIC`/`SPR` decode output with indexed
+PNG replacements byte-for-byte at the palette-index level, compares embedded or
+externally attached image palettes when the source palette is known, compares
+`F15DGTL.BIN` cue ranges with `sounds/voice_cue_*.wav` sample bytes, compares
+cue WAV sample rates against the recovered/export default, compares in-repo font
+tables with `fonts/font_<id>.bdf` and `fonts/font_<id>.png`, rebuilds `WLD`,
+`3DT`, and `3DG` bytes from JSON, compares minimized `.3D3.json` shape-slot
+metadata against the original `.3D3`, rebuilds and byte-compares full
+`.3D3.json` when bulky `model_data` is present, compares unmodified per-shape
+GLBs against the original `.3D3` export for primitive/source-metadata coverage,
+and checks `.glmesh` caches against their source GLBs when caches are present. Use
+`--require-all` when missing supported authoring replacements should fail the
+check; for `.3D3`, this means the minimized JSON index and per-shape GLBs, not
+the combined overview GLB. Use `--require-generated-cache` only when generated
+runtime caches must also exist.
+Use `--strict-original-proof` for converter regression checks; it implies
+generated cache and GLB source-proof requirements.
+
+Recommended validation modes:
+
+- Edited/custom asset pack loadability:
+  `python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --loadability-only`
+  For source-free packs, `/path/to/F15_GAME` may be a missing placeholder path
+  in `--loadability-only`; the command then checks modern files directly from
+  `converted_assets_all` and skips original-equivalence proof. The output path
+  may also be a parent folder containing `converted_assets_all`; the validator
+  will use that child folder automatically and print the normalized directory.
+  Do not use
+  `--require-all` in that source-free mode because there is no original asset
+  inventory to require against. If no replacement files are found, the validator
+  prints a warning so a wrong output path is visible.
+- Custom GLB check:
+  `python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --allow-custom-glb-differences`
+- Converter regression proof:
+  `python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --require-all --strict-original-proof`
+
+For PNG, WAV, font, and JSON table replacements, normal `validate-replacements`
+still checks original equivalence. After intentionally editing those assets, use
+`--loadability-only` to check modern file parseability and structure without
+treating expected content differences as failures. For JSON table replacements,
+loadability mode still rebuilds the replacement and requires a non-empty byte
+stream for the legacy loader bridge. In loadability mode, source-free
+`*.WLD.json`, `*.3DT.json`, and `*.3DG.json` files under the converted output
+tree are also rebuilt even when the original binary asset is absent; byte
+equivalence still requires the original files. Source-free PNG files under the
+converted output tree are also checked for runtime-loadable dimensions and
+indexed-palette requirements, except font atlases which are handled by font
+validation. Source-free `.glb` and `.glmesh` files under the converted output
+tree are also checked for parseability and non-empty renderable primitives;
+primitive/order/color equivalence still requires the original `.3D3` files and
+converter source metadata. Source-free minimized `.3D3.json` files are checked
+for parseable shape-slot metadata, monotonic offsets, and valid
+`model_data_size`; exact slot-table equivalence still requires the original
+`.3D3`. For sound cues, WAV files must parse as
+mono unsigned 8-bit PCM, contain at least one sample, and carry the playback
+sample rate in the RIFF header. If `F15DGTL.BIN` is absent, sound validation
+still checks cue WAV loadability but skips legacy sample-byte comparison.
+Extra `sounds/voice_cue_*.wav` files are also parsed in loadability mode, but
+only the known cue names are used by the current runtime playback path. For
+BDF fonts, expected glyphs must exist with
+non-empty bitmap rows and positive advance widths; in `--loadability-only`, a
+bad BDF is only a warning when the matching PNG atlas fallback is loadable.
+Extra `fonts/font_*.bdf` files are also parsed in loadability mode so
+source-free/custom font packs can be checked without proving equivalence to the
+built-in font tables; they must include all 96 glyphs from U+0020 through
+U+007F with non-empty rows and positive advance widths. Source-free
+`fonts/font_*.png` atlases are also checked
+for the current runtime font ids whose cell dimensions are known.
+`--require-all` requires at least one runtime font source for each known font:
+BDF first, or PNG atlas fallback.
+Indexed PNG replacements must include an embedded palette. Per-shape GLBs must
+contain at least one triangle, line, or point primitive.
+`--loadability-only` is intentionally incompatible with `--strict-original-proof`
+and `--require-source-proof`; those modes are for proving original equivalence,
+not customized asset loadability. It also supersedes
+`--allow-custom-glb-differences`, so do not combine those two custom modes.
+
 ## Converted formats
 
 | Original | Modern output | Notes |
 | --- | --- | --- |
-| `*.PIC`, `*.SPR` | indexed PNG + JSON/YAML sidecar | PNG keeps palette-based pixels; sidecar keeps original decode metadata and source bytes. |
-| F-117A `*.PIC` + `*.PAL` | indexed PNG + JSON/YAML sidecar | Same-stem `.PAL` is used first; known aliases handle files such as `256LEFT.PIC` using `FLIGHT.PAL` and `CLIMBIN.PIC` using `ADV.PAL`; otherwise `PALETTES.PAL` chunk 0 is used as an F-117A fallback. |
-| `TITLE640.PIC` | `640x350` PNG + sidecar | Stored as alternating left/right rows by the original 640-mode loader. |
-| `1.PIC`..`4.PIC` | VGA-style PNG + sidecar | Demo-only images use a different byte-indexed loader path. |
-| `*.3D3` | `.glb` + JSON/YAML sidecar | Blender-friendly model export. JSON keeps shape ids, offsets, raw chunks, and metadata. |
-| `*.3DT` | JSON/YAML sidecar | Terrain object placement tables. |
-| `*.3DG` | JSON/YAML sidecar | Terrain grid lookup data. |
-| `*.WLD` | JSON/YAML sidecar | Theater/world objects, terrain grid, mission object type table, flight-unit templates, and names. |
-| fonts | BDF + PNG + JSON | Uses Unicode codepoints while preserving original CP437 source bytes. |
-| `F15DGTL.BIN` | raw WAV + cue WAVs + JSON | Unsigned 8-bit mono PCM at 7850 Hz by default. |
-| sound drivers | JSON sidecars | Driver executables are preserved for reverse-engineering metadata. |
+| `*.PIC`, `*.SPR` | indexed PNG, optional decode JSON | PNG is authoritative for pixels, dimensions, and palette. `convert-tree --include-image-json` writes bulky decode/index metadata for diagnostics. |
+| F-117A `*.PIC` + `*.PAL` | indexed PNG, optional decode JSON | PNG is authoritative after palette application. Same-stem `.PAL` is used first; known aliases handle files such as `256LEFT.PIC` using `FLIGHT.PAL` and `CLIMBIN.PIC` using `ADV.PAL`; otherwise `PALETTES.PAL` chunk 0 is used as an F-117A fallback. |
+| `TITLE640.PIC` | `640x350` PNG, optional decode JSON | Stored as alternating left/right rows by the original 640-mode loader; runtime loads the PNG into the hi-res title surface when present. |
+| `1.PIC`..`4.PIC` | VGA-style PNG, optional decode JSON | Demo-only images use a different byte-indexed loader path. |
+| `*.3D3` | asset/world directory with combined `.glb`, per-shape `.glb`, optional `cache/*.glmesh` runtime caches, and lightweight JSON index | GLB is authoritative for OpenGL geometry and model metadata; `.glmesh` is generated from GLB for OpenGL runtime loading and stores the source GLB checksum. Default JSON keeps only lightweight ids and lookup metadata. Full JSON with `model_data` can be rebuilt into legacy `.3D3` bytes for the old loader bridge, but default minimized JSON cannot. Use `convert-tree --include-3d3-model-data` only for full reverse-engineering or bridge dumps, and `--include-glmesh-cache` only if you want prebuilt caches. |
+| `*.3DT` | ordered JSON sidecar in the related world directory | Terrain object placement tables. |
+| `*.3DG` | ordered JSON sidecar in the related world directory | Terrain grid lookup data. |
+| `*.WLD` | world directory with ordered JSON sidecar | Theater/world objects, terrain grid, mission object type table, flight-unit templates, and names. |
+| fonts | BDF + PNG, optional JSON | BDF is authoritative for glyph shapes and metrics. PNG is authoritative for atlas pixels only; the current runtime PNG fallback reuses existing advance widths. JSON maps codepoints to atlas/index metadata only with `--include-metadata`. |
+| `F15DGTL.BIN` | cue WAVs, optional JSON, optional raw WAV | `voice_cue_*.wav` files are authoritative for runtime cue replacement. Current runtime replacement accepts mono unsigned 8-bit PCM cue WAVs and uses their RIFF sample rate for playback speed. JSON keeps cue/index metadata only when `--include-metadata` is requested. The full raw blob is not needed for customization; use `--include-raw-blob` only for reverse-engineering reference. |
+| sound drivers | optional JSON sidecars | Driver executable hashes, sizes, and unresolved status are preserved only when `--include-metadata` is requested; executable bytes are not duplicated into custom asset sidecars. |
 
 ## 3D model customization
 
 `3D3` assets are exported to glTF binary (`.glb`) for Blender and other modern tools.
+Bulk conversion writes related world and shape files into the same extensionless directory.
+For example:
+
+```text
+converted_assets_all/WORLD/
+  WORLD.WLD.json
+  WORLD.3DT.json
+  WORLD.3DG.json
+  WORLD.3D3.glb
+  shape_000.glb
+  shape_001.glb
+
+converted_assets_all/15FLT/
+  15FLT.3D3.json
+  15FLT.3D3.glb
+  shape_000.glb
+  shape_001.glb
+```
+
+The combined GLB is useful for overview and old viewer workflows. The `shape_###`
+per-shape GLBs are the preferred files for editing one model slot without
+opening every shape in the source container. Per-shape GLBs are minimized:
+unused accessors, bufferViews, materials, and binary buffer ranges from the
+combined GLB are not copied into the single-shape file. `.glmesh` files are
+generated runtime caches in `cache/` derived from the matching per-shape GLB.
+Runtime lookup keys off the stable `shape_###` slot prefix and is
+case-tolerant; human-readable labels after the number are optional.
+Default conversion does not pre-generate them; use `--include-glmesh-cache` if
+you want cache files ahead of first runtime load. Each cache stores the MD5
+checksum of the source GLB. Edit the GLB directly; the OpenGL runtime loader
+rebuilds the cache automatically when it is missing or its checksum does not
+match the GLB.
+`PHOTO.3D3` is authored the same way in `converted_assets_all/PHOTO/`, even
+though the legacy loader appends those target-view models to the active theater
+shape table at runtime. The OpenGL replacement lookup maps those appended slots
+back to `PHOTO/shape_###*.glb`.
+Bulk conversion writes minimized `.3D3.json` indexes without `model_data`
+base64. Use `decode` or `convert-tree --include-3d3-model-data` only when you
+need a full reverse-engineering dump that can rebuild the original `.3D3` bytes
+for the old loader bridge. If the runtime finds a minimized `.3D3.json`, the
+bridge rejects it and falls back to the original `.3D3`; OpenGL geometry can
+still come from per-shape GLB.
+Current generated caches use the `F15GLM3` header, which also stores source
+primitive kind/index/raw-color/order flags per runtime primitive. The renderer does not
+need those fields to draw, but validators and diagnostic runs use them to prove
+that cache generation did not merge, reorder, or drop order-sensitive `.3D3`
+geometry or lose palette/color identity.
+Older `F15GLM1`/`F15GLM2` caches can still be read by the runtime, but strict
+test-time validation cannot use them to prove source primitive order.
+
+Theater aliases are grouped with their world file: `LIBYA.WLD` with `LB.3D3`,
+`LB.3DT`, and `LB.3DG` under `LIBYA/`, and `GULF.WLD` with `PG.3D3`,
+`PG.3DT`, and `PG.3DG` under `GULF/`.
 
 Important constraints:
 
 - Shape ids must remain stable. Do not compact or renumber shapes if the game will use the edited asset as a replacement.
 - Some original shapes are intentionally 2D or single-sided. The exporter keeps one-sided planes instead of fabricating backfaces, because duplicated reverse faces can create z-fighting.
+- Source line and point primitives are exported in original order with duplicates
+  preserved; do not deduplicate antennas, masts, deck lines, or other line-only
+  details.
+- Source face triangles are also exported in decoded order with order-sensitive
+  metadata. This deliberately avoids color-batching triangles, because coplanar
+  or overlapping faces can depend on draw order.
 - Some theater model slots are non-renderable placeholders. They are skipped in GLB nodes but preserved in sidecar metadata.
 - Shape names are not embedded in `.3D3`; names are derived from matching `.WLD` object labels where possible.
-- For runtime replacement, use both `.glb` and the `.3D3.json` sidecar. GLB alone is not enough to preserve game-specific ids and flags.
+- For runtime replacement, prefer `.glb` for 3D geometry. The default
+  `.3D3.json` sidecar is an index/manifest only and should not duplicate model
+  bytecode; full bridge dumps may include `model_data` only when explicitly
+  generated with `--include-3d3-model-data`. `cache/*.glmesh` is generated data
+  and can be deleted safely.
+- Non-coplanar triangle order is normally harmless, but coplanar or z-fighting
+  geometry may depend on source draw order; preserve order unless a future
+  validator proves the reordering is render-equivalent.
+- GLB `extras` are diagnostic metadata. Geometry and material colors load from
+  the GLB itself, but if Blender or another editor strips primitive extras then
+  old-vs-new validation can no longer prove original source order/raw-color
+  equivalence for that edited shape.
 
 ## World and mission editing
 
@@ -152,7 +384,11 @@ The `.WLD` format does not expose a simple universal friend/enemy enum. Some run
 
 ## Sound cues
 
-`F15DGTL.BIN` is exported as one raw WAV plus driver-backed cue WAVs recovered from ASOUND.
+`F15DGTL.BIN` is exported as driver-backed cue WAVs recovered from ASOUND.
+Customizers should edit only the individual `voice_cue_*.wav` files. Per-cue
+JSON and driver sidecars are optional via `export-sounds --include-metadata`.
+The full raw blob WAV is optional via `export-sounds --include-raw-blob` and is
+meant only as reverse-engineering reference output.
 
 ASOUND cue ranges are inclusive in the driver:
 
@@ -166,22 +402,145 @@ audio_playSample(2), variant 2: 0x6A1B..0x7D9D
 
 `voiceCueThresholds` in the game code are availability checks before playback, not the full cue split table.
 
-The sample rate defaults to `7850` Hz. This comes from recovered driver timer behavior in the 8 kHz range, not from a WAV header in the original asset.
+The exported sample rate defaults to `7850` Hz, and the runtime uses the same
+recovered rate for legacy `F15DGTL.BIN` cue fallback. This comes from recovered
+driver timer behavior in the 8 kHz range, not from a WAV header in the original
+asset. Replacement WAV headers are authoritative at runtime.
 
 ## Runtime replacement recommendation
 
-For future game loading, prefer a manifest-like approach:
+Runtime loading currently uses path-based lookup, not a required manifest. If a
+future pack manifest is added, it should point to the same grouped files:
 
 ```json
 {
   "VN.WLD": { "world": "VN.WLD.json" },
-  "VN.3D3": { "geometry": "VN.3D3.glb", "metadata": "VN.3D3.json" },
+  "VN.3D3": { "geometry": "VN.3D3.glb", "index": "VN.3D3.json" },
   "TITLE640.PIC": { "image": "TITLE640.png", "metadata": "TITLE640.json" },
-  "F15DGTL.BIN": { "sounds": "sounds/f15dgtl_raw.json" }
+  "F15DGTL.BIN": { "sounds": "sounds/voice_cue_*.wav" }
 }
 ```
 
-Do not rely on PNG, GLB, or WAV alone for game replacement. The sidecar JSON carries ids, flags, palette metadata, original offsets, and unresolved bytes that the runtime may need.
+For replacement loading, always prefer the modern media artifact over JSON when
+both contain overlapping facts. JSON exists to locate assets and preserve
+non-media ids/flags/ranges that the media container does not represent.
+
+Current runtime implementation status:
+
+- A shared resolver searches converted asset directories such as `VN/`,
+  `LIBYA/`, `GULF/`, `15FLT/`, and `PHOTO/`.
+- Replacement lookup is case-tolerant for modern filenames and grouped model
+  directories, so packs converted from lowercase or uppercase DOS asset trees
+  can still be found on case-sensitive filesystems.
+- Legacy file loads detect preferred modern replacements and log that the
+  original loader remains active until that format has a native modern importer.
+  Current probes cover `.3D3 -> .glb` for OpenGL geometry, full `.3D3.json` for
+  legacy-byte-stream bridge dumps, `.PIC/.SPR -> .png`, and
+  `.WLD/.3DT/.3DG -> .json`.
+- PIC/SPR PNG replacement is used by the shared start/end image wrappers and by
+  the flight cockpit/side-view picture path, so converted cockpit art can be
+  edited as PNG without touching the original `.PIC`.
+- The shared resolver can also locate per-shape 3D replacements by stable slot
+  id, such as `VN/shape_049_SAM_Radar.glb`. The OpenGL backend can load these
+  through generated `cache/*.glmesh` files and rebuild missing or stale caches
+  from GLB through the `build-glmesh` bridge. The current loader still reads
+  legacy `.3D3` bytes for shape-slot tables, PHOTO append ranges, comparison,
+  and software fallback; GLB-only/free-asset runtime support requires moving
+  those table reads to modern metadata.
+  Full `.3D3.json` files that include `model_data` can be rebuilt through the
+  same JSON bridge as WLD/3DT/3DG and fed to the old loader. Default minimized
+  `.3D3.json` files are detected as metadata-only and do not trigger that
+  bridge.
+- Digitized sound runtime loading now prefers separate
+  `sounds/voice_cue_*.wav` files when present. Each WAV must be uncompressed
+  mono unsigned 8-bit PCM; its RIFF sample rate controls replacement playback
+  speed. Missing cue files fall back to the matching range in `F15DGTL.BIN`;
+  empty or invalid WAVs are rejected and also fall back to the legacy cue range.
+  Old-vs-new WAV equivalence is checked by `validate-replacements` and CTest,
+  not by normal gameplay.
+- PIC/SPR screen and sprite loads now prefer matching PNG replacements when
+  present. Indexed PNGs are copied as palette indices and their embedded palette
+  is required and applied to the active DAC; truecolor PNGs are accepted by
+  mapping pixels to the current game palette. Palette-less indexed PNGs are
+  rejected and fall back to legacy PIC/SPR. Replacement PNGs are sampled into
+  the existing game target rectangle, so higher-resolution source images do not
+  enlarge menus, cockpits, or sprite sheets. Pixel and palette equivalence is
+  checked by `validate-replacements` and CTest, not by normal gameplay.
+  Menu/debrief disk-presence gates for sprite sheets also accept matching PNG
+  replacements before prompting for original disks.
+- WLD/3DT/3DG loads now prefer matching JSON replacements when present. Runtime
+  import uses the converter's `build-binary` command to rebuild the same byte
+  stream the legacy loaders expect, then feeds those bytes into the existing
+  game loaders. This keeps loaded memory compatible while letting JSON be the
+  editable source. Set `F15_ASSET_TOOL` to override the command prefix; by
+  default runtime first looks for `tools/f15assets/cli.py` beside the
+  replacement asset's `converted_assets_all` root, then tries nearby script
+  paths, then falls back to `python3 -m tools.f15assets.cli`. JSON-rebuilt byte
+  equivalence is checked by `validate-replacements` and CTest.
+- Font drawing now prefers `fonts/font_<id>.bdf` when present. The loader parses
+  BDF glyph rows and advance widths, then switches rendering to the BDF-backed
+  font. If BDF is absent or rejected, `fonts/font_<id>.png` is tried as the glyph
+  bitmap atlas; PNG glyph pixels are authoritative, while advance widths
+  currently come from the existing font metrics. BDF fonts with incomplete glyphs
+  or zero advance widths are rejected. Built-in font equivalence is checked by
+  `validate-replacements` and CTest.
+- Runtime GLB import is implemented for the OpenGL backend through a simple
+  runtime mesh bridge generated from per-shape GLBs. The backend treats `.glb`
+  as the source of truth, loads `cache/*.glmesh` only when the embedded source
+  checksum matches, and rebuilds missing or stale caches through `build-glmesh`.
+  Empty generated runtime meshes are rejected and fall back to legacy `.3D3`;
+  stale or empty caches are logged before rebuild/fallback. Replacement runtime
+  mesh equivalence is checked by `validate-replacements` and CTest.
+  Software rendering still uses the original `.3D3` stream. Exported media files
+  are authoritative over JSON metadata where applicable.
+
+## Replacement comparison modes
+
+Comparison is test/developer tooling only:
+
+- `python3 -m tools.f15assets.cli validate-replacements <asset_dir> <converted_dir>`
+  compares exported replacements against original assets outside the game. It
+  recurses by default, matching `convert-all`; use `--no-recursive` for a
+  flat-folder check.
+- CTest `asset_runtime_loader_validation_tests` loads old and modern assets
+  through the real runtime loader paths and compares the resulting data.
+
+`--require-all` applies to authoring replacements such as PNG, BDF, WAV, JSON
+tables, and per-shape GLB. Generated `cache/*.glmesh` files are validated when
+present and required only with `--require-generated-cache`.
+GLB source primitive extras are proof metadata for unmodified conversions; a
+Blender-edited GLB may strip or alter them and still be a valid custom model.
+Use `--require-source-proof` when metadata loss should fail validation.
+`--loadability-only` ignores combined overview GLBs and converter-only proof
+metadata; the runtime-relevant requirement is that each per-shape GLB parses and
+contains renderable triangles, lines, or points.
+
+Runtime comparison helpers are split out of individual loaders under
+`src/shared/asset_compare*.c`. Put byte-stream checks in
+`asset_compare_bytes.c`, indexed image/palette checks in
+`asset_compare_image.c`, bitmap font checks in `asset_compare_font.c`, digitized
+cue checks in `asset_compare_sound.c`, and renderer-independent 3D
+topology/color/source-metadata reporting in `asset_compare_3d.c`. Tool-side
+`validate-replacements` diff helpers live in
+`tools/f15assets/f15assets/validation_compare.py` as a stable facade over
+per-format `validation_compare_*` modules. The heavier per-format validation
+orchestration lives in `validation_image.py`, `validation_font.py`,
+`validation_sound.py`, `validation_structured.py`, and `validation_model3d.py`;
+each module exposes a `validate_*` entry point. `cli.py` should only wire
+commands and repository/output path policy.
+
+Runtime diagnostics currently cover:
+
+- `PIC`/`SPR`: replacement PNG indices against the legacy PIC decoder output.
+- `WLD`/`3DT`/`3DG`: JSON-rebuilt byte stream against the original binary before
+  the existing game loader consumes the replacement stream.
+- Fonts: replacement BDF/PNG glyph rows, metrics, and widths against built-in
+  font tables before installation.
+- Digitized cues: replacement WAV samples against the matching `F15DGTL.BIN`
+  byte range.
+- OpenGL 3D: replacement GLB topology and raw source-color coverage against
+  decoded legacy `.3D3` face/line/point coverage; generated `cache/*.glmesh`
+  files are compared when present.
 
 ## Python package notes
 
@@ -194,5 +553,48 @@ tools/f15assets/tests/*.py
 ```
 
 No install step is required when running from the repository root with `python3 -m tools.f15assets.cli`.
+The game runtime also searches for `tools/f15assets/cli.py` beside the
+replacement asset's `converted_assets_all` root and in nearby relative paths
+before falling back to module execution; use `F15_ASSET_TOOL` if the tool lives
+elsewhere.
 
 The tests are smoke/round-trip helpers for converter development. Run them only when you intentionally want validation work.
+
+`validate-replacements` is the explicit old-vs-modern test/developer comparison path.
+It currently validates `PIC`/`SPR` PNG pixel indices and known embedded/external
+palettes, digitized sound cue WAVs, WLD/3DT/3DG JSON replacements, BDF/PNG font
+replacements, `.3D3` JSON slot metadata, and `.3D3` GLB structure. The `.3D3`
+JSON check verifies the minimized shape offset table and model data size without
+requiring bulky `model_data`; this is the metadata a future GLB-only/free-asset
+runtime needs before original `.3D3` files can be omitted. If bulky `model_data`
+is present, validation also rebuilds the `.3D3` byte stream and compares it with
+the original file. The GLB check verifies combined GLB metadata, renderable
+shape count, per-shape GLB presence, minimized per-shape marker, stable
+`source_shape_index` metadata, primitive/source-metadata coverage against a
+fresh export from the original `.3D3`, and `.glmesh` cache equivalence with the
+source GLB. Full
+runtime mesh primitive counts are also compared against the source GLB so
+geometry drops are reported explicitly. `F15GLM3` source primitive metadata is
+compared against both the original export and the source GLB, so validation
+catches accidental primitive merging, reordering, or raw-color metadata loss
+when `--require-source-proof` is used. Without that flag, missing or changed
+source proof metadata is reported as a warning so custom GLBs remain acceptable.
+Use `--allow-custom-glb-differences` when edited per-shape GLBs intentionally
+change geometry counts or no longer match the original `.3D3` proof metadata.
+Use `--loadability-only` for edited packs when you want structural validation
+without old-vs-new equality checks.
+For image replacements, full equality validation requires indexed PNGs because
+that is the only mode that preserves original palette indices exactly.
+`--loadability-only` accepts truecolor PNGs, matching the runtime convenience
+path that maps truecolor pixels to the active game palette.
+Expanded runtime vertices and RGBA values are compared with a small float
+tolerance so cache validation catches coordinate/color drift without depending
+only on exact byte equality. Stale root-level `shape_*.glmesh` files are
+reported as invalid; generated runtime caches belong under `cache/`.
+Missing generated caches are not failures unless `--require-generated-cache` is
+specified, because the runtime can rebuild them from GLB.
+
+`validate-replacements` is intended for proving an unmodified conversion. After
+intentional customization, differences from the original `.3D3`, PNG, WAV, or
+font source may be expected; runtime fallback and cache checks still apply, but
+old-vs-new equality is no longer the success criterion for that edited asset.

--- a/tools/f15assets/cli.py
+++ b/tools/f15assets/cli.py
@@ -14,6 +14,7 @@ try:
         parse_3d3,
         export_3d3_to_gltf,
         export_3d3_to_glb,
+        export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
@@ -29,6 +30,7 @@ except ModuleNotFoundError:
         parse_3d3,
         export_3d3_to_gltf,
         export_3d3_to_glb,
+        export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
@@ -119,6 +121,11 @@ def _write_gltf_binary(path: Path, payload: Dict[str, Any]) -> None:
     path.write_bytes(glb_data)
 
 
+def _write_gltf_binary_doc(path: Path, gltf: Dict[str, Any]) -> None:
+    glb_data = export_3d3_gltf_to_glb(gltf)
+    path.write_bytes(glb_data)
+
+
 def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
     try:
         import yaml
@@ -131,6 +138,45 @@ def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
 
 def _detect_format(path: Path) -> str:
     return ASSET_EXT_FORMATS.get(path.suffix.lower(), "")
+
+
+def _log_3d3_gltf_diagnostics(gltf: Dict[str, Any], source_path: Path | None) -> None:
+    label = str(source_path) if source_path is not None else "3D3"
+    skipped = gltf.get("extras", {}).get("skipped_shapes", [])
+    if isinstance(skipped, list):
+        for item in skipped:
+            if not isinstance(item, dict):
+                continue
+            meta = item.get("shape_payload")
+            if not isinstance(meta, dict):
+                meta = {}
+            reason = (
+                meta.get("render_error")
+                or meta.get("edge_decode_error")
+                or "no_renderable_primitives"
+            )
+            print(
+                "warning: "
+                f"{label}: skipped shape {item.get('shape_index')} "
+                f"{item.get('shape_name')} "
+                f"offset {item.get('shape_offset')}..{item.get('shape_end')} "
+                f"render_mode={item.get('render_mode')} "
+                f"reason={reason} "
+                f"metadata={json.dumps(meta, sort_keys=True)}",
+                file=sys.stderr,
+            )
+
+    raw_color_usage = gltf.get("extras", {}).get("raw_color_usage", {})
+    point_counts = {}
+    if isinstance(raw_color_usage, dict) and isinstance(raw_color_usage.get("points"), dict):
+        point_counts = raw_color_usage["points"]
+    if point_counts:
+        print(
+            "info: "
+            f"{label}: exported degenerate source lines as POINTS "
+            f"colors={json.dumps(point_counts, sort_keys=True)}",
+            file=sys.stderr,
+        )
 
 
 def _dac6_to_rgb8(data: bytes) -> bytes:
@@ -246,10 +292,12 @@ def _decode_asset(
             gltf_path = Path(args.gltf)
             if gltf_path.suffix.lower() not in {".gltf", ".glb"}:
                 raise ValueError("--gltf expects a .gltf or .glb output path")
+            gltf = export_3d3_to_gltf(payload)
+            _log_3d3_gltf_diagnostics(gltf, source_path)
             if gltf_path.suffix.lower() == ".glb":
-                _write_gltf_binary(gltf_path, payload)
+                _write_gltf_binary_doc(gltf_path, gltf)
             else:
-                _write_gltf(gltf_path, export_3d3_to_gltf(payload), pretty=args.pretty)
+                _write_gltf(gltf_path, gltf, pretty=args.pretty)
         return payload
 
     if fmt == "3DT":

--- a/tools/f15assets/cli.py
+++ b/tools/f15assets/cli.py
@@ -1137,15 +1137,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     fonts = sub.add_parser(
         "export-fonts",
-        help="export extracted in-repo font tables to BDF and atlas PNG; metadata is optional",
+        help="export extracted in-repo font tables to BDF; metadata is optional",
     )
     fonts.add_argument("repo_root", help="Repository root containing src/fontdata.h and src/gfx_impl.c")
-    fonts.add_argument("output", help="Output folder for font atlas assets")
+    fonts.add_argument("output", help="Output folder for BDF font assets")
     fonts.add_argument("--no-bdf", action="store_true", help="Skip BDF font files")
     fonts.add_argument(
         "--include-metadata",
         action="store_true",
-        help="Also write font_<id>.json sidecars and fonts.json; default output is BDF/PNG only",
+        help="Also write font_<id>.json sidecars and fonts.json; default output is BDF only",
     )
     fonts.set_defaults(func=cmd_export_fonts)
 

--- a/tools/f15assets/cli.py
+++ b/tools/f15assets/cli.py
@@ -12,33 +12,61 @@ try:
         decode_pic_asset,
         decode_title640_pic_asset,
         parse_3d3,
+        export_3d3_shape_gltfs,
         export_3d3_to_gltf,
         export_3d3_to_glb,
         export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
+        build_3d3,
+        build_3dg,
+        build_3dt,
+        build_wld,
         export_fonts,
         export_sounds,
     )
-    from tools.f15assets.f15assets.pic import to_png_data
+    from tools.f15assets.f15assets.pic import known_runtime_pic_palette, to_png_data
+    from tools.f15assets.f15assets.sounds import DEFAULT_SAMPLE_RATE
     from tools.f15assets.f15assets.io import from_base64, to_base64
+    from tools.f15assets.f15assets.validation_image import validate_pic_png_replacement, validate_png_replacement_loadability
+    from tools.f15assets.f15assets.validation_sound import validate_sound_replacements
+    from tools.f15assets.f15assets.validation_font import validate_font_replacements
+    from tools.f15assets.f15assets.validation_structured import validate_structured_json_replacements
+    from tools.f15assets.f15assets.validation_model3d import (
+        glb_to_glmesh_bytes,
+        validate_3d3_glb_replacements,
+    )
 except ModuleNotFoundError:
     from f15assets import (
         decode_pic_asset,
         decode_title640_pic_asset,
         parse_3d3,
+        export_3d3_shape_gltfs,
         export_3d3_to_gltf,
         export_3d3_to_glb,
         export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
+        build_3d3,
+        build_3dg,
+        build_3dt,
+        build_wld,
         export_fonts,
         export_sounds,
     )
-    from f15assets.pic import to_png_data
+    from f15assets.pic import known_runtime_pic_palette, to_png_data
+    from f15assets.sounds import DEFAULT_SAMPLE_RATE
     from f15assets.io import from_base64, to_base64
+    from f15assets.validation_image import validate_pic_png_replacement, validate_png_replacement_loadability
+    from f15assets.validation_sound import validate_sound_replacements
+    from f15assets.validation_font import validate_font_replacements
+    from f15assets.validation_structured import validate_structured_json_replacements
+    from f15assets.validation_model3d import (
+        glb_to_glmesh_bytes,
+        validate_3d3_glb_replacements,
+    )
 
 ASSET_EXT_FORMATS = {
     ".pic": "PIC",
@@ -61,6 +89,10 @@ F117_PIC_PALETTE_ALIASES = {
     "256RIGHT": "FLIGHT.PAL",
     "CLIMBIN": "ADV.PAL",
 }
+
+# Some tests and external scripts imported this helper from cli.py before the
+# per-format validator split. Keep the alias while new code uses the public name.
+_glb_to_glmesh_bytes = glb_to_glmesh_bytes
 
 
 def _iter_asset_paths(root: Path, recursive: bool):
@@ -85,26 +117,190 @@ def _read_binary(path: Path) -> bytes:
         return f.read()
 
 
-def _read_yaml(path: Path) -> Dict[str, Any]:
-    try:
-        import yaml
-    except Exception as exc:  # pragma: no cover
-        raise RuntimeError("PyYAML is required for YAML support") from exc
-
-    with path.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    if not isinstance(data, dict):
-        raise ValueError("YAML payload must be a mapping")
-    return data
-
-
-def _write_json(path: Path, payload: Dict[str, Any], pretty: bool = True) -> None:
+def _write_json(path: Path, payload: Dict[str, Any], pretty: bool = True, *, media_sidecar: bool = True) -> None:
+    # Default converter sidecars are media-first: for 3D3, GLB files are the
+    # editable source and JSON is minimized. Full bridge dumps deliberately opt
+    # out so runtime can rebuild the legacy byte stream without original .3D3.
+    writable_payload = _sidecar_payload_for_write(payload) if media_sidecar else payload
+    ordered_payload = _human_ordered_payload(writable_payload)
     with path.open("w", encoding="utf-8") as f:
         if pretty:
-            json.dump(payload, f, indent=2, sort_keys=True)
+            json.dump(ordered_payload, f, indent=2)
             f.write("\n")
         else:
-            json.dump(payload, f)
+            json.dump(ordered_payload, f)
+
+
+def _sidecar_payload_for_write(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if payload.get("format") == "PIC":
+        out = {
+            key: payload[key]
+            for key in (
+                "format",
+                "version",
+                "source_name",
+                "decoded_width",
+                "decoded_height",
+                "max_lzw_width",
+                "bitstream_mode",
+                "palette_profile",
+                "original_length",
+                "decoded_length",
+                "stored_height",
+                "layout",
+                "notes",
+            )
+            if key in payload
+        }
+        out["image"] = {
+            "preferred": "png",
+            "authoritative": True,
+            "notes": "Pixel data, dimensions, and palette from the matching indexed PNG override JSON metadata.",
+        }
+        return out
+
+    if payload.get("format") != "3D3":
+        return payload
+
+    # GLB is the preferred model replacement/editing artifact. Keep the JSON
+    # sidecar as a small index/manifest instead of duplicating model bytecode.
+    out = {
+        key: payload[key]
+        for key in (
+            "format",
+            "version",
+            "signature",
+            "shape_offsets",
+            "model_data_size",
+            "shape_names",
+        )
+        if key in payload
+    }
+    shared_pool = payload.get("shared_vertex_pool")
+    if isinstance(shared_pool, dict):
+        out["shared_vertex_pool"] = {
+            "index_count": len(shared_pool.get("x_indices", [])),
+            "x_value_count": len(shared_pool.get("x_values", [])),
+            "y_value_count": len(shared_pool.get("y_values", [])),
+            "z_value_count": len(shared_pool.get("z_values", [])),
+        }
+    else:
+        out["shared_vertex_pool"] = None
+    out["geometry"] = {
+        "preferred": "glb",
+        "authoritative": True,
+        "combined": True,
+        "per_shape_files": True,
+        "notes": "3D geometry and GLB extras override JSON metadata; JSON is only an index.",
+    }
+    return out
+
+
+_LARGE_JSON_KEYS = {
+    "compressed_payload_base64",
+    "model_data",
+    "name_table",
+    "palette_dac6_base64",
+    "palette_rgb8_base64",
+    "pixels_base64",
+    "raw_bytes_base64",
+    "shape_target_category_table",
+    "terrain_grid",
+    "trailing_bytes",
+    "unknown_bytes_base64",
+    "kill_tally_or_unit_flags",
+    "mission_object_type_table",
+}
+
+_JSON_KEY_ORDER = {
+    "WLD": [
+        "format",
+        "version",
+        "terrain_target_ids",
+        "read_item_size",
+        "ground_unit_count",
+        "world_object_count",
+        "world_objects",
+        "flight_unit_count",
+        "flight_units",
+        "name_strings",
+    ],
+    "3D3": [
+        "format",
+        "version",
+        "signature",
+        "shape_offsets",
+        "shape_names",
+        "model_data_size",
+        "shared_vertex_pool",
+    ],
+}
+
+_RECORD_KEY_ORDER = [
+    "name",
+    "label",
+    "unitRef",
+    "unitType",
+    "objectIdx",
+    "x_coord",
+    "y_coord",
+    "z_coord",
+    "startX",
+    "startY",
+    "startZ",
+    "waypointX",
+    "waypointY",
+    "waypointZ",
+    "targetFlags",
+    "occupantType",
+    "patrolCount",
+    "waypointIdx",
+    "flags",
+    "weaponType",
+    "terrainColor",
+    "damage",
+]
+
+
+def _is_large_json_key(key: object) -> bool:
+    text = str(key)
+    return text in _LARGE_JSON_KEYS or text.endswith("_base64")
+
+
+def _ordered_human_mapping(payload: Dict[str, Any], preferred: list[str] | None = None) -> Dict[str, Any]:
+    preferred = preferred or []
+    out: Dict[str, Any] = {}
+    seen = set()
+
+    for key in preferred:
+        if key in payload:
+            out[key] = _human_ordered_payload(payload[key])
+            seen.add(key)
+
+    normal_keys = [
+        key for key in payload.keys()
+        if key not in seen and not _is_large_json_key(key)
+    ]
+    large_keys = [
+        key for key in payload.keys()
+        if key not in seen and _is_large_json_key(key)
+    ]
+    for key in normal_keys + large_keys:
+        out[key] = _human_ordered_payload(payload[key])
+    return out
+
+
+def _human_ordered_payload(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_human_ordered_payload(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    fmt = value.get("format")
+    if isinstance(fmt, str) and fmt in _JSON_KEY_ORDER:
+        return _ordered_human_mapping(value, _JSON_KEY_ORDER[fmt])
+
+    return _ordered_human_mapping(value, _RECORD_KEY_ORDER)
 
 
 def _write_gltf(path: Path, payload: Dict[str, Any], pretty: bool = True) -> None:
@@ -126,18 +322,73 @@ def _write_gltf_binary_doc(path: Path, gltf: Dict[str, Any]) -> None:
     path.write_bytes(glb_data)
 
 
-def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
-    try:
-        import yaml
-    except Exception as exc:  # pragma: no cover
-        raise RuntimeError("PyYAML is required for --yaml output") from exc
-
-    with path.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(payload, f, sort_keys=True)
+def _remove_if_exists(path: Path) -> None:
+    if path.exists():
+        try:
+            path.unlink()
+        except OSError:
+            pass
 
 
 def _detect_format(path: Path) -> str:
     return ASSET_EXT_FORMATS.get(path.suffix.lower(), "")
+
+
+def _safe_output_stem(value: object) -> str:
+    text = str(value or "").strip()
+    safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in text)
+    safe = "_".join(part for part in safe.split("_") if part)
+    return safe[:96] or "model"
+
+
+def _related_world_stem_for_theater_asset(source_path: Path) -> str:
+    stem = source_path.stem
+    upper_stem = stem.upper()
+    wld_stem = THEATER_WLD_STEM_ALIASES.get(upper_stem, upper_stem)
+    if (source_path.with_name(f"{wld_stem}.WLD")).exists() or (
+        source_path.with_name(f"{wld_stem}.wld")
+    ).exists():
+        return wld_stem
+    return stem
+
+
+def _asset_output_dir(src: Path, relative: Path, input_root: Path, output_root: Path, fmt: str) -> Path:
+    parent = output_root / relative.parent
+    if fmt == "WLD":
+        return parent / src.stem
+    if fmt in {"3D3", "3DT", "3DG"}:
+        return parent / _related_world_stem_for_theater_asset(src)
+    return output_root / relative.with_suffix("")
+
+
+def _write_3d3_shape_models(
+    output_dir: Path,
+    payload: Dict[str, Any],
+    model_format: str,
+    pretty: bool,
+    write_cache: bool = False,
+) -> None:
+    if model_format == "none":
+        return
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for stale_glmesh in output_dir.glob("shape_*.glmesh"):
+        _remove_if_exists(stale_glmesh)
+    cache_dir = output_dir / "cache"
+    if model_format == "glb" and cache_dir.exists():
+        for stale_glmesh in cache_dir.glob("shape_*.glmesh"):
+            _remove_if_exists(stale_glmesh)
+    for shape_index, shape_name, shape_gltf in export_3d3_shape_gltfs(payload):
+        label = _safe_output_stem(shape_name)
+        base_shape = f"shape_{shape_index:03d}"
+        base = base_shape if label == base_shape else f"{base_shape}_{label}"
+        if model_format == "glb":
+            glb_path = output_dir / f"{base}.glb"
+            _write_gltf_binary_doc(glb_path, shape_gltf)
+            if write_cache:
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                (cache_dir / f"{base}.glmesh").write_bytes(glb_to_glmesh_bytes(glb_path))
+        elif model_format == "gltf":
+            _write_gltf(output_dir / f"{base}.gltf", shape_gltf, pretty=pretty)
 
 
 def _log_3d3_gltf_diagnostics(gltf: Dict[str, Any], source_path: Path | None) -> None:
@@ -219,6 +470,19 @@ def _attach_external_palette(payload: Dict[str, Any], source_path: Path | None) 
     if isinstance(profile, dict) and profile.get("status") == "embedded":
         return
 
+    index_bit_depth = 8
+    if isinstance(profile, dict):
+        try:
+            index_bit_depth = int(profile.get("index_bit_depth", 8))
+        except (TypeError, ValueError):
+            index_bit_depth = 8
+    known_palette = known_runtime_pic_palette(source_path.name, index_bit_depth)
+    if known_palette is not None:
+        payload["palette_dac6_base64"] = to_base64(bytes(known_palette["palette_dac6"]))
+        payload["palette_rgb8_base64"] = to_base64(bytes(known_palette["palette_rgb8"]))
+        payload["palette_profile"] = known_palette["profile"]
+        return
+
     found = _find_external_palette(source_path)
     if found is None:
         return
@@ -228,7 +492,9 @@ def _attach_external_palette(payload: Dict[str, Any], source_path: Path | None) 
     payload["palette_rgb8_base64"] = to_base64(_dac6_to_rgb8(palette_dac6))
     payload["palette_profile"] = {
         "source": source,
-        "source_file": str(palette_path),
+        # Store the palette filename, not the user's absolute install path, so
+        # converted image sidecars remain shareable across machines.
+        "source_file": palette_path.name,
         "status": "external",
         "index_mode": "indexed",
         "index_bit_depth": payload.get("palette_profile", {}).get("index_bit_depth", 8)
@@ -348,6 +614,36 @@ def _decode_args(png: str | None = None, gltf: str | None = None, pretty: bool =
     return argparse.Namespace(png=png, gltf=gltf, pretty=pretty)
 
 
+def _minimize_3d3_json(payload: Dict[str, Any]) -> Dict[str, Any]:
+    shared_pool = payload.get("shared_vertex_pool")
+    shared_pool_summary = None
+    if isinstance(shared_pool, dict):
+        shared_pool_summary = {
+            "index_count": len(shared_pool.get("x_indices", [])),
+            "x_value_count": len(shared_pool.get("x_values", [])),
+            "y_value_count": len(shared_pool.get("y_values", [])),
+            "z_value_count": len(shared_pool.get("z_values", [])),
+        }
+    minimized = {
+        "format": payload.get("format", "3D3"),
+        "version": payload.get("version", 1),
+        "signature": payload.get("signature"),
+        "shape_offsets": payload.get("shape_offsets", []),
+        "shape_names": payload.get("shape_names", {}),
+        "model_data_size": payload.get("model_data_size"),
+        "shared_vertex_pool_summary": shared_pool_summary,
+        "trailing_byte_count": len(from_base64(payload.get("trailing_bytes", "")))
+        if isinstance(payload.get("trailing_bytes"), str)
+        else 0,
+        "notes": (
+            "Minimized 3D3 index. GLB files are authoritative for geometry; "
+            "use decode or convert-tree --include-3d3-model-data for a full "
+            "reverse-engineering dump with model_data."
+        ),
+    }
+    return minimized
+
+
 def cmd_decode(args: argparse.Namespace) -> int:
     fmt = args.format.upper() if args.format else _detect_format(Path(args.input))
     if not fmt:
@@ -355,9 +651,7 @@ def cmd_decode(args: argparse.Namespace) -> int:
 
     data = _read_binary(Path(args.input))
     payload = _decode_asset(data, fmt, args, source_path=Path(args.input))
-    _write_json(Path(args.json), payload, pretty=args.pretty)
-    if args.yaml:
-        _write_yaml(Path(args.yaml), payload)
+    _write_json(Path(args.json), payload, pretty=args.pretty, media_sidecar=False)
     return 0
 
 
@@ -365,7 +659,14 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
     input_root = Path(args.input)
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
-        raise ValueError(f"input must be an existing directory: {args.input}")
+        if not getattr(args, "loadability_only", False):
+            raise ValueError(f"input must be an existing directory: {args.input}")
+        if getattr(args, "require_all", False):
+            raise ValueError("--require-all needs an existing original input directory; omit it for source-free --loadability-only checks")
+        print(
+            f"warning: original input directory is missing: {args.input}; running source-free loadability checks only",
+            file=sys.stderr,
+        )
 
     output_root.mkdir(parents=True, exist_ok=True)
 
@@ -381,20 +682,19 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
 
         relative = src.relative_to(input_root)
         dst_base = output_root / relative.with_suffix("")
-        dst_base.parent.mkdir(parents=True, exist_ok=True)
         output_base = dst_base
-        if fmt == "3D3":
-            # Keep the original extension in the basename, e.g. 15FLT.3D3.glb,
-            # so similarly named model records from different formats do not
-            # collide in bulk exports.
-            output_base = dst_base.with_name(src.name)
+        if fmt in {"3D3", "WLD", "3DT", "3DG"}:
+            # Keep complex/gameplay-bearing formats isolated so their sidecars,
+            # combined model, and per-shape model files are easy to browse and edit.
+            output_base = _asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
 
-        if fmt == "3D3":
+        output_base.parent.mkdir(parents=True, exist_ok=True)
+
+        if fmt in {"3D3", "WLD", "3DT", "3DG"}:
             json_path = output_base.with_name(output_base.name + ".json")
-            yaml_path = output_base.with_name(output_base.name + ".yaml")
         else:
             json_path = output_base.with_suffix(".json")
-            yaml_path = output_base.with_suffix(".yaml")
+        json_path.parent.mkdir(parents=True, exist_ok=True)
         png_path = None
         if fmt == "PIC" and not args.no_png:
             png_path = str(output_base.with_suffix(".png"))
@@ -421,19 +721,35 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
             print(f"error: {exc} ({src})", file=sys.stderr)
             continue
 
-        _write_json(json_path, payload, pretty=args.pretty)
-        if args.yaml:
-            _write_yaml(yaml_path, payload)
+        write_json_sidecar = fmt != "PIC" or png_path is None or getattr(args, "include_image_json", False)
+        if write_json_sidecar:
+            json_payload = payload
+            if fmt == "3D3" and not getattr(args, "include_3d3_model_data", False):
+                json_payload = _minimize_3d3_json(payload)
+            _write_json(
+                json_path,
+                json_payload,
+                pretty=args.pretty,
+                media_sidecar=not (fmt == "3D3" and getattr(args, "include_3d3_model_data", False)),
+            )
+        else:
+            _remove_if_exists(json_path)
+        _remove_if_exists(json_path.with_suffix(".yaml"))
 
         if fmt == "3D3":
-            legacy_exts = [".json", ".yaml", ".gltf", ".glb"]
+            _write_3d3_shape_models(
+                output_base.parent,
+                payload,
+                args.models,
+                args.pretty,
+                write_cache=getattr(args, "include_glmesh_cache", False),
+            )
+            legacy_exts = [".json", ".yaml", ".gltf", ".glb", ".glmesh"]
             for legacy_ext in legacy_exts:
-                legacy_path = dst_base.with_suffix(legacy_ext)
-                if legacy_path.exists():
-                    try:
-                        legacy_path.unlink()
-                    except OSError:
-                        pass
+                _remove_if_exists(dst_base.with_suffix(legacy_ext))
+        elif fmt in {"WLD", "3DT", "3DG"}:
+            for legacy_ext in [".json", ".yaml"]:
+                _remove_if_exists(dst_base.with_suffix(legacy_ext))
 
     return 0 if failed == 0 else 1
 
@@ -443,8 +759,17 @@ def cmd_export_fonts(args: argparse.Namespace) -> int:
     output_root = Path(args.output)
     if not (repo_root / "src" / "fontdata.h").exists():
         raise ValueError(f"repo root does not contain src/fontdata.h: {repo_root}")
-    index = export_fonts(repo_root, output_root, write_bdf=not args.no_bdf)
-    _write_json(output_root / "fonts.json", index, pretty=args.pretty)
+    index = export_fonts(
+        repo_root,
+        output_root,
+        write_bdf=not args.no_bdf,
+        include_metadata=getattr(args, "include_metadata", False),
+    )
+    index_path = output_root / "fonts.json"
+    if getattr(args, "include_metadata", False):
+        _write_json(index_path, index, pretty=args.pretty)
+    else:
+        _remove_if_exists(index_path)
     return 0
 
 
@@ -453,9 +778,206 @@ def cmd_export_sounds(args: argparse.Namespace) -> int:
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
         raise ValueError(f"input must be an existing directory: {args.input}")
-    index = export_sounds(input_root, output_root, sample_rate=args.sample_rate)
-    _write_json(output_root / "sounds.json", index, pretty=args.pretty)
+    index = export_sounds(
+        input_root,
+        output_root,
+        sample_rate=args.sample_rate,
+        include_raw_blob=getattr(args, "include_raw_blob", False),
+        include_metadata=getattr(args, "include_metadata", False),
+    )
+    if getattr(args, "include_metadata", False):
+        _write_json(output_root / "sounds.json", index, pretty=args.pretty)
     return 0
+
+
+def cmd_build_binary(args: argparse.Namespace) -> int:
+    json_path = Path(args.json)
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    fmt = args.format.upper() if args.format else str(payload.get("format", "")).upper()
+    builders = {
+        "3D3": build_3d3,
+        "WLD": build_wld,
+        "3DT": build_3dt,
+        "3DG": build_3dg,
+    }
+    if fmt not in builders:
+        raise ValueError("build-binary currently supports 3D3, WLD, 3DT, and 3DG JSON")
+    sys.stdout.buffer.write(builders[fmt](payload))
+    return 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def _structured_json_path(src: Path, relative: Path, input_root: Path, output_root: Path, fmt: str) -> Path:
+    if fmt in {"WLD", "3D3", "3DT", "3DG"}:
+        output_base = _asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
+        return output_base.with_name(output_base.name + ".json")
+    return (output_root / relative).with_suffix(".json")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def cmd_build_glmesh(args: argparse.Namespace) -> int:
+    sys.stdout.buffer.write(glb_to_glmesh_bytes(Path(args.glb)))
+    return 0
+
+
+
+
+def cmd_validate_replacements(args: argparse.Namespace) -> int:
+    input_root = Path(args.input)
+    output_root = Path(args.output)
+    if not input_root.exists() or not input_root.is_dir():
+        if not args.loadability_only:
+            raise ValueError(f"input must be an existing directory: {args.input}")
+        if args.require_all:
+            raise ValueError("--require-all needs an existing original input directory; omit it for source-free --loadability-only checks")
+        print(
+            f"warning: original input directory is missing: {args.input}; running source-free loadability checks only",
+            file=sys.stderr,
+        )
+    if output_root.exists() and output_root.is_dir() and output_root.name != "converted_assets_all" and (output_root / "converted_assets_all").is_dir():
+        output_root = output_root / "converted_assets_all"
+        print(f"using converted output directory: {output_root}", file=sys.stderr)
+    if not output_root.exists() or not output_root.is_dir():
+        raise ValueError(f"output must be an existing directory: {args.output}")
+    if args.loadability_only and args.strict_original_proof:
+        raise ValueError("--loadability-only and --strict-original-proof are incompatible validation modes")
+    if args.loadability_only and args.require_source_proof:
+        raise ValueError("--loadability-only and --require-source-proof are incompatible validation modes")
+    if args.loadability_only and args.allow_custom_glb_differences:
+        raise ValueError("--loadability-only already allows custom GLB content differences; do not combine it with --allow-custom-glb-differences")
+
+    checked = 0
+    failed = 0
+    pic_checked = 0
+    checked_png_paths: set[Path] = set()
+    if input_root.exists():
+        for src in _iter_asset_paths(input_root, recursive=args.recursive):
+            fmt = _detect_format(src)
+            if fmt != "PIC":
+                continue
+            relative = src.relative_to(input_root)
+            png_path = output_root / relative.with_suffix(".png")
+            if not png_path.exists():
+                if args.require_all:
+                    print(f"missing replacement PNG: {png_path}", file=sys.stderr)
+                    failed += 1
+                continue
+            checked += 1
+            pic_checked += 1
+            checked_png_paths.add(png_path.resolve())
+            try:
+                errors = validate_pic_png_replacement(src, png_path, _read_binary, args.loadability_only)
+            except Exception as exc:
+                errors = [f"{src}: {exc}"]
+            if errors:
+                failed += 1
+                for error in errors:
+                    print(error, file=sys.stderr)
+    if args.loadability_only:
+        for png_path in sorted(output_root.rglob("*.png")):
+            if png_path.resolve() in checked_png_paths:
+                continue
+            if "fonts" in {part.lower() for part in png_path.relative_to(output_root).parts[:-1]}:
+                continue
+            checked += 1
+            pic_checked += 1
+            errors = validate_png_replacement_loadability(png_path)
+            if errors:
+                failed += 1
+                for error in errors:
+                    print(error, file=sys.stderr)
+
+    sound_checked, sound_failed = validate_sound_replacements(input_root, output_root, args.require_all, args.loadability_only)
+    checked += sound_checked
+    failed += sound_failed
+    font_checked, font_failed = validate_font_replacements(Path(args.repo_root), output_root, args.require_all, args.loadability_only)
+    checked += font_checked
+    failed += font_failed
+    structured_checked, structured_failed = validate_structured_json_replacements(
+        input_root,
+        output_root,
+        args.recursive,
+        args.require_all,
+        _iter_asset_paths,
+        _detect_format,
+        _structured_json_path,
+        args.loadability_only,
+    )
+    checked += structured_checked
+    failed += structured_failed
+    glb_checked, glb_failed = validate_3d3_glb_replacements(
+        input_root,
+        output_root,
+        args.recursive,
+        args.require_all,
+        _iter_asset_paths,
+        _detect_format,
+        _asset_output_dir,
+        _load_shape_names_for_3d3,
+        args.require_generated_cache or args.strict_original_proof,
+        args.require_source_proof or args.strict_original_proof,
+        args.allow_custom_glb_differences and not args.strict_original_proof,
+        args.loadability_only,
+    )
+    checked += glb_checked
+    failed += glb_failed
+
+    if args.loadability_only and checked == 0:
+        print(
+            f"warning: no replacement files were checked under {output_root}; expected PNG, WAV, BDF, WLD/3DT/3DG JSON, 3D3 JSON, GLB, or GLMESH replacements",
+            file=sys.stderr,
+        )
+
+    print(
+        f"validated replacements: PIC/SPR PNG={pic_checked}, "
+        f"sound WAV={sound_checked}, font BDF/PNG={font_checked}, "
+        f"WLD/3DT/3DG JSON={structured_checked}, 3D3 JSON/GLB/GLMESH={glb_checked}; failures={failed}"
+    )
+    return 0 if failed == 0 else 1
 
 
 def _repo_root_from_tool() -> Path:
@@ -473,10 +995,12 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
     convert_args = argparse.Namespace(
         input=str(input_root),
         output=str(output_root),
-        recursive=False,
+        recursive=True,
         models="glb",
         no_png=False,
-        yaml=False,
+        include_image_json=getattr(args, "include_image_json", False),
+        include_3d3_model_data=getattr(args, "include_3d3_model_data", True),
+        include_glmesh_cache=getattr(args, "include_glmesh_cache", False),
         continue_on_error=False,
         pretty=args.pretty,
     )
@@ -489,6 +1013,7 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
         repo_root=str(repo_root),
         output=str(output_root / "fonts"),
         no_bdf=False,
+        include_metadata=getattr(args, "include_metadata", False),
         pretty=args.pretty,
     )
     result = cmd_export_fonts(font_args)
@@ -498,7 +1023,9 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
     sound_args = argparse.Namespace(
         input=str(input_root),
         output=str(output_root / "sounds"),
-        sample_rate=7850,
+        sample_rate=DEFAULT_SAMPLE_RATE,
+        include_raw_blob=getattr(args, "include_raw_blob", False),
+        include_metadata=getattr(args, "include_metadata", False),
         pretty=args.pretty,
     )
     return cmd_export_sounds(sound_args)
@@ -517,11 +1044,43 @@ def build_parser() -> argparse.ArgumentParser:
     )
     convert_all.add_argument("input", help="Installed game folder containing original assets")
     convert_all.add_argument("output", help="Output folder for all converted assets")
+    convert_all.add_argument(
+        "--include-image-json",
+        action="store_true",
+        help="Also write bulky PIC/SPR decode JSON; default output uses PNG as the image source",
+    )
+    convert_all.add_argument(
+        "--include-3d3-model-data",
+        action="store_true",
+        default=True,
+        help="Write .3D3 model_data base64 into JSON so modern-only packs can rebuild shape tables (default)",
+    )
+    convert_all.add_argument(
+        "--minimize-3d3-json",
+        dest="include_3d3_model_data",
+        action="store_false",
+        help="Omit bulky .3D3 model_data; requires original .3D3 files at runtime for shape tables",
+    )
+    convert_all.add_argument(
+        "--include-glmesh-cache",
+        action="store_true",
+        help="Also pre-generate cache/*.glmesh runtime meshes; default output relies on runtime rebuild from GLB",
+    )
+    convert_all.add_argument(
+        "--include-metadata",
+        action="store_true",
+        help="Also export optional font JSON, sound cue JSON, driver sidecars, and index metadata",
+    )
+    convert_all.add_argument(
+        "--include-raw-blob",
+        action="store_true",
+        help="Also export f15dgtl_raw.wav/f15dgtl_raw.json for reverse-engineering reference",
+    )
     convert_all.set_defaults(func=cmd_convert_all)
 
     decode = sub.add_parser(
         "decode",
-        help="decode game asset to modern editable sidecar files",
+        help="decode one game asset to full diagnostic JSON and optional media files",
     )
     decode.add_argument("input", help="Input binary asset")
     decode.add_argument("json", help="Output JSON sidecar")
@@ -534,7 +1093,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--png",
         help="Optional indexed PNG output for PIC/SPR (unsupported for other formats)",
     )
-    decode.add_argument("--yaml", help="Optional YAML output sidecar path")
     decode.add_argument(
         "--gltf",
         help="Optional .gltf or .glb output for 3D3 models",
@@ -543,7 +1101,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     convert = sub.add_parser(
         "convert-tree",
-        help="convert all supported assets in a folder to modern editable targets",
+        help="convert supported assets in one folder; use convert-all for recursive default conversion",
     )
     convert.add_argument("input", help="Input folder containing game assets")
     convert.add_argument("output", help="Output folder for converted assets")
@@ -555,7 +1113,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output format for 3D3 models (`glb` is self-contained by default)",
     )
     convert.add_argument("--no-png", action="store_true", help="Skip PNG output for PIC/SPR")
-    convert.add_argument("--yaml", action="store_true", help="Also write YAML sidecar files")
+    convert.add_argument(
+        "--include-image-json",
+        action="store_true",
+        help="Also write bulky PIC/SPR decode JSON; by default PNG is the image replacement source",
+    )
+    convert.add_argument(
+        "--include-3d3-model-data",
+        action="store_true",
+        help="Also write bulky .3D3 model_data base64 into JSON; by default GLB is the geometry source",
+    )
+    convert.add_argument(
+        "--include-glmesh-cache",
+        action="store_true",
+        help="Also pre-generate cache/*.glmesh runtime meshes; default output relies on runtime rebuild from GLB",
+    )
     convert.add_argument(
         "--continue-on-error",
         action="store_true",
@@ -565,26 +1137,110 @@ def build_parser() -> argparse.ArgumentParser:
 
     fonts = sub.add_parser(
         "export-fonts",
-        help="export extracted in-repo font tables to atlas PNG and JSON metadata",
+        help="export extracted in-repo font tables to BDF and atlas PNG; metadata is optional",
     )
     fonts.add_argument("repo_root", help="Repository root containing src/fontdata.h and src/gfx_impl.c")
     fonts.add_argument("output", help="Output folder for font atlas assets")
     fonts.add_argument("--no-bdf", action="store_true", help="Skip BDF font files")
+    fonts.add_argument(
+        "--include-metadata",
+        action="store_true",
+        help="Also write font_<id>.json sidecars and fonts.json; default output is BDF/PNG only",
+    )
     fonts.set_defaults(func=cmd_export_fonts)
 
     sounds = sub.add_parser(
         "export-sounds",
-        help="export digitized sample blob and sound-driver sidecars",
+        help="export digitized cue WAVs; optional metadata sidecars are opt-in",
     )
     sounds.add_argument("input", help="Installed game folder containing F15DGTL.BIN and sound drivers")
     sounds.add_argument("output", help="Output folder for sound assets")
     sounds.add_argument(
         "--sample-rate",
         type=int,
-        default=7850,
-        help="Sample rate for raw unsigned 8-bit PCM WAV export",
+        default=DEFAULT_SAMPLE_RATE,
+        help="Sample rate for exported unsigned 8-bit PCM cue WAVs",
+    )
+    sounds.add_argument(
+        "--include-raw-blob",
+        action="store_true",
+        help="Also export f15dgtl_raw.wav/f15dgtl_raw.json for reverse-engineering reference",
+    )
+    sounds.add_argument(
+        "--include-metadata",
+        action="store_true",
+        help="Also export cue JSON, driver sidecars, and sounds.json metadata for reverse engineering",
     )
     sounds.set_defaults(func=cmd_export_sounds)
+
+    build_binary = sub.add_parser(
+        "build-binary",
+        help="rebuild runtime binary bytes from structured replacement JSON",
+    )
+    build_binary.add_argument("json", help="Input 3D3/WLD/3DT/3DG JSON replacement")
+    build_binary.add_argument(
+        "--format",
+        choices=["3D3", "3d3", "WLD", "wld", "3DT", "3dt", "3DG", "3dg"],
+        help="Force JSON format instead of reading payload.format",
+    )
+    build_binary.set_defaults(func=cmd_build_binary)
+
+    build_glmesh = sub.add_parser(
+        "build-glmesh",
+        help="expand a replacement GLB into a simple runtime mesh stream for the OpenGL backend",
+    )
+    build_glmesh.add_argument("glb", help="Input per-shape GLB")
+    build_glmesh.set_defaults(func=cmd_build_glmesh)
+
+    validate = sub.add_parser(
+        "validate-replacements",
+        help="compare original asset loads against modern replacements; use flags for strict proof or custom GLB workflows",
+    )
+    validate.add_argument("input", help="Installed game folder containing original assets")
+    validate.add_argument("output", help="Converted asset folder")
+    validate.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root for validating in-repo original font tables",
+    )
+    validate.add_argument(
+        "--no-recursive",
+        dest="recursive",
+        action="store_false",
+        default=True,
+        help="Only validate assets directly under the input folder",
+    )
+    validate.add_argument(
+        "--require-all",
+        action="store_true",
+        help="Fail if a supported original asset has no modern authoring replacement",
+    )
+    validate.add_argument(
+        "--require-generated-cache",
+        action="store_true",
+        help="Also fail if generated 3D cache/*.glmesh runtime caches are missing",
+    )
+    validate.add_argument(
+        "--require-source-proof",
+        action="store_true",
+        help="Fail if GLB/GLMESH source primitive metadata is missing or no longer matches the original export",
+    )
+    validate.add_argument(
+        "--strict-original-proof",
+        action="store_true",
+        help="Strict converter-regression mode: require generated 3D caches and GLB/GLMESH source proof metadata",
+    )
+    validate.add_argument(
+        "--allow-custom-glb-differences",
+        action="store_true",
+        help="Warn instead of failing when per-shape GLB geometry/source proof differs from the original .3D3 export",
+    )
+    validate.add_argument(
+        "--loadability-only",
+        action="store_true",
+        help="Validate modern files parse and have required structure, but skip equality checks against original assets",
+    )
+    validate.set_defaults(func=cmd_validate_replacements)
 
     return parser
 

--- a/tools/f15assets/f15assets/__init__.py
+++ b/tools/f15assets/f15assets/__init__.py
@@ -2,7 +2,7 @@
 
 from .pic import decode_pic_asset, decode_title640_pic_asset, encode_pic_asset
 from .model3d import build_3d3, export_3d3_to_gltf, parse_3d3
-from .model3d import export_3d3_to_glb
+from .model3d import export_3d3_gltf_to_glb, export_3d3_to_glb
 from .terrain import parse_3dg, build_3dg, parse_3dt, build_3dt
 from .world import parse_wld, build_wld
 from .fonts import export_fonts, load_font_assets
@@ -15,6 +15,7 @@ __all__ = [
     "parse_3d3",
     "build_3d3",
     "export_3d3_to_gltf",
+    "export_3d3_gltf_to_glb",
     "export_3d3_to_glb",
     "parse_3dg",
     "build_3dg",

--- a/tools/f15assets/f15assets/__init__.py
+++ b/tools/f15assets/f15assets/__init__.py
@@ -1,12 +1,17 @@
 """Asset converters for F-15 Strike Eagle II formats."""
 
 from .pic import decode_pic_asset, decode_title640_pic_asset, encode_pic_asset
-from .model3d import build_3d3, export_3d3_to_gltf, parse_3d3
+from .model3d import build_3d3, export_3d3_shape_gltfs, export_3d3_to_gltf, parse_3d3
 from .model3d import export_3d3_gltf_to_glb, export_3d3_to_glb
 from .terrain import parse_3dg, build_3dg, parse_3dt, build_3dt
 from .world import parse_wld, build_wld
 from .fonts import export_fonts, load_font_assets
 from .sounds import export_sounds, decode_digitized_blob
+from .validation_image import validate_pic_png_replacement, validate_png_replacement_loadability
+from .validation_font import validate_font_replacements
+from .validation_sound import validate_sound_replacements
+from .validation_structured import validate_structured_json_replacements
+from .validation_model3d import glb_to_glmesh_bytes, validate_3d3_glb_replacements
 
 __all__ = [
     "decode_pic_asset",
@@ -14,6 +19,7 @@ __all__ = [
     "encode_pic_asset",
     "parse_3d3",
     "build_3d3",
+    "export_3d3_shape_gltfs",
     "export_3d3_to_gltf",
     "export_3d3_gltf_to_glb",
     "export_3d3_to_glb",
@@ -27,4 +33,11 @@ __all__ = [
     "load_font_assets",
     "export_sounds",
     "decode_digitized_blob",
+    "validate_pic_png_replacement",
+    "validate_png_replacement_loadability",
+    "validate_font_replacements",
+    "validate_sound_replacements",
+    "validate_structured_json_replacements",
+    "glb_to_glmesh_bytes",
+    "validate_3d3_glb_replacements",
 ]

--- a/tools/f15assets/f15assets/fonts.py
+++ b/tools/f15assets/f15assets/fonts.py
@@ -13,6 +13,189 @@ FONT_CODEPOINT_COUNT = 96
 ATLAS_COLUMNS = 16
 ATLAS_PADDING = 1
 
+# The original game has no Cyrillic source glyphs. Export Russian glyphs as
+# explicit 5x7 bitmap templates instead of borrowing Latin letters: letters such
+# as И/Й must have their diagonal in the Cyrillic direction, and shapes such as
+# Д/Л/Я/Ю do not have safe Latin equivalents. The templates are downsampled or
+# centred into each recovered font's cell size, so every font_<id>.bdf receives
+# the same Unicode coverage while preserving its original height/width limits.
+CYRILLIC_5X7 = {
+    0x0401: ["01010", "11111", "10000", "11110", "10000", "10000", "11111"],
+    0x0410: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+    0x0411: ["11111", "10000", "10000", "11110", "10001", "10001", "11110"],
+    0x0412: ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
+    0x0413: ["11111", "10000", "10000", "10000", "10000", "10000", "10000"],
+    0x0414: ["01111", "01001", "01001", "01001", "01001", "11111", "10001"],
+    0x0415: ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+    0x0416: ["10101", "10101", "10101", "01110", "10101", "10101", "10101"],
+    0x0417: ["11110", "00001", "00001", "01110", "00001", "00001", "11110"],
+    0x0418: ["10001", "10011", "10101", "10101", "11001", "10001", "10001"],
+    0x0419: ["01010", "10001", "10011", "10101", "11001", "10001", "10001"],
+    0x041A: ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+    0x041B: ["01111", "01001", "01001", "01001", "01001", "01001", "10001"],
+    0x041C: ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+    0x041D: ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
+    0x041E: ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+    0x041F: ["11111", "10001", "10001", "10001", "10001", "10001", "10001"],
+    0x0420: ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+    0x0421: ["01111", "10000", "10000", "10000", "10000", "10000", "01111"],
+    0x0422: ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+    0x0423: ["10001", "10001", "10001", "01111", "00001", "00001", "11110"],
+    0x0424: ["00100", "01110", "10101", "10101", "01110", "00100", "00100"],
+    0x0425: ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
+    0x0426: ["10001", "10001", "10001", "10001", "10001", "11111", "00001"],
+    0x0427: ["10001", "10001", "10001", "01111", "00001", "00001", "00001"],
+    0x0428: ["10101", "10101", "10101", "10101", "10101", "10101", "11111"],
+    0x0429: ["10101", "10101", "10101", "10101", "10101", "11111", "00001"],
+    0x042A: ["11000", "01000", "01000", "01110", "01001", "01001", "01110"],
+    0x042B: ["10001", "10001", "10001", "11101", "10011", "10011", "11101"],
+    0x042C: ["10000", "10000", "10000", "11110", "10001", "10001", "11110"],
+    0x042D: ["11110", "00001", "00001", "01111", "00001", "00001", "11110"],
+    0x042E: ["10010", "10101", "10101", "11101", "10101", "10101", "10010"],
+    0x042F: ["01111", "10001", "10001", "01111", "00101", "01001", "10001"],
+}
+
+CYRILLIC_LOWER_TO_UPPER = {
+    0x0451: 0x0401,
+    **{codepoint + 0x20: codepoint for codepoint in range(0x0410, 0x0430)},
+}
+
+CYRILLIC_LOWER_5X7 = {
+    0x0451: ["01010", "00000", "01110", "10001", "11111", "10000", "01110"],
+    0x0430: ["00000", "00000", "01110", "00001", "01111", "10001", "01111"],
+    0x0431: ["00111", "01000", "10000", "11110", "10001", "10001", "01110"],
+    0x0432: ["00000", "00000", "11110", "10001", "11110", "10001", "11110"],
+    0x0433: ["00000", "00000", "11111", "10000", "10000", "10000", "10000"],
+    0x0434: ["00000", "00000", "01111", "01001", "01001", "11111", "10001"],
+    0x0435: ["00000", "00000", "01110", "10001", "11111", "10000", "01110"],
+    0x0436: ["00000", "00000", "10101", "10101", "01110", "10101", "10101"],
+    0x0437: ["00000", "00000", "11110", "00001", "01110", "00001", "11110"],
+    0x0438: ["00000", "00000", "10001", "10011", "10101", "11001", "10001"],
+    0x0439: ["01010", "00100", "10001", "10011", "10101", "11001", "10001"],
+    0x043A: ["00000", "00000", "10001", "10010", "11100", "10010", "10001"],
+    0x043B: ["00000", "00000", "01111", "01001", "01001", "01001", "10001"],
+    0x043C: ["00000", "00000", "10001", "11011", "10101", "10001", "10001"],
+    0x043D: ["00000", "00000", "10001", "10001", "11111", "10001", "10001"],
+    0x043E: ["00000", "00000", "01110", "10001", "10001", "10001", "01110"],
+    0x043F: ["00000", "00000", "11111", "10001", "10001", "10001", "10001"],
+    0x0440: ["00000", "00000", "11110", "10001", "11110", "10000", "10000"],
+    0x0441: ["00000", "00000", "01111", "10000", "10000", "10000", "01111"],
+    0x0442: ["00000", "00000", "11111", "00100", "00100", "00100", "00100"],
+    0x0443: ["00000", "00000", "10001", "10001", "01111", "00001", "11110"],
+    0x0444: ["00000", "00100", "01110", "10101", "10101", "01110", "00100"],
+    0x0445: ["00000", "00000", "10001", "01010", "00100", "01010", "10001"],
+    0x0446: ["00000", "00000", "10001", "10001", "10001", "11111", "00001"],
+    0x0447: ["00000", "00000", "10001", "10001", "01111", "00001", "00001"],
+    0x0448: ["00000", "00000", "10101", "10101", "10101", "10101", "11111"],
+    0x0449: ["00000", "00000", "10101", "10101", "10101", "11111", "00001"],
+    0x044A: ["00000", "00000", "11000", "01000", "01110", "01001", "01110"],
+    0x044B: ["00000", "00000", "10001", "10001", "11101", "10011", "11101"],
+    0x044C: ["00000", "00000", "10000", "10000", "11110", "10001", "11110"],
+    0x044D: ["00000", "00000", "11110", "00001", "01111", "00001", "11110"],
+    0x044E: ["00000", "00000", "10010", "10101", "11101", "10101", "10010"],
+    0x044F: ["00000", "00000", "01111", "10001", "01111", "00101", "10001"],
+}
+
+CYRILLIC_4X5 = {
+    0x0414: ["0111", "0101", "0101", "1111", "1001"],
+    0x0416: ["1010", "1010", "0100", "1010", "1010"],
+    0x041B: ["0111", "0101", "0101", "0101", "1001"],
+    0x041E: ["0110", "1001", "1001", "1001", "0110"],
+    0x0421: ["0111", "1000", "1000", "1000", "0111"],
+    0x0426: ["1001", "1001", "1001", "1111", "0001"],
+    0x0428: ["1001", "1001", "1011", "1011", "1111"],
+    0x0429: ["1001", "1001", "1011", "1111", "0001"],
+    0x042D: ["1110", "0001", "0111", "0001", "1110"],
+    0x042E: ["1010", "1011", "1111", "1011", "1010"],
+    0x042F: ["0111", "1001", "0111", "0101", "1001"],
+    0x0436: ["1010", "1010", "0100", "1010", "1010"],
+    0x0448: ["1001", "1001", "1011", "1011", "1111"],
+    0x0449: ["1001", "1001", "1011", "1111", "0001"],
+}
+
+LATIN_EXTENDED_4X5 = {
+    0x00C1: ["0010", "0110", "1001", "1111", "1001"],  # Á
+    0x00E4: ["1010", "0110", "0001", "0111", "0111"],  # ä
+    0x00E1: ["0010", "0110", "0001", "0111", "0111"],  # á
+    0x00C9: ["0010", "1111", "1000", "1110", "1111"],  # É
+    0x00E9: ["0010", "0110", "1111", "1000", "0111"],  # é
+    0x00F6: ["1010", "0110", "1001", "1001", "0110"],  # ö
+    0x00FC: ["1010", "1001", "1001", "1001", "0111"],  # ü
+    0x0104: ["0110", "1001", "1111", "1001", "1011"],  # Ą
+    0x0105: ["0110", "0001", "0111", "1001", "0011"],  # ą
+    0x0106: ["0010", "0111", "1000", "1000", "0111"],  # Ć
+    0x0107: ["0010", "0111", "1000", "1000", "0111"],  # ć
+    0x010C: ["1010", "0111", "1000", "1000", "0111"],  # Č
+    0x010D: ["1010", "0111", "1000", "1000", "0111"],  # č
+    0x0110: ["1110", "1011", "1011", "1011", "1110"],  # Đ
+    0x0111: ["0010", "1110", "1011", "1011", "1110"],  # đ
+    0x0118: ["1111", "1000", "1110", "1000", "1111"],  # Ę
+    0x0119: ["0111", "1000", "1110", "1000", "0111"],  # ę
+    0x0141: ["1000", "1010", "1100", "1000", "1111"],  # Ł
+    0x0142: ["1000", "1010", "1100", "1000", "1000"],  # ł
+    0x0143: ["0010", "1001", "1101", "1011", "1001"],  # Ń
+    0x0144: ["0010", "1110", "1001", "1001", "1001"],  # ń
+    0x00D3: ["0010", "0110", "1001", "1001", "0110"],  # Ó
+    0x00F3: ["0010", "0110", "1001", "1001", "0110"],  # ó
+    0x015A: ["0010", "1111", "1000", "0110", "1110"],  # Ś
+    0x015B: ["0010", "1110", "1100", "0010", "1110"],  # ś
+    0x0160: ["1010", "1111", "1000", "0110", "1110"],  # Š
+    0x0161: ["1010", "1110", "1100", "0010", "1110"],  # š
+    0x0179: ["0010", "1111", "0010", "0100", "1111"],  # Ź
+    0x017A: ["0010", "1111", "0010", "0100", "1111"],  # ź
+    0x017B: ["0010", "1111", "0010", "0100", "1111"],  # Ż
+    0x017C: ["0010", "1111", "0010", "0100", "1111"],  # ż
+    0x017D: ["1010", "1111", "0010", "0100", "1111"],  # Ž
+    0x017E: ["1010", "1111", "0010", "0100", "1111"],  # ž
+}
+
+LATIN_EXTENDED_8X8 = {
+    0x0104: ["00110000", "01001000", "10000100", "11111100", "10000100", "10000100", "10000100", "00001000"],  # Ą
+    0x0105: ["00000000", "00000000", "01111000", "00000100", "01111100", "10000100", "01111100", "00001000"],  # ą
+    0x0118: ["11111100", "10000000", "10000000", "11111000", "10000000", "10000000", "11111100", "00001000"],  # Ę
+    0x0119: ["00000000", "00000000", "01111000", "10000100", "11111100", "10000000", "01111000", "00001000"],  # ę
+    0x0110: ["11110000", "10001000", "10001000", "11111000", "10001000", "10001000", "11110000", "00000000"],  # Đ
+    0x0111: ["00001000", "00111100", "00001000", "01111000", "10001000", "10001000", "01111000", "00000000"],  # đ
+    0x0141: ["10000000", "10000000", "10010000", "10100000", "11000000", "10000000", "11111000", "00000000"],  # Ł
+    0x0142: ["10000000", "10000000", "10010000", "10100000", "11000000", "10000000", "10000000", "00000000"],  # ł
+    0x0179: ["00010000", "11111100", "00001000", "00010000", "00100000", "01000000", "11111100", "00000000"],  # Ź
+    0x017A: ["00010000", "00000000", "11111000", "00010000", "00100000", "01000000", "11111000", "00000000"],  # ź
+    0x017B: ["00010000", "11111100", "00001000", "00010000", "00100000", "01000000", "11111100", "00000000"],  # Ż
+    0x017C: ["00010000", "00000000", "11111000", "00010000", "00100000", "01000000", "11111000", "00000000"],  # ż
+    0x017D: ["00101000", "00010000", "11111100", "00001000", "00010000", "00100000", "11111100", "00000000"],  # Ž
+    0x017E: ["00101000", "00010000", "11111000", "00010000", "00100000", "01000000", "11111000", "00000000"],  # ž
+}
+
+# German and Polish letters are generated from each font's own ASCII Latin
+# glyphs, then accented in-place. This keeps the recovered font style instead
+# of replacing letters with a generic Unicode font. The BDF remains the source
+# of truth for authors who want to hand-tune any generated glyph.
+LATIN_EXTENDED_GLYPHS = {
+    # German
+    0x00C4: ("A", "diaeresis"), 0x00D6: ("O", "diaeresis"),
+    0x00DC: ("U", "diaeresis"), 0x00DF: ("B", "eszett"),
+    0x00E4: ("a", "diaeresis"), 0x00F6: ("o", "diaeresis"),
+    0x00FC: ("u", "diaeresis"), 0x1E9E: ("B", "eszett"),
+    # Acute Latin letters useful for localized custom text.
+    0x00C1: ("A", "acute"), 0x00E1: ("a", "acute"),
+    0x00C9: ("E", "acute"), 0x00E9: ("e", "acute"),
+    # Polish
+    0x0104: ("A", "ogonek"), 0x0105: ("a", "ogonek"),
+    0x0106: ("C", "acute"), 0x0107: ("c", "acute"),
+    # Serbian Latin
+    0x010C: ("C", "caron"), 0x010D: ("c", "caron"),
+    0x0110: ("D", "slash"), 0x0111: ("d", "slash"),
+    0x0118: ("E", "ogonek"), 0x0119: ("e", "ogonek"),
+    0x0141: ("L", "slash"), 0x0142: ("l", "slash"),
+    0x0143: ("N", "acute"), 0x0144: ("n", "acute"),
+    0x00D3: ("O", "acute"), 0x00F3: ("o", "acute"),
+    0x015A: ("S", "acute"), 0x015B: ("s", "acute"),
+    0x0160: ("S", "caron"), 0x0161: ("s", "caron"),
+    0x0179: ("Z", "acute"), 0x017A: ("z", "acute"),
+    0x017B: ("Z", "dot"), 0x017C: ("z", "dot"),
+    0x017D: ("Z", "caron"), 0x017E: ("z", "caron"),
+}
+
 
 def _extract_c_initializer(text: str, decl_pattern: str) -> str | None:
     match = re.search(decl_pattern, text, re.S)
@@ -194,20 +377,165 @@ def _glyph_bdf_bitmap(glyph_rows: List[int], width: int) -> List[str]:
     return [f"{row & 0xFF:0{hex_width}X}" for row in glyph_rows]
 
 
+def _cyrillic_template(codepoint: int) -> List[str]:
+    if codepoint in CYRILLIC_LOWER_5X7:
+        return CYRILLIC_LOWER_5X7[codepoint]
+    upper = CYRILLIC_LOWER_TO_UPPER.get(codepoint, codepoint)
+    return CYRILLIC_5X7[upper]
+
+
+def _scale_template_columns(row: str, width: int) -> str:
+    if width == len(row):
+        return row
+    if width <= 0:
+        return ""
+    scaled = []
+    for x in range(width):
+        start = int(x * len(row) / width)
+        end = int((x + 1) * len(row) / width)
+        if end <= start:
+            end = start + 1
+        scaled.append("1" if "1" in row[start:end] else "0")
+    return "".join(scaled)
+
+
+def _template_to_glyph_rows(template: List[str], cell_width: int, height: int) -> List[int]:
+    draw_width = max(1, min(5, cell_width))
+    x_offset = max(0, (cell_width - draw_width) // 2)
+    rows: List[int] = []
+    for y in range(height):
+        if len(template) == 7 and height == 6:
+            # The 6-row menu fonts need the centre row preserved; simple
+            # rounding skips it and damages Э/З/Я-like glyphs.
+            src_y = [0, 1, 2, 3, 5, 6][y]
+        else:
+            src_y = round(y * (len(template) - 1) / max(1, height - 1))
+        scaled = _scale_template_columns(template[src_y], draw_width)
+        bits = 0
+        for x, pixel in enumerate(scaled):
+            if pixel == "1" and x + x_offset < 8:
+                bits |= 0x80 >> (x + x_offset)
+        rows.append(bits)
+    return rows
+
+
+def _cyrillic_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], int]:
+    cell_width = int(font["cell_width"])
+    height = int(font["height"])
+    template = CYRILLIC_4X5.get(codepoint) if cell_width <= 4 and height <= 5 else None
+    if template is None:
+        template = _cyrillic_template(codepoint)
+        if codepoint in CYRILLIC_LOWER_5X7 and height < 7:
+            # Lowercase Russian letters in a 5/6-row font should not spend two
+            # rows on empty ascenders; trim them so small letters remain legible.
+            while len(template) > 1 and template[0].count("1") == 0:
+                template = template[1:]
+    rows = _template_to_glyph_rows(template or _cyrillic_template(codepoint), cell_width, height)
+    # Match the recovered font's normal uppercase advance where possible. This
+    # keeps Russian UI text layout close to existing Latin menu text while BDF
+    # still allows authors to tune individual advances by hand.
+    advance_idx = ord("M") - FONT_CODEPOINT_START
+    advance = int(font["advance_widths"][advance_idx])
+    return rows, max(1, min(255, advance))
+
+
+def _ascii_glyph(font: Dict[str, Any], source_char: str) -> Tuple[List[int], int]:
+    idx = ord(source_char) - FONT_CODEPOINT_START
+    if idx < 0 or idx >= FONT_CODEPOINT_COUNT:
+        idx = ord("?") - FONT_CODEPOINT_START
+    return list(font["glyphs"][idx]), int(font["advance_widths"][idx])
+
+
+def _set_pixel(rows: List[int], x: int, y: int, cell_width: int) -> None:
+    if 0 <= y < len(rows) and 0 <= x < min(cell_width, 8):
+        rows[y] |= 0x80 >> x
+
+
+def _overlay_mark(rows: List[int], cell_width: int, mark: str) -> None:
+    width = min(cell_width, 8)
+    if width <= 0 or not rows:
+        return
+    mid = width // 2
+    right = width - 1
+    if mark == "diaeresis":
+        _set_pixel(rows, max(0, mid - 2), 0, cell_width)
+        _set_pixel(rows, min(right, mid + 1), 0, cell_width)
+    elif mark == "acute":
+        _set_pixel(rows, min(right, mid + 1), 0, cell_width)
+        if len(rows) > 1:
+            _set_pixel(rows, mid, 1, cell_width)
+    elif mark == "caron":
+        lit_columns = [
+            x
+            for row in rows[1:]
+            for x in range(width)
+            if row & (0x80 >> x)
+        ]
+        if lit_columns:
+            mid = (min(lit_columns) + max(lit_columns)) // 2
+        _set_pixel(rows, max(0, mid - 1), 0, cell_width)
+        _set_pixel(rows, mid, min(1, len(rows) - 1), cell_width)
+        _set_pixel(rows, min(right, mid + 1), 0, cell_width)
+    elif mark == "dot":
+        _set_pixel(rows, mid, 0, cell_width)
+    elif mark == "ogonek":
+        _set_pixel(rows, max(0, right - 1), len(rows) - 1, cell_width)
+        if len(rows) > 1:
+            _set_pixel(rows, right, len(rows) - 2, cell_width)
+    elif mark == "slash":
+        # Polish Ł/ł and Serbian Đ/đ use a crossbar/diagonal through the stem.
+        # It should sit around the optical middle, slightly high; placing it
+        # near the bottom reads like a descender instead of a letter mark.
+        y0 = 1 if len(rows) <= 5 else max(1, len(rows) // 2 - 2)
+        _set_pixel(rows, min(right, mid + 1), y0, cell_width)
+        _set_pixel(rows, mid, min(len(rows) - 1, y0 + 1), cell_width)
+        if width > 4:
+            _set_pixel(rows, max(0, mid - 1), min(len(rows) - 1, y0 + 2), cell_width)
+
+
+def _latin_extended_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], int]:
+    source_char, mark = LATIN_EXTENDED_GLYPHS[codepoint]
+    cell_width = int(font["cell_width"])
+    height = int(font["height"])
+    if codepoint in LATIN_EXTENDED_4X5 and cell_width <= 4 and height <= 5:
+        rows = _template_to_glyph_rows(LATIN_EXTENDED_4X5[codepoint], cell_width, height)
+        _, advance = _ascii_glyph(font, source_char)
+        return rows, max(1, min(255, advance))
+    if mark == "eszett":
+        rows = _template_to_glyph_rows(
+            ["01110", "10001", "10000", "11110", "10001", "10001", "11110"],
+            cell_width,
+            height,
+        )
+        _, advance = _ascii_glyph(font, source_char)
+        return rows, max(1, min(255, advance))
+    rows, advance = _ascii_glyph(font, source_char)
+    if mark in {"acute", "caron", "diaeresis", "dot"} and len(rows) > 5:
+        # Reserve the first row for the accent. Without this, the mark is ORed
+        # into an already-lit uppercase row (for example Z/Ž), which makes the
+        # accent look shifted right or glued to the letter.
+        rows = [0] + rows[:-1]
+    _overlay_mark(rows, int(font["cell_width"]), mark)
+    return rows, max(1, min(255, advance))
+
+
 def build_bdf(font: Dict[str, Any]) -> str:
     font_id = int(font["font_id"])
     width = int(font["cell_width"])
     height = int(font["height"])
+    cyrillic_codepoints = sorted(CYRILLIC_5X7) + sorted(CYRILLIC_LOWER_TO_UPPER)
+    latin_codepoints = sorted(LATIN_EXTENDED_GLYPHS)
+    extra_codepoints = cyrillic_codepoints + latin_codepoints
     lines = [
         "STARTFONT 2.1",
-        f"FONT -MicroProse-F15SE2-Font{font_id}-Medium-R-Normal--{height * 10}-100-75-75-C-{width * 10}-CP437",
+        f"FONT -MicroProse-F15SE2-Font{font_id}-Medium-R-Normal--{height * 10}-100-75-75-C-{width * 10}-Unicode",
         f"SIZE {height} 75 75",
         f"FONTBOUNDINGBOX {width} {height} 0 0",
         f"STARTPROPERTIES 2",
         f"FONT_ASCENT {height}",
         "FONT_DESCENT 0",
         "ENDPROPERTIES",
-        f"CHARS {FONT_CODEPOINT_COUNT}",
+        f"CHARS {FONT_CODEPOINT_COUNT + len(extra_codepoints)}",
     ]
     for idx, glyph_rows in enumerate(font["glyphs"]):
         codepoint = FONT_CODEPOINT_START + idx
@@ -224,21 +552,45 @@ def build_bdf(font: Dict[str, Any]) -> str:
                 "ENDCHAR",
             ]
         )
+    for codepoint in extra_codepoints:
+        if codepoint in LATIN_EXTENDED_GLYPHS:
+            glyph_rows, advance = _latin_extended_glyph(font, codepoint)
+        else:
+            glyph_rows, advance = _cyrillic_glyph(font, codepoint)
+        lines.extend(
+            [
+                f"STARTCHAR U+{codepoint:04X}",
+                f"ENCODING {codepoint}",
+                f"SWIDTH {advance * 100} 0",
+                f"DWIDTH {advance} 0",
+                f"BBX {width} {height} 0 0",
+                "BITMAP",
+                *_glyph_bdf_bitmap(glyph_rows, width),
+                "ENDCHAR",
+            ]
+        )
     lines.extend(["ENDFONT", ""])
     return "\n".join(lines)
 
 
-def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True, include_metadata: bool = False) -> Dict[str, Any]:
+def export_fonts(
+    repo_root: Path,
+    output_root: Path,
+    *,
+    write_bdf: bool = True,
+    include_metadata: bool = False,
+) -> Dict[str, Any]:
     output_root.mkdir(parents=True, exist_ok=True)
     fonts = load_font_assets(repo_root)
     exported = []
     for font_id, font in sorted(fonts.items()):
-        image, metadata = _build_atlas(font)
         stem = f"font_{font_id}"
         png_path = output_root / f"{stem}.png"
         json_path = output_root / f"{stem}.json"
-        image.save(png_path)
+        if png_path.exists():
+            png_path.unlink()
         if include_metadata:
+            _image, metadata = _build_atlas(font)
             json_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         elif json_path.exists():
             json_path.unlink()
@@ -248,10 +600,10 @@ def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True, 
             bdf_path.write_text(build_bdf(font), encoding="ascii")
         record = {
             "font_id": font_id,
+            "source": "repository_font_tables",
             # The index is meant to travel with the exported font folder, so
             # keep paths relative instead of baking in a developer machine's
             # checkout/output directory.
-            "png": png_path.name,
             "bdf": bdf_path.name if bdf_path is not None else None,
         }
         if include_metadata:
@@ -262,10 +614,9 @@ def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True, 
         "version": 1,
         "source": "repository_font_tables",
         "authoring_source": "font_<id>.bdf",
-        "runtime_authoritative": "font_<id>.bdf, then font_<id>.png fallback if BDF is missing or rejected",
+        "runtime_authoritative": "font_<id>.bdf",
         "notes": (
-            "Edit BDF for glyph pixels and advance widths. PNG atlas is a "
-            "bitmap fallback and current runtime reuses existing widths for PNG. "
+            "Edit BDF for glyph pixels, Unicode codepoints, and advance widths. "
             "Per-font JSON is optional metadata and is not used by the runtime loader."
         ),
         "exported": exported,

--- a/tools/f15assets/f15assets/fonts.py
+++ b/tools/f15assets/f15assets/fonts.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import base64
 import json
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
-
-from .io import to_base64
 
 FONT_CODEPOINT_START = 0x20
 FONT_CODEPOINT_COUNT = 96
@@ -112,12 +109,12 @@ def load_font_assets(repo_root: Path) -> Dict[int, Dict[str, Any]]:
             "cell_width": cell_width,
             "height": height,
             "source_files": [
-                str(fontdata_path),
-                str(gfx_impl_path),
+                "src/fontdata.h",
+                "src/gfx_impl.c",
             ],
             "source_sha256": {
-                str(fontdata_path): _font_source_hash(fontdata_path),
-                str(gfx_impl_path): _font_source_hash(gfx_impl_path),
+                "src/fontdata.h": _font_source_hash(fontdata_path),
+                "src/gfx_impl.c": _font_source_hash(gfx_impl_path),
             },
         }
     return fonts
@@ -163,7 +160,6 @@ def _build_atlas(font: Dict[str, Any]) -> Tuple["Image.Image", Dict[str, Any]]:
                 "bitmap_width": cell_width,
                 "bitmap_height": height,
                 "advance_width": int(font["advance_widths"][idx]),
-                "bitmap_rows_base64": to_base64(bytes(glyph_rows)),
             }
         )
     metadata = {
@@ -182,9 +178,9 @@ def _build_atlas(font: Dict[str, Any]) -> Tuple["Image.Image", Dict[str, Any]]:
         "atlas_mode": "indexed_1bit_black_white",
         "authoring_formats": ["bdf", "png_atlas_json"],
         "notes": (
-            "Glyphs are exported with Unicode codepoints. Original game bytes "
-            "are preserved as source_byte/source_encoding so additional language "
-            "glyphs can be added without losing legacy mapping."
+            "Glyph shapes are stored in the BDF and PNG atlas. JSON is only "
+            "supplemental atlas/index metadata and must not override BDF/PNG "
+            "glyph data."
         ),
         "source_files": font["source_files"],
         "source_sha256": font["source_sha256"],
@@ -232,7 +228,7 @@ def build_bdf(font: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True) -> Dict[str, Any]:
+def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True, include_metadata: bool = False) -> Dict[str, Any]:
     output_root.mkdir(parents=True, exist_ok=True)
     fonts = load_font_assets(repo_root)
     exported = []
@@ -242,22 +238,35 @@ def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True) 
         png_path = output_root / f"{stem}.png"
         json_path = output_root / f"{stem}.json"
         image.save(png_path)
-        json_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if include_metadata:
+            json_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        elif json_path.exists():
+            json_path.unlink()
         bdf_path = None
         if write_bdf:
             bdf_path = output_root / f"{stem}.bdf"
             bdf_path.write_text(build_bdf(font), encoding="ascii")
-        exported.append(
-            {
-                "font_id": font_id,
-                "png": str(png_path),
-                "json": str(json_path),
-                "bdf": str(bdf_path) if bdf_path is not None else None,
-            }
-        )
+        record = {
+            "font_id": font_id,
+            # The index is meant to travel with the exported font folder, so
+            # keep paths relative instead of baking in a developer machine's
+            # checkout/output directory.
+            "png": png_path.name,
+            "bdf": bdf_path.name if bdf_path is not None else None,
+        }
+        if include_metadata:
+            record["json"] = json_path.name
+        exported.append(record)
     return {
         "format": "F15_FONT_EXPORT_INDEX",
         "version": 1,
-        "source": str(repo_root),
+        "source": "repository_font_tables",
+        "authoring_source": "font_<id>.bdf",
+        "runtime_authoritative": "font_<id>.bdf, then font_<id>.png fallback if BDF is missing or rejected",
+        "notes": (
+            "Edit BDF for glyph pixels and advance widths. PNG atlas is a "
+            "bitmap fallback and current runtime reuses existing widths for PNG. "
+            "Per-font JSON is optional metadata and is not used by the runtime loader."
+        ),
         "exported": exported,
     }

--- a/tools/f15assets/f15assets/model3d.py
+++ b/tools/f15assets/f15assets/model3d.py
@@ -954,6 +954,17 @@ def _shape_label(shape_names: object, shape_index: int) -> str:
     return f"shape_{shape_index:03d}"
 
 
+def _color_key(color: object) -> str:
+    if color is None:
+        return "none"
+    return f"0x{int(color) & 0xFF:02x}"
+
+
+def _bump_color_count(bucket: Dict[str, int], color: object, amount: int = 1) -> None:
+    key = _color_key(color)
+    bucket[key] = bucket.get(key, 0) + int(amount)
+
+
 def parse_3d3(data: bytes) -> Dict[str, Any]:
     if len(data) < 6:
         raise ValueError(".3D3 data too short")
@@ -1098,15 +1109,34 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
             "has_shared_vertex_pool": bool(shared_pool),
             "shared_vertex_pool": shared_pool_summary,
             "skipped_shapes": [],
+            "raw_color_usage": {"faces": {}, "lines": {}, "points": {}},
         },
     }
 
     for shape_index, shape_offset in enumerate(shape_offsets):
         if shape_offset >= model_data_size:
+            gltf["extras"]["skipped_shapes"].append(
+                {
+                    "shape_index": shape_index,
+                    "shape_name": _shape_label(shape_names, shape_index),
+                    "shape_offset": shape_offset,
+                    "shape_end": model_data_size,
+                    "render_mode": None,
+                    "shape_payload": {
+                        "render_error": "shape_offset_outside_model_data",
+                        "model_data_size": model_data_size,
+                    },
+                }
+            )
             continue
         shape_end = model_data_size
         color_materials: Dict[int, int] = {}
         fallback_face_material = 1
+        shape_color_usage: Dict[str, Dict[str, int]] = {
+            "faces": {},
+            "lines": {},
+            "points": {},
+        }
         if shape_index + 1 < len(shape_offsets):
             shape_end = min(model_data_size, shape_offsets[shape_index + 1])
             if shape_end < shape_offset:
@@ -1184,6 +1214,8 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                         if tri_index < len(triangle_colors)
                         else None
                     )
+                    _bump_color_count(shape_color_usage["faces"], color)
+                    _bump_color_count(gltf["extras"]["raw_color_usage"]["faces"], color)
                     triangles_by_color.setdefault(color, []).extend(int(v) for v in tri)
 
                 for color, tri_indices in triangles_by_color.items():
@@ -1230,6 +1262,7 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     )
 
             lines_by_color: Dict[Optional[int], set[Tuple[int, int]]] = {}
+            points_by_color: Dict[Optional[int], set[int]] = {}
             for line in lines:
                 if len(line) == 2:
                     a, b = int(line[0]), int(line[1])
@@ -1239,8 +1272,56 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     color = line[2]
                     color = None if color is None else int(color)
                 if a == b:
+                    if 0 <= a < len(vertices):
+                        points_by_color.setdefault(color, set()).add(a)
+                        _bump_color_count(shape_color_usage["points"], color)
+                        _bump_color_count(gltf["extras"]["raw_color_usage"]["points"], color)
                     continue
                 lines_by_color.setdefault(color, set()).add(tuple(sorted((a, b))))
+                _bump_color_count(shape_color_usage["lines"], color)
+                _bump_color_count(gltf["extras"]["raw_color_usage"]["lines"], color)
+
+            for color, point_set in sorted(points_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
+                uniq_points = sorted(point_set)
+                if not uniq_points:
+                    continue
+                point_bin, point_type = _pack_indices(uniq_points)
+                point_view = _emit_buffer_view(gltf, point_bin, 34963)
+                point_acc = _emit_accessor(
+                    gltf,
+                    point_view,
+                    component_type=point_type,
+                    type_name="SCALAR",
+                    count=len(uniq_points),
+                )
+                gltf["accessors"][point_acc]["min"] = [0]
+                gltf["accessors"][point_acc]["max"] = [max(0, len(vertices) - 1)]
+
+                if color is None:
+                    material_index = 0
+                else:
+                    r, g, b, a = _face_material_color(color)
+                    material_index = len(gltf["materials"])
+                    gltf["materials"].append(
+                        {
+                            "name": f"points_color_0x{color:02x}",
+                            "doubleSided": True,
+                            "pbrMetallicRoughness": {
+                                "baseColorFactor": [r, g, b, a],
+                                "metallicFactor": 0.0,
+                                "roughnessFactor": 1.0,
+                            },
+                        }
+                    )
+
+                primitives.append(
+                    {
+                        "attributes": {"POSITION": pos_acc},
+                        "indices": point_acc,
+                        "mode": 0,
+                        "material": material_index,
+                    }
+                )
 
             for color, line_set in sorted(lines_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
                 uniq_lines = sorted(line_set)
@@ -1314,6 +1395,7 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                 "shape_offset": shape_offset,
                 "shape_end": shape_end,
                 "shape_payload": shape_parse["metadata"],
+                "raw_color_usage": shape_color_usage,
             },
         }
         gltf["meshes"].append(mesh)
@@ -1336,6 +1418,11 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
 def export_3d3_to_glb(payload: Dict[str, Any]) -> bytes:
     """Export a ``3D3`` payload as a binary glTF (`.glb`) blob."""
     gltf = export_3d3_to_gltf(payload)
+    return export_3d3_gltf_to_glb(gltf)
+
+
+def export_3d3_gltf_to_glb(gltf: Dict[str, Any]) -> bytes:
+    """Pack a generated 3D3 glTF document as a binary glTF (`.glb`) blob."""
     buffer_uri = gltf["buffers"][0].get("uri", "")
     if not buffer_uri.startswith("data:application/octet-stream;base64,"):
         raise ValueError("expected embedded binary buffer URI in glTF payload")

--- a/tools/f15assets/f15assets/model3d.py
+++ b/tools/f15assets/f15assets/model3d.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import copy
 import re
 import struct
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -162,10 +163,11 @@ def _decode_primitive_command_stream(
     triangle_colors: List[int] = []
     lines: List[Tuple[int, int, Optional[int]]] = []
     face_edge_colors: Dict[int, int] = {}
-    if seen_faces is None:
-        seen_faces = set()
-    if seen_triangles is None:
-        seen_triangles = set()
+    # Do not suppress duplicate faces/triangles here. The game runtime decoder
+    # intentionally over-collects grouped 0xff/RLE primitive runs, and duplicate
+    # coplanar primitives are part of how the original painter/z-fighting behavior
+    # resolves for some shapes. The validation/runtime loader test compares this
+    # coverage directly, so the editable GLB must preserve it.
 
     cursor = 0
     while cursor < len(stream) and (command_budget is None or command_budget > 0):
@@ -203,14 +205,6 @@ def _decode_primitive_command_stream(
                     command_budget -= 1
                 continue
 
-            signature = _canonical_polygon_signature(polygon_vertices)
-            if signature and signature in seen_faces:
-                if command_budget is not None:
-                    command_budget -= 1
-                continue
-            if signature:
-                seen_faces.add(signature)
-
             a = polygon_vertices[0]
             for i in range(1, len(polygon_vertices) - 1):
                 b = polygon_vertices[i]
@@ -218,12 +212,8 @@ def _decode_primitive_command_stream(
                 if a < len(vertices) and b < len(vertices) and c < len(vertices):
                     if a != b and b != c and a != c:
                         tri = (a, b, c)
-                        tri_signature = tuple(sorted(tri))
-                        tri_key = (tri_signature, color)
-                        if tri_key not in seen_triangles:
-                            seen_triangles.add(tri_key)
-                            triangles.append(tri)
-                            triangle_colors.append(color)
+                        triangles.append(tri)
+                        triangle_colors.append(color)
         else:
             # Non-face commands are kept as line primitives. Some source shapes
             # are intentionally 2D/single-sided, so fabricating reverse faces
@@ -607,6 +597,80 @@ def _decode_model_edges_and_primitives(
             "metadata": {"lod_records": lod_records, "transform_records": transform_records},
         }
 
+    special_form = stream[cursor] & 0x3F
+    if special_form == 0x3F:
+        if cursor + 2 > len(stream):
+            raise ValueError("truncated 3D3 point record")
+        color = int(stream[cursor + 1])
+        return {
+            "render_mode": render_mode,
+            "vertices": [(0, 0, 0)],
+            "edges": [],
+            "triangles": [],
+            "triangle_colors": [],
+            "lines": [(0, 0, color)],
+            "metadata": {
+                "form": "point",
+                "point_color": color,
+                "lod_records": lod_records,
+                "transform_records": transform_records,
+            },
+        }
+
+    if special_form == 0x3E:
+        if cursor + 3 > len(stream):
+            raise ValueError("truncated 3D3 edgerun record")
+        count = int(stream[cursor + 2])
+        refs_start = cursor + 3
+        refs_end = refs_start + count
+        if refs_end > len(stream):
+            raise ValueError("truncated 3D3 edgerun refs")
+        vertices: List[Tuple[int, int, int]] = []
+        lines: List[Tuple[int, int, Optional[int]]] = []
+        unresolved_vertex_count = 0
+        refs = list(stream[refs_start:refs_end])
+        for ref in refs:
+            x = y = z = 0
+            if shared_pool:
+                x_indices = shared_pool.get("x_indices", [])
+                y_indices = shared_pool.get("y_indices", [])
+                z_indices = shared_pool.get("z_indices", [])
+                x_values = shared_pool.get("x_values", [])
+                y_values = shared_pool.get("y_values", [])
+                z_values = shared_pool.get("z_values", [])
+                if ref < len(x_indices) and ref < len(y_indices) and ref < len(z_indices):
+                    xi = x_indices[ref]
+                    yi = y_indices[ref]
+                    zi = z_indices[ref]
+                    x = x_values[xi] if xi < len(x_values) else 0
+                    y = y_values[yi] if yi < len(y_values) else 0
+                    z = z_values[zi] if zi < len(z_values) else 0
+                else:
+                    unresolved_vertex_count += 1
+            else:
+                unresolved_vertex_count += 1
+            vertices.append((x, y, z))
+            # The GL replacement bridge represents edgerun dots as point
+            # primitives. The current runtime comparison treats their source
+            # color as 0 because the legacy GL path shades edgeruns by distance
+            # instead of using a fixed face/line palette byte.
+            lines.append((len(vertices) - 1, len(vertices) - 1, 0))
+        return {
+            "render_mode": render_mode,
+            "vertices": vertices,
+            "edges": [],
+            "triangles": [],
+            "triangle_colors": [],
+            "lines": lines,
+            "metadata": {
+                "form": "edgerun",
+                "run_refs": refs,
+                "unresolved_vertex_count": unresolved_vertex_count,
+                "lod_records": lod_records,
+                "transform_records": transform_records,
+            },
+        }
+
     face_info = stream[cursor]
     cursor += 1
     face_count = face_info & 0x1F
@@ -840,14 +904,14 @@ def _decode_model_edges_and_primitives(
             edge_key = tuple(sorted((a, b)))
             if edge_key in colored_line_edges:
                 continue
+            color = face_edge_colors_by_index.get(edge_idx, face_edge_colors.get(edge_key))
+            if color is None:
+                continue
             lines.append(
                 (
                     a,
                     b,
-                    face_edge_colors_by_index.get(
-                        edge_idx,
-                        face_edge_colors.get(edge_key, dominant_face_color),
-                    ),
+                    color,
                 )
             )
 
@@ -1205,7 +1269,13 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
             gltf["accessors"][pos_acc]["max"] = [float(x) for x in maxs]
 
             if triangles:
-                triangles_by_color: Dict[Optional[int], List[int]] = {}
+                # Do not batch triangles by material/color here. The original
+                # renderer's display-list order is part of the asset semantics:
+                # many aircraft/building details are coplanar or intentionally
+                # z-fighting, so reordering faces can visibly change which color
+                # wins. One glTF primitive per decoded triangle is larger than
+                # color batching but preserves source draw order for validation
+                # and for the runtime GLMESH cache.
                 for tri_index, tri in enumerate(triangles):
                     if len(tri) != 3:
                         continue
@@ -1216,9 +1286,8 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     )
                     _bump_color_count(shape_color_usage["faces"], color)
                     _bump_color_count(gltf["extras"]["raw_color_usage"]["faces"], color)
-                    triangles_by_color.setdefault(color, []).extend(int(v) for v in tri)
 
-                for color, tri_indices in triangles_by_color.items():
+                    tri_indices = [int(v) for v in tri]
                     tri_bin, tri_type = _pack_indices(tri_indices)
                     tri_view = _emit_buffer_view(gltf, tri_bin, 34963)
                     tri_acc = _emit_accessor(
@@ -1258,12 +1327,20 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                             "indices": tri_acc,
                             "mode": 4,
                             "material": material_index,
+                            "extras": {
+                                "source_primitive_kind": "triangle",
+                                "source_primitive_index": tri_index,
+                                "source_color": color,
+                                "source_order_sensitive": True,
+                            },
                         }
                     )
 
-            lines_by_color: Dict[Optional[int], set[Tuple[int, int]]] = {}
-            points_by_color: Dict[Optional[int], set[int]] = {}
-            for line in lines:
+            # Lines and degenerate point features carry visible model detail
+            # (antennas, masts, deck markings). Emit one primitive per decoded
+            # source item so different-colored line/point features are not
+            # accidentally reordered by material batching.
+            for line_index, line in enumerate(lines):
                 if len(line) == 2:
                     a, b = int(line[0]), int(line[1])
                     color = None
@@ -1272,62 +1349,56 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     color = line[2]
                     color = None if color is None else int(color)
                 if a == b:
-                    if 0 <= a < len(vertices):
-                        points_by_color.setdefault(color, set()).add(a)
-                        _bump_color_count(shape_color_usage["points"], color)
-                        _bump_color_count(gltf["extras"]["raw_color_usage"]["points"], color)
-                    continue
-                lines_by_color.setdefault(color, set()).add(tuple(sorted((a, b))))
-                _bump_color_count(shape_color_usage["lines"], color)
-                _bump_color_count(gltf["extras"]["raw_color_usage"]["lines"], color)
-
-            for color, point_set in sorted(points_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
-                uniq_points = sorted(point_set)
-                if not uniq_points:
-                    continue
-                point_bin, point_type = _pack_indices(uniq_points)
-                point_view = _emit_buffer_view(gltf, point_bin, 34963)
-                point_acc = _emit_accessor(
-                    gltf,
-                    point_view,
-                    component_type=point_type,
-                    type_name="SCALAR",
-                    count=len(uniq_points),
-                )
-                gltf["accessors"][point_acc]["min"] = [0]
-                gltf["accessors"][point_acc]["max"] = [max(0, len(vertices) - 1)]
-
-                if color is None:
-                    material_index = 0
-                else:
-                    r, g, b, a = _face_material_color(color)
-                    material_index = len(gltf["materials"])
-                    gltf["materials"].append(
+                    if not (0 <= a < len(vertices)):
+                        continue
+                    point_bin, point_type = _pack_indices([a])
+                    point_view = _emit_buffer_view(gltf, point_bin, 34963)
+                    point_acc = _emit_accessor(
+                        gltf,
+                        point_view,
+                        component_type=point_type,
+                        type_name="SCALAR",
+                        count=1,
+                    )
+                    gltf["accessors"][point_acc]["min"] = [0]
+                    gltf["accessors"][point_acc]["max"] = [max(0, len(vertices) - 1)]
+                    if color is None:
+                        material_index = 0
+                    else:
+                        r, g, b, a_rgba = _face_material_color(color)
+                        material_index = len(gltf["materials"])
+                        gltf["materials"].append(
+                            {
+                                "name": f"points_color_0x{color:02x}_{line_index:03d}",
+                                "doubleSided": True,
+                                "pbrMetallicRoughness": {
+                                    "baseColorFactor": [r, g, b, a_rgba],
+                                    "metallicFactor": 0.0,
+                                    "roughnessFactor": 1.0,
+                                },
+                            }
+                        )
+                    _bump_color_count(shape_color_usage["points"], color)
+                    _bump_color_count(gltf["extras"]["raw_color_usage"]["points"], color)
+                    primitives.append(
                         {
-                            "name": f"points_color_0x{color:02x}",
-                            "doubleSided": True,
-                            "pbrMetallicRoughness": {
-                                "baseColorFactor": [r, g, b, a],
-                                "metallicFactor": 0.0,
-                                "roughnessFactor": 1.0,
+                            "attributes": {"POSITION": pos_acc},
+                            "indices": point_acc,
+                            "mode": 0,
+                            "material": material_index,
+                            "extras": {
+                                "source_primitive_kind": "points",
+                                "source_primitive_index": line_index,
+                                "source_color": color,
+                                "source_order_sensitive": True,
                             },
                         }
                     )
-
-                primitives.append(
-                    {
-                        "attributes": {"POSITION": pos_acc},
-                        "indices": point_acc,
-                        "mode": 0,
-                        "material": material_index,
-                    }
-                )
-
-            for color, line_set in sorted(lines_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
-                uniq_lines = sorted(line_set)
-                if not uniq_lines:
                     continue
-                line_indices = [int(v) for edge in uniq_lines for v in edge]
+
+                if not (0 <= a < len(vertices) and 0 <= b < len(vertices)):
+                    continue
+                line_indices = [a, b]
                 line_bin, line_type = _pack_indices(line_indices)
                 line_view = _emit_buffer_view(gltf, line_bin, 34963)
                 line_acc = _emit_accessor(
@@ -1343,26 +1414,34 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                 if color is None:
                     material_index = 0
                 else:
-                    r, g, b, a = _face_material_color(color)
+                    r, g, b_rgb, a_rgba = _face_material_color(color)
                     material_index = len(gltf["materials"])
                     gltf["materials"].append(
                         {
-                            "name": f"lines_color_0x{color:02x}",
+                            "name": f"lines_color_0x{color:02x}_{line_index:03d}",
                             "doubleSided": True,
                             "pbrMetallicRoughness": {
-                                "baseColorFactor": [r, g, b, a],
+                                "baseColorFactor": [r, g, b_rgb, a_rgba],
                                 "metallicFactor": 0.0,
                                 "roughnessFactor": 1.0,
                             },
                         }
                     )
 
+                _bump_color_count(shape_color_usage["lines"], color)
+                _bump_color_count(gltf["extras"]["raw_color_usage"]["lines"], color)
                 primitives.append(
                     {
                         "attributes": {"POSITION": pos_acc},
                         "indices": line_acc,
                         "mode": 1,
                         "material": material_index,
+                        "extras": {
+                            "source_primitive_kind": "lines",
+                            "source_primitive_index": line_index,
+                            "source_color": color,
+                            "source_order_sensitive": True,
+                        },
                     }
                 )
 
@@ -1419,6 +1498,112 @@ def export_3d3_to_glb(payload: Dict[str, Any]) -> bytes:
     """Export a ``3D3`` payload as a binary glTF (`.glb`) blob."""
     gltf = export_3d3_to_gltf(payload)
     return export_3d3_gltf_to_glb(gltf)
+
+
+def _minimized_single_mesh_gltf(gltf: Dict[str, Any], mesh: Dict[str, Any], shape_index: int, shape_name: str) -> Dict[str, Any]:
+    """Build a self-contained glTF containing one mesh and only referenced data."""
+    buffer_uri = gltf["buffers"][0].get("uri", "")
+    if not buffer_uri.startswith("data:application/octet-stream;base64,"):
+        raise ValueError("expected embedded binary buffer URI in glTF payload")
+    src_buffer = from_base64(buffer_uri.split(",", 1)[1])
+
+    accessor_map: Dict[int, int] = {}
+    buffer_view_map: Dict[int, int] = {}
+    material_map: Dict[int, int] = {}
+    out_buffer = bytearray()
+    out: Dict[str, Any] = {
+        "asset": copy.deepcopy(gltf.get("asset", {"version": "2.0"})),
+        "scene": 0,
+        "scenes": [{"name": "default", "nodes": [0]}],
+        "nodes": [{"name": shape_name, "mesh": 0}],
+        "meshes": [],
+        "accessors": [],
+        "bufferViews": [],
+        "buffers": [{"byteLength": 0, "uri": "data:application/octet-stream;base64,"}],
+        "materials": [],
+        "extras": copy.deepcopy(gltf.get("extras", {})),
+    }
+    out["extras"]["source_shape_index"] = shape_index
+    out["extras"]["source_shape_name"] = shape_name
+    out["extras"]["minimized_per_shape_glb"] = True
+
+    def remap_buffer_view(old_view_index: int) -> int:
+        if old_view_index in buffer_view_map:
+            return buffer_view_map[old_view_index]
+        old_view = gltf["bufferViews"][old_view_index]
+        src_offset = int(old_view.get("byteOffset", 0))
+        src_length = int(old_view.get("byteLength", 0))
+        out_buffer.extend(b"\x00" * _align4(len(out_buffer)))
+        dst_offset = len(out_buffer)
+        out_buffer.extend(src_buffer[src_offset : src_offset + src_length])
+        new_view = copy.deepcopy(old_view)
+        new_view["buffer"] = 0
+        new_view["byteOffset"] = dst_offset
+        new_view["byteLength"] = src_length
+        new_index = len(out["bufferViews"])
+        out["bufferViews"].append(new_view)
+        buffer_view_map[old_view_index] = new_index
+        return new_index
+
+    def remap_accessor(old_accessor_index: int) -> int:
+        if old_accessor_index in accessor_map:
+            return accessor_map[old_accessor_index]
+        old_accessor = gltf["accessors"][old_accessor_index]
+        new_accessor = copy.deepcopy(old_accessor)
+        if "bufferView" in new_accessor:
+            new_accessor["bufferView"] = remap_buffer_view(int(new_accessor["bufferView"]))
+        new_index = len(out["accessors"])
+        out["accessors"].append(new_accessor)
+        accessor_map[old_accessor_index] = new_index
+        return new_index
+
+    def remap_material(old_material_index: int) -> int:
+        if old_material_index in material_map:
+            return material_map[old_material_index]
+        new_index = len(out["materials"])
+        out["materials"].append(copy.deepcopy(gltf["materials"][old_material_index]))
+        material_map[old_material_index] = new_index
+        return new_index
+
+    new_mesh = copy.deepcopy(mesh)
+    for prim in new_mesh.get("primitives", []):
+        attrs = prim.get("attributes", {})
+        if isinstance(attrs, dict):
+            for attr_name, accessor_index in list(attrs.items()):
+                attrs[attr_name] = remap_accessor(int(accessor_index))
+        if "indices" in prim:
+            prim["indices"] = remap_accessor(int(prim["indices"]))
+        if "material" in prim:
+            prim["material"] = remap_material(int(prim["material"]))
+
+    out["meshes"] = [new_mesh]
+    out["buffers"][0]["uri"] = "data:application/octet-stream;base64," + to_base64(bytes(out_buffer))
+    out["buffers"][0]["byteLength"] = len(out_buffer)
+    return out
+
+
+def export_3d3_shape_gltfs(payload: Dict[str, Any]) -> List[Tuple[int, str, Dict[str, Any]]]:
+    """Export renderable 3D3 shapes as individual self-contained glTF documents.
+
+    Each returned document keeps only the accessors, bufferViews, materials, and
+    embedded binary buffer ranges referenced by the one exported mesh.
+    """
+    gltf = export_3d3_to_gltf(payload)
+    out: List[Tuple[int, str, Dict[str, Any]]] = []
+    for mesh in gltf.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        extras = mesh.get("extras", {})
+        if not isinstance(extras, dict):
+            extras = {}
+        try:
+            shape_index = int(extras.get("shape_index", len(out)))
+        except (TypeError, ValueError):
+            shape_index = len(out)
+        shape_name = str(extras.get("shape_name") or mesh.get("name") or f"shape_{shape_index:03d}")
+        shape_doc = _minimized_single_mesh_gltf(gltf, mesh, shape_index, shape_name)
+        out.append((shape_index, shape_name, shape_doc))
+    return out
 
 
 def export_3d3_gltf_to_glb(gltf: Dict[str, Any]) -> bytes:

--- a/tools/f15assets/f15assets/pic.py
+++ b/tools/f15assets/f15assets/pic.py
@@ -530,12 +530,35 @@ DEFAULT_EGA16_PALETTE_6BIT = [
     0x3F,
 ]
 
+WALL_PIC_PALETTE1_EGA16_6BIT = [
+    0x00, 0x00, 0x00,
+    0x00, 0x00, 0x2A,
+    0x00, 0x2A, 0x00,
+    0x00, 0x2A, 0x2A,
+    0x2A, 0x00, 0x00,
+    0x00, 0x00, 0x00,
+    0x2A, 0x15, 0x00,
+    0x2A, 0x2A, 0x2A,
+    0x15, 0x15, 0x15,
+    0x15, 0x15, 0x3F,
+    0x15, 0x3F, 0x15,
+    0x15, 0x3F, 0x3F,
+    0x3F, 0x15, 0x15,
+    0x3F, 0x15, 0x3F,
+    0x3F, 0x3F, 0x15,
+    0x3F, 0x3F, 0x3F,
+]
+
 _DEFAULT_VGA256_PALETTE_CACHE: Optional[List[int]] = None
 
 
 def _to_png_color_rgb8(value_6bit: int) -> int:
     value_8bit = int(value_6bit) & 0x3F
     return max(0, min(255, (value_8bit << 2) | (value_8bit >> 4)))
+
+
+def _dac6_palette_to_rgb8(values_6bit: List[int]) -> List[int]:
+    return [_to_png_color_rgb8(value) for value in values_6bit]
 
 
 def _extract_u8_array_from_source(name: str) -> Optional[List[int]]:
@@ -650,6 +673,97 @@ def _fallback_vga_palette(index_bit_depth: int) -> List[int]:
 
 def _default_palette(index_bit_depth: int) -> List[int]:
     return _fallback_vga_palette(index_bit_depth)
+
+
+RUNTIME_DAC_PALETTE1_FILES = {
+    "WALL.PIC",
+    "HISCORE.PIC",
+    "DESK.PIC",
+    "DEATH.PIC",
+    "PROMO.PIC",
+    "MEDAL.PIC",
+}
+
+RUNTIME_DAC_PALETTE4_FILES = {
+    "TITLE16.PIC",
+}
+
+
+def known_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> Optional[Dict[str, Any]]:
+    if not source_name:
+        return None
+    source_file = Path(source_name).name.upper()
+    if source_file in RUNTIME_DAC_PALETTE1_FILES:
+        dac_values = WALL_PIC_PALETTE1_EGA16_6BIT
+        palette_id = 1
+    elif source_file in RUNTIME_DAC_PALETTE4_FILES:
+        dac_values = [
+            0x00, 0x00, 0x00,
+            0x00, 0x00, 0x2A,
+            0x00, 0x00, 0x00,
+            0x00, 0x2A, 0x2A,
+            0x2A, 0x00, 0x00,
+            0x2A, 0x00, 0x2A,
+            0x2A, 0x15, 0x00,
+            0x2A, 0x2A, 0x2A,
+            0x15, 0x15, 0x15,
+            0x15, 0x15, 0x3F,
+            0x00, 0x00, 0x00,
+            0x15, 0x3F, 0x3F,
+            0x3F, 0x15, 0x15,
+            0x3F, 0x15, 0x3F,
+            0x3F, 0x3F, 0x15,
+            0x3F, 0x3F, 0x3F,
+        ]
+        palette_id = 4
+    else:
+        return None
+
+    # PIC streams carry indices only. These files are known to be displayed under
+    # a non-default gfx_setDac() state, so the self-contained PNG must embed that
+    # active DAC state rather than the generic VGA/EGA palette.
+    palette = list(_default_palette(index_bit_depth))
+    palette[:48] = _dac6_palette_to_rgb8(dac_values)
+    return {
+        "palette_rgb8": palette[:768],
+        "palette_dac6": dac_values[:],
+        "profile": {
+            "source": f"known_runtime_gfx_setDac_{palette_id}",
+            "status": "known_external_runtime_palette",
+            "source_file": source_file,
+            "index_mode": "indexed",
+            "index_bit_depth": index_bit_depth,
+            "color_mode": "palette_index",
+            "palette_format": "vga_dac_6bit_rgb_triples_first_16",
+            "notes": f"Runtime sets DAC palette {palette_id} around this screen; PNG embeds that active palette.",
+        },
+    }
+
+
+def expected_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> Dict[str, Any]:
+    known = known_runtime_pic_palette(source_name, index_bit_depth)
+    if known is not None:
+        return known
+
+    # Most static PIC/SPR files are decoded under the default low 16 DAC plus
+    # the generated VGA 256-color table. Returning this for every source makes
+    # validation compare palette bytes for all indexed PNG replacements instead
+    # of silently skipping files whose original PIC stream has no embedded DAC.
+    palette = list(_default_palette(index_bit_depth))
+    return {
+        "palette_rgb8": palette[:768],
+        "palette_dac6": [],
+        "profile": {
+            "source": "default_runtime_vga_dac",
+            "status": "expected_default_runtime_palette",
+            "source_file": Path(source_name).name if source_name else None,
+            "index_mode": "indexed",
+            "index_bit_depth": index_bit_depth,
+            "color_mode": "palette_index",
+            "palette_format": "rgb8_256_entries",
+            "notes": "Default runtime DAC palette used when no source-specific gfx_setDac context is known.",
+        },
+    }
 
 
 def to_png_data(

--- a/tools/f15assets/f15assets/sounds.py
+++ b/tools/f15assets/f15assets/sounds.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+import struct
 import wave
 from pathlib import Path
 from typing import Any, Dict, List
-
-from .io import to_base64
 
 # The sound drivers program the PIT in the 8 kHz range. One recovered path uses
 # a 0x98 low-byte divisor, which is about 7850 Hz on a 1.193182 MHz PIT.
 DEFAULT_SAMPLE_RATE = 7850
 SOUND_DRIVER_NAMES = ("NSOUND.EXE", "ASOUND.EXE", "ISOUND.EXE", "RSOUND.EXE", "TSOUND.EXE")
 DIGITIZED_SAMPLE_BLOB = "F15DGTL.BIN"
+ASOUND_TICK_HZ = 60
 
 # ASOUND.EXE does not store a simple monotonic split list. The game calls
 # audio_playSample(weaponIdx), and ASOUND dispatches only sample offsets 0, 2,
@@ -100,9 +101,9 @@ def decode_digitized_blob(data: bytes, *, sample_rate: int = DEFAULT_SAMPLE_RATE
             "F15DGTL.BIN is exported as a single raw unsigned 8-bit PCM stream. "
             "Enumerated cue WAV files are emitted from ASOUND.EXE playback ranges. "
             "voiceCueThresholds in egdata.c are availability guards, not the full "
-            "sample split table."
+            "sample split table. WAV files are authoritative for sample data and "
+            "audio format; JSON is supplemental cue/index metadata."
         ),
-        "source_bytes_base64": to_base64(data),
     }
 
 
@@ -132,15 +133,15 @@ def infer_digitized_segments(data: bytes) -> List[Dict[str, Any]]:
 
 
 def unresolved_sound_driver_record(path: Path, data: bytes) -> Dict[str, Any]:
-    # Preserve driver executables byte-for-byte in metadata. They contain the
-    # actual hardware playback/synthesis logic, but the exporter only decodes
-    # the external digitized blob today.
+    # Preserve only portable identification metadata for the DOS sound drivers.
+    # The executable bytes are not useful authoring files for customizers; they
+    # remain in the original game directory for future driver research.
     return {
         "format": "F15_SOUND_DRIVER",
         "version": 1,
         "id": path.name,
         "status": "unresolved",
-        "source_file": str(path),
+        "source_file": path.name,
         "source_offset": 0,
         "source_length": len(data),
         "source_bytes_sha256": _sha256(data),
@@ -150,100 +151,342 @@ def unresolved_sound_driver_record(path: Path, data: bytes) -> Dict[str, Any]:
             "Effect mapping, synthesis parameters, and sample split tables are "
             "not decoded by this exporter yet."
         ),
-        "source_bytes_base64": to_base64(data),
     }
 
 
-def export_sounds(asset_root: Path, output_root: Path, *, sample_rate: int = DEFAULT_SAMPLE_RATE) -> Dict[str, Any]:
+def _repo_root_from_tools() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _extract_asound_array(source_text: str, name: str) -> List[int]:
+    match = re.search(
+        rf"const\s+AsoundU8\s+{re.escape(name)}\[\]\s*=\s*\{{(?P<body>.*?)\}};",
+        source_text,
+        re.S,
+    )
+    if not match:
+        raise ValueError(f"missing ASOUND stream array {name}")
+    values: List[int] = []
+    for token in re.findall(r"0x[0-9a-fA-F]+|\b\d+\b", match.group("body")):
+        values.append(int(token, 0) & 0xFF)
+    return values
+
+
+def _decode_asound_stream(stream: List[int], voice: int, *, max_events: int = 10000) -> List[Dict[str, Any]]:
+    pos = 0
+    tick = 0
+    loop_pos = 0
+    loop_count = 0
+    keyoff_gap = 1
+    events: List[Dict[str, Any]] = []
+
+    for _ in range(max_events):
+        if pos >= len(stream):
+            events.append({"tick": tick, "voice": voice, "type": "stream_end", "reason": "eof"})
+            return events
+        op = stream[pos]
+        pos += 1
+        if op < 0xF8:
+            if pos >= len(stream):
+                events.append({"tick": tick, "voice": voice, "type": "decode_error", "reason": "truncated_note"})
+                return events
+            duration = stream[pos]
+            pos += 1
+            if op == 0 and duration == 0:
+                events.append({"tick": tick, "voice": voice, "type": "stream_end", "reason": "zero_note"})
+                return events
+            # The runtime schedules key-off before the full duration. Preserve
+            # both values so JSON is lossless enough for a future native loader;
+            # MIDI uses sounding_ticks for note length.
+            sounding_ticks = max(1, duration - keyoff_gap) if duration > keyoff_gap else 1
+            events.append(
+                {
+                    "tick": tick,
+                    "voice": voice,
+                    "type": "note",
+                    "note": op,
+                    "duration_ticks": duration,
+                    "sounding_ticks": sounding_ticks,
+                    "keyoff_gap_ticks": keyoff_gap,
+                }
+            )
+            tick += duration
+            continue
+        if op == 0xF8:
+            period = stream[pos] if pos < len(stream) else 0
+            step = stream[pos + 1] if pos + 1 < len(stream) else 0
+            pos += 2
+            events.append({"tick": tick, "voice": voice, "type": "volume_fade", "period": period, "step": struct.unpack("b", bytes([step]))[0]})
+        elif op == 0xF9:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "volume", "value": value})
+        elif op == 0xFA:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "pitch_delta", "value": struct.unpack("b", bytes([value]))[0]})
+        elif op == 0xFB:
+            keyoff_gap = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "keyoff_gap", "ticks": keyoff_gap})
+        elif op == 0xFC:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "instrument", "value": value})
+        elif op == 0xFD:
+            events.append({"tick": tick, "voice": voice, "type": "stream_end", "reason": "callback_or_end"})
+            return events
+        elif op == 0xFE:
+            loop_pos = pos
+            events.append({"tick": tick, "voice": voice, "type": "loop_start", "stream_pos": loop_pos})
+        elif op == 0xFF:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            if loop_count == 0:
+                loop_count = value
+                pos = loop_pos
+            else:
+                loop_count -= 1
+                if loop_count != 0:
+                    pos = loop_pos
+                else:
+                    loop_pos = pos
+            events.append({"tick": tick, "voice": voice, "type": "loop", "count": value, "remaining": loop_count})
+    raise ValueError("ASOUND stream decode exceeded safety event limit")
+
+
+def _write_varlen(value: int) -> bytes:
+    value = max(0, int(value))
+    out = [value & 0x7F]
+    value >>= 7
+    while value:
+        out.append(0x80 | (value & 0x7F))
+        value >>= 7
+    return bytes(reversed(out))
+
+
+def _midi_track(events: List[tuple[int, bytes]]) -> bytes:
+    events = sorted(events, key=lambda item: item[0])
+    data = bytearray()
+    last = 0
+    for tick, payload in events:
+        data.extend(_write_varlen(tick - last))
+        data.extend(payload)
+        last = tick
+    data.extend(b"\x00\xFF\x2F\x00")
+    return b"MTrk" + struct.pack(">I", len(data)) + data
+
+
+def _write_intro_midi(path: Path, voices: List[Dict[str, Any]]) -> None:
+    ppq = 480
+    midi_ticks_per_asound_tick = 16  # 60 Hz ASOUND tick at 120 BPM.
+    tracks = []
+    meta = [
+        (0, b"\xFF\x51\x03\x07\xA1\x20"),  # 120 BPM
+        (0, b"\xFF\x58\x04\x04\x02\x18\x08"),
+    ]
+    tracks.append(_midi_track(meta))
+    for voice in voices:
+        channel = int(voice["voice"]) % 16
+        track_events: List[tuple[int, bytes]] = []
+        current_program = 0
+        for event in voice["events"]:
+            tick = int(event["tick"]) * midi_ticks_per_asound_tick
+            if event["type"] == "instrument":
+                current_program = int(event["value"]) % 128
+                track_events.append((tick, bytes([0xC0 | channel, current_program])))
+            elif event["type"] == "note" and int(event["note"]) > 0:
+                note = max(0, min(127, int(event["note"])))
+                velocity = 96
+                end_tick = tick + int(event["sounding_ticks"]) * midi_ticks_per_asound_tick
+                track_events.append((tick, bytes([0x90 | channel, note, velocity])))
+                track_events.append((end_tick, bytes([0x80 | channel, note, 0])))
+        tracks.append(_midi_track(track_events))
+    header = b"MThd" + struct.pack(">IHHH", 6, 1, len(tracks), ppq)
+    path.write_bytes(header + b"".join(tracks))
+
+
+def export_intro_music(output_root: Path, *, repo_root: Path | None = None) -> Dict[str, Any]:
+    repo = repo_root or _repo_root_from_tools()
+    model_path = repo / "src" / "asound" / "asound_model.c"
+    source_text = model_path.read_text(encoding="utf-8")
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    voices: List[Dict[str, Any]] = []
+    for phase in ("intro", "release"):
+        for voice in range(6):
+            name = f"asound_{phase}_voice{voice}"
+            stream = _extract_asound_array(source_text, name)
+            voices.append(
+                {
+                    "phase": phase,
+                    "voice": voice,
+                    "source_symbol": name,
+                    "stream_bytes": stream,
+                    "events": _decode_asound_stream(stream, voice),
+                }
+            )
+
+    json_path = output_root / "intro_music.asound.json"
+    midi_path = output_root / "intro_music.mid"
+    record = {
+        "format": "F15_ASOUND_MUSIC",
+        "version": 1,
+        "source": "recovered_asound_model",
+        "source_file": "src/asound/asound_model.c",
+        "tick_hz": ASOUND_TICK_HZ,
+        "runtime_authoritative": "intro_music.asound.json",
+        "midi_preview": midi_path.name,
+        "notes": "ASOUND JSON preserves driver stream commands. MIDI is a best-effort note preview and does not preserve OPL instrument timbre.",
+        "voices": voices,
+    }
+    json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_intro_midi(midi_path, [voice for voice in voices if voice["phase"] == "intro"])
+    return {
+        "id": "intro_music",
+        "status": "decoded_recovered_asound_streams",
+        "json": json_path.name,
+        "midi": midi_path.name,
+        "runtime_authoritative": json_path.name,
+        "notes": "MIDI is for editing/preview; ASOUND JSON is the lossless replacement candidate.",
+    }
+
+
+def export_sounds(
+    asset_root: Path,
+    output_root: Path,
+    *,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    include_raw_blob: bool = False,
+    include_metadata: bool = False,
+) -> Dict[str, Any]:
     output_root.mkdir(parents=True, exist_ok=True)
     exported: List[Dict[str, Any]] = []
+
+    # Keep repeated default conversions honest: optional metadata/reference
+    # files from older runs must not linger and look like required customizer
+    # assets. The cue WAV files are the default authoring/runtime surface.
+    if not include_metadata:
+        for stale_path in output_root.glob("voice_cue_*.json"):
+            stale_path.unlink()
+        for stale_path in output_root.glob("*_driver.json"):
+            stale_path.unlink()
+        stale_index = output_root / "sounds.json"
+        if stale_index.exists():
+            stale_index.unlink()
+    if not include_raw_blob:
+        for stale_name in ("f15dgtl_raw.wav", "f15dgtl_raw.json"):
+            stale_path = output_root / stale_name
+            if stale_path.exists():
+                stale_path.unlink()
 
     blob_path = asset_root / DIGITIZED_SAMPLE_BLOB
     if blob_path.exists():
         data = blob_path.read_bytes()
-        wav_path = output_root / "f15dgtl_raw.wav"
-        json_path = output_root / "f15dgtl_raw.json"
-        write_unsigned_pcm8_wav(wav_path, data, sample_rate=sample_rate)
-        record = decode_digitized_blob(data, sample_rate=sample_rate)
-        record["source_file"] = str(blob_path)
-        record["wav_file"] = str(wav_path)
-        for segment in record["segments"]:
+        segments = infer_digitized_segments(data)
+
+        if include_raw_blob:
+            wav_path = output_root / "f15dgtl_raw.wav"
+            json_path = output_root / "f15dgtl_raw.json"
+            write_unsigned_pcm8_wav(wav_path, data, sample_rate=sample_rate)
+            record = decode_digitized_blob(data, sample_rate=sample_rate)
+            # Keep JSON portable: source_file names the original game asset, and
+            # wav/json references are relative to this sound export directory.
+            record["source_file"] = DIGITIZED_SAMPLE_BLOB
+            record["wav_file"] = wav_path.name
+            json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            exported.append(
+                {
+                    "id": "F15DGTL.BIN",
+                    "status": record["status"],
+                    "wav": wav_path.name,
+                    "json": json_path.name,
+                    "notes": "Optional full-blob reference export; runtime replacement uses voice_cue_*.wav files.",
+                }
+            )
+
+        cue_exports: List[Dict[str, Any]] = []
+        for segment in segments:
             start = int(segment["source_offset"])
             end = start + int(segment["source_length"])
             segment_wav_path = output_root / f"{segment['id']}.wav"
-            segment_json_path = output_root / f"{segment['id']}.json"
             write_unsigned_pcm8_wav(segment_wav_path, data[start:end], sample_rate=sample_rate)
-            segment_record = {
-                "format": "F15_SOUND_SEGMENT",
-                "version": 1,
+            cue_export = {
                 "id": segment["id"],
-                "status": "decoded_driver_recovered_cue",
-                "source_file": str(blob_path),
-                "parent_blob": "F15DGTL.BIN",
-                "wav_file": str(segment_wav_path),
-                "source_offset": start,
-                "source_length": end - start,
-                "source_bytes_sha256": _sha256(data[start:end]),
-                "codec": "unsigned_pcm_u8",
-                "sample_rate": sample_rate,
-                "sample_rate_status": "driver_recovered",
-                "channels": 1,
-                "bits_per_sample": 8,
-                "sample_count": end - start,
-                "duration_seconds": (end - start) / float(sample_rate) if sample_rate > 0 else 0,
+                "wav": segment_wav_path.name,
                 "boundary_status": segment["boundary_status"],
-                "boundary_source": segment["boundary_source"],
-                "play_sample_arg": segment["play_sample_arg"],
-                "variant": segment["variant"],
-                "driver_case": segment["driver_case"],
-                "source_end_inclusive": segment["source_end_inclusive"],
-                "source_bytes_base64": to_base64(data[start:end]),
             }
-            segment["wav_file"] = str(segment_wav_path)
-            segment["json_file"] = str(segment_json_path)
-            segment_json_path.write_text(
-                json.dumps(segment_record, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-        json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            if include_metadata:
+                segment_json_path = output_root / f"{segment['id']}.json"
+                segment_record = {
+                    "format": "F15_SOUND_SEGMENT",
+                    "version": 1,
+                    "id": segment["id"],
+                    "status": "decoded_driver_recovered_cue",
+                    "source_file": DIGITIZED_SAMPLE_BLOB,
+                    "parent_blob": "F15DGTL.BIN",
+                    "wav_file": segment_wav_path.name,
+                    "source_offset": start,
+                    "source_length": end - start,
+                    "source_bytes_sha256": _sha256(data[start:end]),
+                    "codec": "unsigned_pcm_u8",
+                    "sample_rate": sample_rate,
+                    "sample_rate_status": "driver_recovered",
+                    "channels": 1,
+                    "bits_per_sample": 8,
+                    "sample_count": end - start,
+                    "duration_seconds": (end - start) / float(sample_rate) if sample_rate > 0 else 0,
+                    "boundary_status": segment["boundary_status"],
+                    "boundary_source": segment["boundary_source"],
+                    "play_sample_arg": segment["play_sample_arg"],
+                    "variant": segment["variant"],
+                    "driver_case": segment["driver_case"],
+                    "source_end_inclusive": segment["source_end_inclusive"],
+                }
+                segment_json_path.write_text(
+                    json.dumps(segment_record, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                cue_export["json"] = segment_json_path.name
+            cue_exports.append(cue_export)
+
         exported.append(
             {
-                "id": "F15DGTL.BIN",
-                "status": record["status"],
-                "wav": str(wav_path),
-                "json": str(json_path),
-                "segments": [
-                    {
-                        "id": segment["id"],
-                        "wav": segment["wav_file"],
-                        "json": segment["json_file"],
-                        "boundary_status": segment["boundary_status"],
-                    }
-                    for segment in record["segments"]
-                ],
+                "id": "digitized_voice_cues",
+                "status": "decoded_driver_recovered_cues",
+                "source_file": DIGITIZED_SAMPLE_BLOB,
+                "authoring_source": "voice_cue_*.wav",
+                "runtime_authoritative": "voice_cue_*.wav",
+                "notes": "Edit the individual cue WAVs for customization. No full sound blob is needed by the replacement runtime; use --include-raw-blob only for reverse-engineering reference output.",
+                "segments": cue_exports,
             }
         )
 
-    for name in SOUND_DRIVER_NAMES:
-        driver_path = asset_root / name
-        if not driver_path.exists():
-            continue
-        data = driver_path.read_bytes()
-        json_path = output_root / f"{driver_path.stem.lower()}_driver.json"
-        record = unresolved_sound_driver_record(driver_path, data)
-        json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        exported.append(
-            {
-                "id": name,
-                "status": "unresolved",
-                "json": str(json_path),
-            }
-        )
+    if include_metadata:
+        for name in SOUND_DRIVER_NAMES:
+            driver_path = asset_root / name
+            if not driver_path.exists():
+                continue
+            data = driver_path.read_bytes()
+            json_path = output_root / f"{driver_path.stem.lower()}_driver.json"
+            record = unresolved_sound_driver_record(driver_path, data)
+            json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            exported.append(
+                {
+                    "id": name,
+                    "status": "unresolved",
+                    "json": json_path.name,
+                }
+            )
+
+    exported.append(export_intro_music(output_root))
 
     return {
         "format": "F15_SOUND_EXPORT_INDEX",
         "version": 1,
-        "source": str(asset_root),
+        "source": "game_asset_directory",
         "sample_rate": sample_rate,
+        "metadata_included": include_metadata,
+        "raw_blob_included": include_raw_blob,
         "exported": exported,
     }

--- a/tools/f15assets/f15assets/validation_compare.py
+++ b/tools/f15assets/f15assets/validation_compare.py
@@ -1,0 +1,36 @@
+"""Compatibility facade for replacement-asset validation comparisons.
+
+Format-specific comparison code lives in validation_compare_* modules. Keep this
+module as the stable import point for CLI code and downstream scripts.
+"""
+
+from __future__ import annotations
+
+from .validation_compare_core import (
+    compare_byte_sequence,
+    compare_count_value,
+    compare_mapping_exact,
+    compare_sequence_exact,
+    first_byte_difference,
+)
+from .validation_compare_font import compare_font_atlas_rows, compare_font_glyph96
+from .validation_compare_image import compare_png_palette, compare_png_pixels
+from .validation_compare_model3d import compare_glmesh_primitive_streams
+from .validation_compare_sound import compare_wav_sample_rate, compare_wav_samples
+from .validation_compare_structured import compare_structured_rebuild
+
+__all__ = [
+    "compare_byte_sequence",
+    "compare_count_value",
+    "compare_font_atlas_rows",
+    "compare_font_glyph96",
+    "compare_glmesh_primitive_streams",
+    "compare_mapping_exact",
+    "compare_png_palette",
+    "compare_png_pixels",
+    "compare_sequence_exact",
+    "compare_structured_rebuild",
+    "compare_wav_sample_rate",
+    "compare_wav_samples",
+    "first_byte_difference",
+]

--- a/tools/f15assets/f15assets/validation_compare_core.py
+++ b/tools/f15assets/f15assets/validation_compare_core.py
@@ -1,0 +1,74 @@
+"""Shared diff helpers for replacement-asset validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def first_byte_difference(expected: bytes, actual: bytes) -> int:
+    """Return the first differing offset, or -1 when only the length differs."""
+
+    return next((idx for idx, (a, b) in enumerate(zip(expected, actual)) if a != b), -1)
+
+
+def compare_byte_sequence(
+    label: str,
+    expected: bytes,
+    actual: bytes,
+    expected_name: str,
+    actual_name: str,
+    differ_text: str,
+) -> str | None:
+    """Return a single human-readable byte diff message, or None on equality."""
+
+    if expected == actual:
+        return None
+    first = first_byte_difference(expected, actual)
+    if first >= 0:
+        return (
+            f"{label}: {differ_text} at offset {first} "
+            f"({expected_name}={expected[first]}, {actual_name}={actual[first]})"
+        )
+    return (
+        f"{label}: {differ_text} length differs "
+        f"({expected_name}={len(expected)}, {actual_name}={len(actual)})"
+    )
+
+
+def compare_mapping_exact(
+    path: str,
+    what: str,
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    actual_name: str = "actual",
+    expected_name: str = "expected",
+) -> str | None:
+    """Compare small diagnostic dictionaries such as primitive-count summaries."""
+
+    if actual == expected:
+        return None
+    return f"{path}: {what} differ ({actual_name}={actual}, {expected_name}={expected})"
+
+
+def compare_sequence_exact(path: str, what: str, actual: list[Any], expected: list[Any]) -> str | None:
+    """Compare compact source-proof lists without embedding bulky geometry dumps."""
+
+    if actual == expected:
+        return None
+    return f"{path}: {what} differs"
+
+
+def compare_count_value(
+    path: str,
+    count_name: str,
+    actual: int,
+    expected: int,
+    actual_name: str = "actual",
+    expected_name: str = "expected",
+) -> str | None:
+    if actual == expected:
+        return None
+    return (
+        f"{path}: {count_name} count differs "
+        f"({actual_name}={actual}, {expected_name}={expected})"
+    )

--- a/tools/f15assets/f15assets/validation_compare_font.py
+++ b/tools/f15assets/f15assets/validation_compare_font.py
@@ -1,0 +1,29 @@
+"""Font replacement comparison helpers."""
+
+from __future__ import annotations
+
+
+def compare_font_glyph96(
+    path: str,
+    codepoint: int,
+    expected_rows: list[int],
+    actual_rows: list[int],
+    expected_width: int,
+    actual_width: int,
+) -> str | None:
+    """Compare one exported 96-glyph font cell after it has passed loadability checks."""
+
+    if actual_rows != expected_rows:
+        return f"{path}: bitmap differs for U+{codepoint:04X}"
+    if actual_width != expected_width:
+        return (
+            f"{path}: advance width differs for U+{codepoint:04X} "
+            f"(legacy={expected_width}, bdf={actual_width})"
+        )
+    return None
+
+
+def compare_font_atlas_rows(path: str, expected_rows: list[list[int]], actual_rows: list[list[int]]) -> str | None:
+    if actual_rows != expected_rows:
+        return f"{path}: atlas bitmap differs from original font rows"
+    return None

--- a/tools/f15assets/f15assets/validation_compare_image.py
+++ b/tools/f15assets/f15assets/validation_compare_image.py
@@ -1,0 +1,23 @@
+"""Image replacement comparison helpers."""
+
+from __future__ import annotations
+
+from .validation_compare_core import compare_byte_sequence, first_byte_difference
+
+
+def compare_png_pixels(src: str, legacy_pixels: bytes, modern_pixels: bytes) -> str | None:
+    return compare_byte_sequence(src, legacy_pixels, modern_pixels, "legacy", "png", "PNG pixels differ")
+
+
+def compare_png_palette(src: str, legacy_palette: bytes, modern_palette: bytes) -> str | None:
+    if legacy_palette == modern_palette:
+        return None
+    first = first_byte_difference(legacy_palette, modern_palette)
+    if first >= 0:
+        entry = first // 3
+        channel = "rgb"[first % 3]
+        return (
+            f"{src}: PNG embedded palette differs at entry {entry} channel {channel} "
+            f"(legacy={legacy_palette[first]}, png={modern_palette[first]})"
+        )
+    return f"{src}: PNG embedded palette length differs"

--- a/tools/f15assets/f15assets/validation_compare_model3d.py
+++ b/tools/f15assets/f15assets/validation_compare_model3d.py
@@ -1,0 +1,42 @@
+"""3D model replacement comparison helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compare_glmesh_primitive_streams(
+    expected_stream: list[dict[str, Any]],
+    actual_stream: list[dict[str, Any]],
+    tolerance: float = 1e-5,
+) -> str | None:
+    """Compare reduced runtime-mesh primitive streams.
+
+    Vertex float values are allowed a tiny tolerance because GLB authoring tools
+    can round-trip text/float encodings differently. Integer source identity,
+    primitive modes, color metadata, and ordering must remain exact.
+    """
+
+    if len(expected_stream) != len(actual_stream):
+        return f"primitive count differs (expected={len(expected_stream)}, actual={len(actual_stream)})"
+
+    for prim_index, (exp, act) in enumerate(zip(expected_stream, actual_stream)):
+        for key in ("mode", "source_kind", "source_index", "source_color", "source_flags"):
+            if exp[key] != act[key]:
+                return f"primitive {prim_index} {key} differs (expected={exp[key]}, actual={act[key]})"
+        if len(exp["vertices"]) != len(act["vertices"]):
+            return (
+                f"primitive {prim_index} vertex count differs "
+                f"(expected={len(exp['vertices'])}, actual={len(act['vertices'])})"
+            )
+        for channel, (a, b) in enumerate(zip(exp["rgba"], act["rgba"])):
+            if abs(float(a) - float(b)) > tolerance:
+                return f"primitive {prim_index} rgba[{channel}] differs (expected={a}, actual={b})"
+        for vertex_index, (exp_vertex, act_vertex) in enumerate(zip(exp["vertices"], act["vertices"])):
+            for axis, (a, b) in enumerate(zip(exp_vertex, act_vertex)):
+                if abs(float(a) - float(b)) > tolerance:
+                    return (
+                        f"primitive {prim_index} vertex {vertex_index} axis {axis} differs "
+                        f"(expected={a}, actual={b})"
+                    )
+    return None

--- a/tools/f15assets/f15assets/validation_compare_music.py
+++ b/tools/f15assets/f15assets/validation_compare_music.py
@@ -1,0 +1,58 @@
+"""ASOUND music replacement comparison helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def extract_asound_array(source_text: str, name: str) -> list[int]:
+    match = re.search(
+        rf"const\s+AsoundU8\s+{re.escape(name)}\[\]\s*=\s*\{{(?P<body>.*?)\}};",
+        source_text,
+        re.S,
+    )
+    if not match:
+        raise ValueError(f"missing ASOUND stream array {name}")
+    return [int(token, 0) & 0xFF for token in re.findall(r"0x[0-9a-fA-F]+|\b\d+\b", match.group("body"))]
+
+
+def compare_intro_music_json(json_path: Path, source_text: str) -> list[str]:
+    errors: list[str] = []
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [f"{json_path}: {exc}"]
+
+    voices = payload.get("voices", [])
+    if payload.get("format") != "F15_ASOUND_MUSIC":
+        errors.append(f"{json_path}: wrong music JSON format")
+    if not isinstance(voices, list) or len(voices) != 12:
+        errors.append(f"{json_path}: expected 12 intro/release voices")
+        return errors
+
+    by_symbol = {voice.get("source_symbol"): voice for voice in voices if isinstance(voice, dict)}
+    for phase in ("intro", "release"):
+        for voice_id in range(6):
+            symbol = f"asound_{phase}_voice{voice_id}"
+            voice = by_symbol.get(symbol)
+            if not isinstance(voice, dict):
+                errors.append(f"{json_path}: missing voice {symbol}")
+                continue
+            expected_stream = extract_asound_array(source_text, symbol)
+            actual_stream = [int(value) & 0xFF for value in voice.get("stream_bytes", [])]
+            if actual_stream != expected_stream:
+                errors.append(f"{json_path}: stream bytes differ for {symbol}")
+            if not isinstance(voice.get("events"), list) or not voice["events"]:
+                errors.append(f"{json_path}: missing decoded events for {symbol}")
+    return errors
+
+
+def compare_intro_music_midi(midi_path: Path) -> list[str]:
+    if not midi_path.exists():
+        return [f"missing intro music MIDI preview: {midi_path}"]
+    data = midi_path.read_bytes()
+    if len(data) < 14 or not data.startswith(b"MThd"):
+        return [f"{midi_path}: invalid MIDI header"]
+    return []

--- a/tools/f15assets/f15assets/validation_compare_sound.py
+++ b/tools/f15assets/f15assets/validation_compare_sound.py
@@ -1,0 +1,15 @@
+"""Sound replacement comparison helpers."""
+
+from __future__ import annotations
+
+from .validation_compare_core import compare_byte_sequence
+
+
+def compare_wav_samples(path: str, legacy_samples: bytes, modern_samples: bytes) -> str | None:
+    return compare_byte_sequence(path, legacy_samples, modern_samples, "legacy", "wav", "WAV samples differ")
+
+
+def compare_wav_sample_rate(path: str, expected_rate: int, actual_rate: int) -> str | None:
+    if actual_rate == expected_rate:
+        return None
+    return f"{path}: WAV sample rate differs (expected={expected_rate}, wav={actual_rate})"

--- a/tools/f15assets/f15assets/validation_compare_structured.py
+++ b/tools/f15assets/f15assets/validation_compare_structured.py
@@ -1,0 +1,9 @@
+"""Structured asset rebuild comparison helpers for WLD/3DT/3DG JSON."""
+
+from __future__ import annotations
+
+from .validation_compare_core import compare_byte_sequence
+
+
+def compare_structured_rebuild(path: str, fmt: str, original: bytes, rebuilt: bytes) -> str | None:
+    return compare_byte_sequence(path, original, rebuilt, "original", "json", f"rebuilt {fmt} differs")

--- a/tools/f15assets/f15assets/validation_font.py
+++ b/tools/f15assets/f15assets/validation_font.py
@@ -1,0 +1,262 @@
+"""Bitmap font BDF/PNG replacement validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from .fonts import FONT_CODEPOINT_COUNT, FONT_CODEPOINT_START, load_font_assets
+from .validation_compare import compare_font_atlas_rows, compare_font_glyph96
+
+__all__ = ["validate_font_replacements"]
+
+RUNTIME_FONT_ATLAS_DIMS = {
+    # These are the same runtime slots and atlas cell sizes used by gfx_impl.c.
+    # They let --loadability-only validate PNG-only custom font packs even when
+    # the captured in-repo font tables are not available for equivalence proof.
+    0: (4, 5),
+    1: (8, 8),
+    3: (6, 6),
+    4: (8, 7),
+    5: (6, 6),
+}
+
+
+def _parse_bdf_font(path: Path) -> Dict[int, Dict[str, Any]]:
+    glyphs: Dict[int, Dict[str, Any]] = {}
+    current: Dict[str, Any] | None = None
+    bitmap_rows: list[int] = []
+    in_bitmap = False
+
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if line.startswith("STARTCHAR "):
+            current = {"advance_width": 0, "bitmap_rows": []}
+            bitmap_rows = []
+            in_bitmap = False
+        elif current is not None and line.startswith("ENCODING "):
+            current["encoding"] = int(line.split()[1], 0)
+        elif current is not None and line.startswith("DWIDTH "):
+            parts = line.split()
+            if len(parts) >= 2:
+                current["advance_width"] = int(parts[1], 0)
+        elif current is not None and line.startswith("BITMAP"):
+            bitmap_rows = []
+            in_bitmap = True
+        elif current is not None and line.startswith("ENDCHAR"):
+            encoding = current.get("encoding")
+            if isinstance(encoding, int):
+                current["bitmap_rows"] = bitmap_rows
+                glyphs[encoding] = current
+            current = None
+            bitmap_rows = []
+            in_bitmap = False
+        elif current is not None and in_bitmap and line:
+            bitmap_rows.append(int(line, 16) & 0xFF)
+
+    return glyphs
+
+
+def _read_font_png_rows(path: Path, cell_width: int, height: int) -> list[list[int]]:
+    try:
+        from PIL import Image
+    except Exception as exc:
+        raise RuntimeError("Pillow is required for font PNG validation") from exc
+
+    image = Image.open(path)
+    converted = None
+    try:
+        if image.mode not in {"P", "L", "RGB", "RGBA"}:
+            converted = image.convert("RGBA")
+            image.close()
+            image = converted
+        rows: list[list[int]] = []
+        cell_stride_x = cell_width + 1
+        cell_stride_y = height + 1
+        expected_w = 16 * cell_stride_x - 1
+        expected_h = 6 * cell_stride_y - 1
+        if image.size[0] < expected_w or image.size[1] < expected_h:
+            raise ValueError(f"font atlas too small: {image.size[0]}x{image.size[1]}, expected at least {expected_w}x{expected_h}")
+
+        pix = image.load()
+        for idx in range(FONT_CODEPOINT_COUNT):
+            x0 = (idx % 16) * cell_stride_x
+            y0 = (idx // 16) * cell_stride_y
+            glyph_rows: list[int] = []
+            for y in range(height):
+                bits = 0
+                for x in range(cell_width):
+                    value = pix[x0 + x, y0 + y]
+                    if isinstance(value, int):
+                        lit = value != 0
+                    else:
+                        lit = any(int(channel) != 0 for channel in value[:3])
+                        if len(value) >= 4:
+                            lit = lit and int(value[3]) != 0
+                    if lit:
+                        bits |= 0x80 >> x
+                glyph_rows.append(bits)
+            rows.append(glyph_rows)
+        return rows
+    finally:
+        image.close()
+
+
+def _font_id_from_media_path(path: Path, suffix: str) -> int | None:
+    name = path.name.lower()
+    if not name.startswith("font_") or not name.endswith(suffix):
+        return None
+    try:
+        return int(name[len("font_") : -len(suffix)], 10)
+    except ValueError:
+        return None
+
+
+def validate_font_replacements(
+    repo_root: Path,
+    output_root: Path,
+    require_all: bool,
+    loadability_only: bool = False,
+) -> tuple[int, int]:
+    font_root = output_root / "fonts"
+    checked = 0
+    failed = 0
+    checked_font_paths: set[Path] = set()
+
+    try:
+        original_fonts = load_font_assets(repo_root)
+    except Exception as exc:
+        print(f"font validation unavailable: {exc}", file=sys.stderr)
+        if not loadability_only:
+            return checked, failed + (1 if require_all else 0)
+        original_fonts = {}
+
+    for font_id, font in sorted(original_fonts.items()):
+        original_rows = font.get("glyphs", [])
+        original_widths = font.get("advance_widths", [])
+        bdf_path = font_root / f"font_{font_id}.bdf"
+        png_path = font_root / f"font_{font_id}.png"
+        bdf_errors: list[str] = []
+        has_bdf = bdf_path.exists()
+        has_png = png_path.exists()
+        if not bdf_path.exists():
+            if require_all and not has_png:
+                bdf_errors.append(f"missing replacement BDF: {bdf_path}")
+        else:
+            checked += 1
+            checked_font_paths.add(bdf_path.resolve())
+            try:
+                modern_glyphs = _parse_bdf_font(bdf_path)
+            except Exception as exc:
+                bdf_errors.append(f"{bdf_path}: {exc}")
+            else:
+                for idx in range(FONT_CODEPOINT_COUNT):
+                    codepoint = FONT_CODEPOINT_START + idx
+                    modern = modern_glyphs.get(codepoint)
+                    if modern is None:
+                        bdf_errors.append(f"{bdf_path}: missing glyph U+{codepoint:04X}")
+                        continue
+                    actual_rows = [int(row) & 0xFF for row in modern.get("bitmap_rows", [])]
+                    actual_width = int(modern.get("advance_width", -1))
+                    if not actual_rows:
+                        bdf_errors.append(f"{bdf_path}: glyph U+{codepoint:04X} has no bitmap rows")
+                        continue
+                    if actual_width <= 0:
+                        bdf_errors.append(f"{bdf_path}: glyph U+{codepoint:04X} has invalid advance width {actual_width}")
+                        continue
+                    if loadability_only:
+                        continue
+
+                    glyph_error = compare_font_glyph96(
+                        str(bdf_path),
+                        codepoint,
+                        [int(row) & 0xFF for row in original_rows[idx]],
+                        actual_rows,
+                        int(original_widths[idx]),
+                        actual_width,
+                    )
+                    if glyph_error:
+                        bdf_errors.append(glyph_error)
+
+        png_valid = False
+        if not png_path.exists():
+            if require_all and not has_bdf:
+                print(f"missing replacement font PNG: {png_path}", file=sys.stderr)
+                failed += 1
+        else:
+            checked += 1
+            checked_font_paths.add(png_path.resolve())
+            try:
+                actual_png_rows = _read_font_png_rows(
+                    png_path,
+                    int(font["cell_width"]),
+                    int(font["height"]),
+                )
+                png_valid = True
+            except Exception as exc:
+                print(f"{png_path}: {exc}", file=sys.stderr)
+                failed += 1
+            else:
+                if not loadability_only:
+                    expected_png_rows = [
+                        [int(row) & 0xFF for row in glyph_rows]
+                        for glyph_rows in original_rows
+                    ]
+                    atlas_error = compare_font_atlas_rows(str(png_path), expected_png_rows, actual_png_rows)
+                    if atlas_error:
+                        print(atlas_error, file=sys.stderr)
+                        failed += 1
+
+        if bdf_errors and (not loadability_only or not png_valid):
+            for error in bdf_errors:
+                print(error, file=sys.stderr)
+            failed += len(bdf_errors)
+        elif bdf_errors:
+            for error in bdf_errors:
+                print(f"warning: {error}; PNG atlas fallback is loadable", file=sys.stderr)
+
+    if loadability_only and font_root.exists():
+        for bdf_path in sorted(font_root.glob("font_*.bdf")):
+            if bdf_path.resolve() in checked_font_paths:
+                continue
+            checked += 1
+            try:
+                modern_glyphs = _parse_bdf_font(bdf_path)
+            except Exception as exc:
+                print(f"{bdf_path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+            for idx in range(FONT_CODEPOINT_COUNT):
+                codepoint = FONT_CODEPOINT_START + idx
+                glyph = modern_glyphs.get(codepoint)
+                if glyph is None:
+                    print(f"{bdf_path}: missing glyph U+{codepoint:04X}", file=sys.stderr)
+                    failed += 1
+                    continue
+                actual_rows = [int(row) & 0xFF for row in glyph.get("bitmap_rows", [])]
+                actual_width = int(glyph.get("advance_width", -1))
+                if not actual_rows:
+                    print(f"{bdf_path}: glyph U+{int(codepoint):04X} has no bitmap rows", file=sys.stderr)
+                    failed += 1
+                    continue
+                if actual_width <= 0:
+                    print(f"{bdf_path}: glyph U+{int(codepoint):04X} has invalid advance width {actual_width}", file=sys.stderr)
+                    failed += 1
+                    continue
+        for png_path in sorted(font_root.glob("font_*.png")):
+            if png_path.resolve() in checked_font_paths:
+                continue
+            font_id = _font_id_from_media_path(png_path, ".png")
+            dims = RUNTIME_FONT_ATLAS_DIMS.get(font_id if font_id is not None else -1)
+            if dims is None:
+                print(f"warning: {png_path}: no runtime font atlas dimensions for this font id; skipping source-free PNG loadability check", file=sys.stderr)
+                continue
+            checked += 1
+            try:
+                _read_font_png_rows(png_path, dims[0], dims[1])
+            except Exception as exc:
+                print(f"{png_path}: {exc}", file=sys.stderr)
+                failed += 1
+
+    return checked, failed

--- a/tools/f15assets/f15assets/validation_image.py
+++ b/tools/f15assets/f15assets/validation_image.py
@@ -1,0 +1,96 @@
+"""PIC/SPR PNG replacement validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from .io import from_base64
+from .pic import decode_pic_asset, decode_title640_pic_asset, expected_runtime_pic_palette
+from .validation_compare import compare_png_palette, compare_png_pixels
+
+__all__ = ["validate_png_replacement_loadability", "validate_pic_png_replacement"]
+
+
+def _open_png_for_validation(path: Path):
+    try:
+        from PIL import Image
+    except Exception as exc:
+        raise RuntimeError("Pillow is required for replacement validation") from exc
+
+    return Image.open(path)
+
+
+def _validate_png_loadable_like_runtime(path: Path) -> None:
+    image = _open_png_for_validation(path)
+    try:
+        if image.size[0] <= 0 or image.size[1] <= 0:
+            raise ValueError(f"PNG has invalid dimensions: {path}")
+        if image.mode == "P" and not image.getpalette():
+            raise ValueError(f"expected embedded palette in indexed PNG replacement: {path}")
+    finally:
+        image.close()
+
+
+def validate_png_replacement_loadability(path: Path) -> list[str]:
+    """Validate a PNG with the same broad rules the runtime PIC/SPR loader uses."""
+
+    try:
+        _validate_png_loadable_like_runtime(path)
+    except Exception as exc:
+        return [f"{path}: {exc}"]
+    return []
+
+
+def _read_indexed_png_pixels_and_palette(path: Path, width: int, height: int) -> tuple[bytes, bytes]:
+    image = _open_png_for_validation(path)
+    if image.mode != "P":
+        raise ValueError(f"expected indexed PNG replacement for byte-for-byte comparison: {path}")
+    if image.size != (width, height):
+        raise ValueError(f"expected {width}x{height} PNG replacement: {path} is {image.size[0]}x{image.size[1]}")
+    palette = image.getpalette() or []
+    if not palette:
+        raise ValueError(f"expected embedded palette in indexed PNG replacement: {path}")
+    palette_bytes = bytes((palette[:768] + [0] * max(0, 768 - len(palette[:768])))[:768])
+    return bytes(image.tobytes()), palette_bytes
+
+
+def validate_pic_png_replacement(
+    src: Path,
+    png_path: Path,
+    read_binary: Callable[[Path], bytes],
+    loadability_only: bool = False,
+) -> list[str]:
+    errors: list[str] = []
+    is_title640 = src.name.upper() == "TITLE640.PIC"
+    data = read_binary(src)
+    payload = (
+        decode_title640_pic_asset(data, source_name=src.name)
+        if is_title640
+        else decode_pic_asset(data, source_name=src.name)
+    )
+    width = int(payload.get("decoded_width", 320))
+    height = int(payload.get("decoded_height", 200))
+    if loadability_only:
+        _validate_png_loadable_like_runtime(png_path)
+        return errors
+    legacy_pixels = from_base64(payload["pixels_base64"])[: width * height]
+    modern_pixels, modern_palette = _read_indexed_png_pixels_and_palette(png_path, width, height)
+    pixel_error = compare_png_pixels(str(src), legacy_pixels, modern_pixels)
+    if pixel_error:
+        errors.append(pixel_error)
+    try:
+        index_bit_depth = int(payload.get("palette_profile", {}).get("index_bit_depth", 8))
+    except (TypeError, ValueError):
+        index_bit_depth = 8
+    legacy_palette_b64 = payload.get("palette_rgb8_base64")
+    if isinstance(legacy_palette_b64, str):
+        legacy_palette = from_base64(legacy_palette_b64)[:768]
+    else:
+        expected_palette = expected_runtime_pic_palette(src.name, index_bit_depth)
+        legacy_palette = bytes(expected_palette["palette_rgb8"][:768])
+    legacy_palette = legacy_palette + (b"\x00" * max(0, 768 - len(legacy_palette)))
+    palette_error = compare_png_palette(str(src), legacy_palette[:768], modern_palette)
+    if palette_error:
+        errors.append(palette_error)
+    return errors

--- a/tools/f15assets/f15assets/validation_model3d.py
+++ b/tools/f15assets/f15assets/validation_model3d.py
@@ -1,0 +1,917 @@
+"""3D3 JSON, GLB, and GLMESH replacement validation/build helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+from .model3d import build_3d3, export_3d3_gltf_to_glb, export_3d3_shape_gltfs, parse_3d3
+from .validation_compare import (
+    compare_byte_sequence,
+    compare_count_value,
+    compare_glmesh_primitive_streams,
+    compare_mapping_exact,
+    compare_sequence_exact,
+)
+
+__all__ = ["glb_to_glmesh_bytes", "validate_3d3_glb_replacements"]
+
+
+def _safe_output_stem(value: object) -> str:
+    text = str(value or "").strip()
+    safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in text)
+    safe = "_".join(part for part in safe.split("_") if part)
+    return safe[:96] or "model"
+
+
+def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
+    for path in (primary, *fallbacks):
+        if path.exists():
+            return path
+    return primary
+
+
+def _read_glb_json(path: Path) -> Dict[str, Any]:
+    data = path.read_bytes()
+    if len(data) < 20:
+        raise ValueError("GLB too short")
+    magic, version, total_length = struct.unpack_from("<III", data, 0)
+    if magic != 0x46546C67:
+        raise ValueError("bad GLB magic")
+    if version != 2:
+        raise ValueError(f"unsupported GLB version {version}")
+    if total_length != len(data):
+        raise ValueError(f"GLB length header mismatch: header={total_length}, actual={len(data)}")
+    json_length, chunk_type = struct.unpack_from("<II", data, 12)
+    if chunk_type != 0x4E4F534A:
+        raise ValueError("first GLB chunk is not JSON")
+    if 20 + json_length > len(data):
+        raise ValueError("truncated GLB JSON chunk")
+    return json.loads(data[20 : 20 + json_length].decode("utf-8"))
+
+
+def _read_glb_doc_and_bin(path: Path) -> tuple[Dict[str, Any], bytes]:
+    data = path.read_bytes()
+    if len(data) < 20:
+        raise ValueError("GLB too short")
+    magic, version, total_length = struct.unpack_from("<III", data, 0)
+    if magic != 0x46546C67 or version != 2 or total_length != len(data):
+        raise ValueError("invalid GLB header")
+    json_length, json_type = struct.unpack_from("<II", data, 12)
+    if json_type != 0x4E4F534A:
+        raise ValueError("first GLB chunk is not JSON")
+    json_end = 20 + json_length
+    if json_end + 8 > len(data):
+        raise ValueError("missing GLB BIN chunk")
+    bin_length, bin_type = struct.unpack_from("<II", data, json_end)
+    if bin_type != 0x004E4942:
+        raise ValueError("second GLB chunk is not BIN")
+    bin_start = json_end + 8
+    if bin_start + bin_length > len(data):
+        raise ValueError("truncated GLB BIN chunk")
+    return json.loads(data[20:json_end].decode("utf-8")), data[bin_start : bin_start + bin_length]
+
+
+def _gltf_accessor_values(doc: Dict[str, Any], blob: bytes, accessor_index: int) -> list[Any]:
+    accessor = doc["accessors"][accessor_index]
+    view = doc["bufferViews"][int(accessor["bufferView"])]
+    offset = int(view.get("byteOffset", 0)) + int(accessor.get("byteOffset", 0))
+    count = int(accessor["count"])
+    component = int(accessor["componentType"])
+    type_name = str(accessor["type"])
+    dims = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}[type_name]
+    fmt_map = {
+        5121: ("B", 1),
+        5123: ("H", 2),
+        5125: ("I", 4),
+        5126: ("f", 4),
+    }
+    if component not in fmt_map:
+        raise ValueError(f"unsupported GLB component type {component}")
+    fmt, size = fmt_map[component]
+    stride = int(view.get("byteStride", dims * size))
+    values: list[Any] = []
+    for i in range(count):
+        base = offset + i * stride
+        item = struct.unpack_from("<" + fmt * dims, blob, base)
+        values.append(item[0] if dims == 1 else item)
+    return values
+
+
+def _material_rgba(doc: Dict[str, Any], material_index: int | None) -> tuple[float, float, float, float]:
+    if material_index is None:
+        return (1.0, 1.0, 1.0, 1.0)
+    materials = doc.get("materials", [])
+    if not isinstance(materials, list) or material_index < 0 or material_index >= len(materials):
+        return (1.0, 1.0, 1.0, 1.0)
+    pbr = materials[material_index].get("pbrMetallicRoughness", {})
+    color = pbr.get("baseColorFactor", [1.0, 1.0, 1.0, 1.0])
+    if not isinstance(color, list) or len(color) < 4:
+        return (1.0, 1.0, 1.0, 1.0)
+    return tuple(float(max(0.0, min(1.0, float(v)))) for v in color[:4])
+
+
+def _source_primitive_meta(prim: Dict[str, Any]) -> tuple[int, int, int, int]:
+    extras = prim.get("extras", {})
+    if not isinstance(extras, dict):
+        # Custom GLBs exported from Blender may not preserve converter extras.
+        # Drawing still uses geometry/materials; these defaults only mean the
+        # runtime cache cannot prove original .3D3 primitive identity.
+        return (0, -1, -1, 0)
+    kind = extras.get("source_primitive_kind")
+    if kind == "triangle":
+        kind_id = 1
+    elif kind == "lines":
+        kind_id = 2
+    elif kind == "points":
+        kind_id = 3
+    else:
+        kind_id = 0
+    try:
+        source_index = int(extras.get("source_primitive_index", -1))
+    except (TypeError, ValueError):
+        source_index = -1
+    try:
+        source_color = int(extras.get("source_color", -1))
+    except (TypeError, ValueError):
+        source_color = -1
+    flags = 1 if extras.get("source_order_sensitive") is True else 0
+    return (kind_id, source_index, source_color, flags)
+
+
+def glb_to_glmesh_bytes(path: Path) -> bytes:
+    source = path.read_bytes()
+    source_md5 = hashlib.md5(source).hexdigest().encode("ascii")
+    doc, blob = _read_glb_doc_and_bin(path)
+    primitives: list[tuple[int, int, int, int, int, tuple[float, float, float, float], list[tuple[float, float, float]]]] = []
+    for mesh in doc.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        for prim in mesh.get("primitives", []):
+            if not isinstance(prim, dict):
+                continue
+            mode = int(prim.get("mode", 4))
+            if mode not in {0, 1, 4}:
+                continue
+            attrs = prim.get("attributes", {})
+            if not isinstance(attrs, dict) or "POSITION" not in attrs:
+                continue
+            positions = _gltf_accessor_values(doc, blob, int(attrs["POSITION"]))
+            indices = (
+                _gltf_accessor_values(doc, blob, int(prim["indices"]))
+                if "indices" in prim
+                else list(range(len(positions)))
+            )
+            verts = []
+            for index in indices:
+                pos = positions[int(index)]
+                verts.append((float(pos[0]), float(pos[1]), float(pos[2])))
+            kind_id, source_index, source_color, source_flags = _source_primitive_meta(prim)
+            primitives.append((mode, kind_id, source_index, source_color, source_flags, _material_rgba(doc, prim.get("material")), verts))
+
+    out = bytearray()
+    # F15GLM3 layout:
+    #   0x00  8 bytes   magic "F15GLM3\0"
+    #   0x08 32 bytes   lowercase ASCII MD5 of the source GLB
+    #   0x28  4 bytes   primitive count (uint32 LE)
+    #   0x2c...         primitive records:
+    #       mode:uint32, vertex_count:uint32,
+    #       source_kind:int32, source_index:int32, source_color:int32,
+    #       source_flags:uint32, rgba:4*float32, vertices:N*vec3(float32)
+    #
+    # The source_* fields duplicate GLB extras on purpose. GLMESH is a reduced
+    # runtime cache, and these fields let validation prove that reduction did not
+    # merge/reorder color- or z-fighting-sensitive .3D3 primitives.
+    out.extend(b"F15GLM3\0")
+    out.extend(source_md5)
+    out.extend(struct.pack("<I", len(primitives)))
+    for mode, kind_id, source_index, source_color, source_flags, rgba, verts in primitives:
+        out.extend(struct.pack("<IIiiiIffff", mode, len(verts), kind_id, source_index, source_color, source_flags, *rgba))
+        for v in verts:
+            out.extend(struct.pack("<fff", *v))
+    return bytes(out)
+
+
+def _glmesh_primitive_counts(data: bytes) -> Dict[str, int]:
+    if data.startswith(b"F15GLM3\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 40
+    elif data.startswith(b"F15GLM2\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 24
+    elif data.startswith(b"F15GLM1\0"):
+        pos = 12
+        prim_count = struct.unpack_from("<I", data, 8)[0]
+        prim_header_size = 24
+    else:
+        raise ValueError("bad GLMESH magic")
+
+    counts = {"triangles": 0, "lines": 0, "points": 0, "primitives": int(prim_count)}
+    for _ in range(int(prim_count)):
+        if pos + prim_header_size > len(data):
+            raise ValueError("truncated GLMESH primitive header")
+        mode, nverts = struct.unpack_from("<II", data, pos)
+        pos += prim_header_size
+        payload_size = int(nverts) * 12
+        if pos + payload_size > len(data):
+            raise ValueError("truncated GLMESH vertex payload")
+        if mode not in {0, 1, 4}:
+            raise ValueError(f"unsupported GLMESH primitive mode {mode}")
+        if mode == 4 and int(nverts) % 3:
+            raise ValueError("triangle GLMESH primitive has a non-multiple-of-3 vertex count")
+        if mode == 1 and int(nverts) % 2:
+            raise ValueError("line GLMESH primitive has a non-multiple-of-2 vertex count")
+        if mode == 4:
+            counts["triangles"] += int(nverts) // 3
+        elif mode == 1:
+            counts["lines"] += int(nverts) // 2
+        elif mode == 0:
+            counts["points"] += int(nverts)
+        pos += payload_size
+    if pos != len(data):
+        raise ValueError("GLMESH has trailing bytes")
+    return counts
+
+
+def _glmesh_source_meta(data: bytes) -> list[tuple[int, int, int, int]]:
+    if not data.startswith(b"F15GLM3\0"):
+        return []
+    pos = 44
+    prim_count = struct.unpack_from("<I", data, 40)[0]
+    meta: list[tuple[int, int, int, int]] = []
+    for _ in range(int(prim_count)):
+        if pos + 40 > len(data):
+            raise ValueError("truncated GLMESH primitive header")
+        _mode, nverts, kind_id, source_index, source_color, source_flags = struct.unpack_from("<IIiiiI", data, pos)
+        meta.append((int(kind_id), int(source_index), int(source_color), int(source_flags)))
+        pos += 40
+        payload_size = int(nverts) * 12
+        if pos + payload_size > len(data):
+            raise ValueError("truncated GLMESH vertex payload")
+        pos += payload_size
+    return meta
+
+
+def _glmesh_stream(data: bytes) -> list[Dict[str, Any]]:
+    if data.startswith(b"F15GLM3\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 40
+    elif data.startswith(b"F15GLM2\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 24
+    elif data.startswith(b"F15GLM1\0"):
+        pos = 12
+        prim_count = struct.unpack_from("<I", data, 8)[0]
+        prim_header_size = 24
+    else:
+        raise ValueError("bad GLMESH magic")
+
+    stream: list[Dict[str, Any]] = []
+    for _ in range(int(prim_count)):
+        if pos + prim_header_size > len(data):
+            raise ValueError("truncated GLMESH primitive header")
+        mode, nverts = struct.unpack_from("<II", data, pos)
+        if prim_header_size == 40:
+            kind_id, source_index, source_color, source_flags = struct.unpack_from("<iiiI", data, pos + 8)
+            rgba = struct.unpack_from("<ffff", data, pos + 24)
+        else:
+            kind_id, source_index, source_color, source_flags = 0, -1, -1, 0
+            rgba = struct.unpack_from("<ffff", data, pos + 8)
+        pos += prim_header_size
+        payload_size = int(nverts) * 12
+        if pos + payload_size > len(data):
+            raise ValueError("truncated GLMESH vertex payload")
+        vertices = [
+            struct.unpack_from("<fff", data, pos + vertex_offset)
+            for vertex_offset in range(0, payload_size, 12)
+        ]
+        if mode not in {0, 1, 4}:
+            raise ValueError(f"unsupported GLMESH primitive mode {mode}")
+        if mode == 4 and int(nverts) % 3:
+            raise ValueError("triangle GLMESH primitive has a non-multiple-of-3 vertex count")
+        if mode == 1 and int(nverts) % 2:
+            raise ValueError("line GLMESH primitive has a non-multiple-of-2 vertex count")
+        pos += payload_size
+        # Keep the parsed stream explicit. The validator compares this reduced
+        # runtime cache against a cache rebuilt from the edited GLB, so stale or
+        # hand-edited caches cannot silently drop geometry/color/order metadata.
+        stream.append(
+            {
+                "mode": int(mode),
+                "vertices": vertices,
+                "source_kind": int(kind_id),
+                "source_index": int(source_index),
+                "source_color": int(source_color),
+                "source_flags": int(source_flags),
+                "rgba": tuple(float(value) for value in rgba),
+            }
+        )
+    if pos != len(data):
+        raise ValueError("GLMESH has trailing bytes")
+    return stream
+
+
+def _compare_glmesh_streams(expected: bytes, actual: bytes, tolerance: float = 1e-5) -> str | None:
+    return compare_glmesh_primitive_streams(_glmesh_stream(expected), _glmesh_stream(actual), tolerance)
+
+
+def _glb_primitive_counts(doc: Dict[str, Any]) -> Dict[str, int]:
+    counts = {"triangles": 0, "lines": 0, "points": 0, "primitives": 0}
+    accessors = doc.get("accessors", [])
+    if not isinstance(accessors, list):
+        return counts
+    for mesh in doc.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        for prim in mesh.get("primitives", []):
+            if not isinstance(prim, dict):
+                continue
+            mode = int(prim.get("mode", 4))
+            count = 0
+            try:
+                if "indices" in prim:
+                    accessor_index = int(prim["indices"])
+                else:
+                    attrs = prim.get("attributes", {})
+                    if not isinstance(attrs, dict) or "POSITION" not in attrs:
+                        continue
+                    accessor_index = int(attrs["POSITION"])
+                if 0 <= accessor_index < len(accessors) and isinstance(accessors[accessor_index], dict):
+                    count = int(accessors[accessor_index].get("count", 0))
+            except (TypeError, ValueError):
+                continue
+            counts["primitives"] += 1
+            if mode == 4:
+                counts["triangles"] += count // 3
+            elif mode == 1:
+                counts["lines"] += count // 2
+            elif mode == 0:
+                counts["points"] += count
+    return counts
+
+
+def _glb_source_meta(doc: Dict[str, Any]) -> list[tuple[int, int, int, int]]:
+    meta: list[tuple[int, int, int, int]] = []
+    for mesh in doc.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        for prim in mesh.get("primitives", []):
+            if isinstance(prim, dict):
+                meta.append(_source_primitive_meta(prim))
+    return meta
+
+
+def _glb_raw_color_usage(doc: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
+    extras = doc.get("extras", {})
+    if not isinstance(extras, dict):
+        return {"faces": {}, "lines": {}, "points": {}}
+    usage = extras.get("raw_color_usage", {})
+    if not isinstance(usage, dict):
+        return {"faces": {}, "lines": {}, "points": {}}
+    normalized: Dict[str, Dict[str, int]] = {}
+    for key in ("faces", "lines", "points"):
+        bucket = usage.get(key, {})
+        if not isinstance(bucket, dict):
+            normalized[key] = {}
+            continue
+        normalized[key] = {str(color): int(count) for color, count in sorted(bucket.items())}
+    return normalized
+
+
+def _validate_glb_order_sensitive_primitives(path: Path, doc: Dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    meshes = doc.get("meshes", [])
+    if not isinstance(meshes, list):
+        return [f"{path}: meshes is not a list"]
+    # The converter deliberately emits order-sensitive primitives instead of
+    # compact material batches. Per-kind monotonic source indices are the cheap
+    # invariant that catches accidental optimizer/editor rewrites which would be
+    # harmless for most modern meshes but can break this game's coplanar planes,
+    # z-fighting decals, line antennas, and color-overlap behavior.
+    previous_by_kind = {"triangle": -1, "lines": -1, "points": -1}
+    for mesh in meshes:
+        if not isinstance(mesh, dict):
+            continue
+        for primitive_index, prim in enumerate(mesh.get("primitives", [])):
+            if not isinstance(prim, dict):
+                continue
+            extras = prim.get("extras", {})
+            if not isinstance(extras, dict):
+                errors.append(f"{path}: primitive {primitive_index} missing source extras")
+                continue
+            if extras.get("source_order_sensitive") is not True:
+                errors.append(f"{path}: primitive {primitive_index} is not marked order-sensitive")
+            kind = extras.get("source_primitive_kind")
+            if kind not in {"triangle", "lines", "points"}:
+                errors.append(f"{path}: primitive {primitive_index} has invalid source kind {kind!r}")
+            if kind in previous_by_kind:
+                try:
+                    source_index = int(extras.get("source_primitive_index", -1))
+                except (TypeError, ValueError):
+                    source_index = -1
+                if source_index < 0:
+                    errors.append(f"{path}: {kind} primitive {primitive_index} missing source index")
+                elif source_index <= previous_by_kind[kind]:
+                    errors.append(
+                        f"{path}: {kind} primitive {primitive_index} source index is not monotonic "
+                        f"({source_index} after {previous_by_kind[kind]})"
+                    )
+                previous_by_kind[kind] = source_index
+    return errors
+
+
+def _validate_3d3_json_index(
+    json_path: Path,
+    original_payload: Dict[str, Any],
+    original_bytes: bytes,
+    require_all: bool,
+    loadability_only: bool,
+) -> tuple[int, int]:
+    """Validate .3D3 JSON slot metadata and optional full-byte rebuild data."""
+
+    if not json_path.exists():
+        if require_all:
+            print(f"missing .3D3 JSON index: {json_path}", file=sys.stderr)
+            return 0, 1
+        return 0, 0
+
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"{json_path}: {exc}", file=sys.stderr)
+        return 1, 1
+
+    checked = 1
+    failed = 0
+    if payload.get("format") != "3D3":
+        print(f"{json_path}: expected format=3D3", file=sys.stderr)
+        failed += 1
+
+    actual_offsets = payload.get("shape_offsets")
+    expected_offsets = original_payload.get("shape_offsets", [])
+    if not isinstance(actual_offsets, list) or not all(isinstance(v, int) for v in actual_offsets):
+        print(f"{json_path}: shape_offsets must be a list of integers", file=sys.stderr)
+        failed += 1
+    elif not loadability_only:
+        message = compare_sequence_exact(
+            str(json_path),
+            ".3D3 shape offset table",
+            [int(v) for v in actual_offsets],
+            [int(v) for v in expected_offsets],
+        )
+        if message:
+            print(message, file=sys.stderr)
+            failed += 1
+
+    actual_model_size = payload.get("model_data_size")
+    expected_model_size = int(original_payload.get("model_data_size", 0))
+    if not isinstance(actual_model_size, int) or actual_model_size < 0:
+        print(f"{json_path}: model_data_size must be a non-negative integer", file=sys.stderr)
+        failed += 1
+    elif not loadability_only:
+        message = compare_count_value(
+            str(json_path),
+            ".3D3 model_data_size",
+            int(actual_model_size),
+            expected_model_size,
+            "json",
+            "original",
+        )
+        if message:
+            print(message, file=sys.stderr)
+            failed += 1
+
+    if isinstance(actual_offsets, list) and isinstance(actual_model_size, int):
+        previous = -1
+        for idx, value in enumerate(actual_offsets):
+            if not isinstance(value, int):
+                continue
+            if value < previous:
+                print(f"{json_path}: shape_offsets[{idx}] is not monotonic", file=sys.stderr)
+                failed += 1
+                break
+            if value > actual_model_size:
+                print(f"{json_path}: shape_offsets[{idx}] exceeds model_data_size", file=sys.stderr)
+                failed += 1
+                break
+            previous = value
+
+    if "model_data" in payload:
+        try:
+            rebuilt = build_3d3(payload)
+        except Exception as exc:
+            print(f"{json_path}: failed to rebuild full .3D3 JSON: {exc}", file=sys.stderr)
+            failed += 1
+        else:
+            if not rebuilt:
+                print(f"{json_path}: rebuilt .3D3 JSON is empty", file=sys.stderr)
+                failed += 1
+            elif not loadability_only:
+                message = compare_byte_sequence(
+                    str(json_path),
+                    original_bytes,
+                    rebuilt,
+                    "original",
+                    "json",
+                    "rebuilt .3D3 differs",
+                )
+                if message:
+                    print(message, file=sys.stderr)
+                    failed += 1
+    return checked, failed
+
+
+def _validate_3d3_json_loadability(json_path: Path) -> tuple[int, int]:
+    """Validate a source-free/minimized .3D3 JSON index without original bytes."""
+
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"{json_path}: {exc}", file=sys.stderr)
+        return 1, 1
+
+    failed = 0
+    if payload.get("format") != "3D3":
+        print(f"{json_path}: expected format=3D3", file=sys.stderr)
+        failed += 1
+
+    actual_offsets = payload.get("shape_offsets")
+    actual_model_size = payload.get("model_data_size")
+    if not isinstance(actual_offsets, list) or not all(isinstance(v, int) for v in actual_offsets):
+        print(f"{json_path}: shape_offsets must be a list of integers", file=sys.stderr)
+        failed += 1
+    if not isinstance(actual_model_size, int) or actual_model_size < 0:
+        print(f"{json_path}: model_data_size must be a non-negative integer", file=sys.stderr)
+        failed += 1
+
+    if isinstance(actual_offsets, list) and isinstance(actual_model_size, int):
+        previous = -1
+        for idx, value in enumerate(actual_offsets):
+            if not isinstance(value, int):
+                continue
+            if value < previous:
+                print(f"{json_path}: shape_offsets[{idx}] is not monotonic", file=sys.stderr)
+                failed += 1
+                break
+            if value > actual_model_size:
+                print(f"{json_path}: shape_offsets[{idx}] exceeds model_data_size", file=sys.stderr)
+                failed += 1
+                break
+            previous = value
+
+    if "model_data" in payload:
+        try:
+            rebuilt = build_3d3(payload)
+        except Exception as exc:
+            print(f"{json_path}: failed to rebuild full .3D3 JSON: {exc}", file=sys.stderr)
+            failed += 1
+        else:
+            if not rebuilt:
+                print(f"{json_path}: rebuilt .3D3 JSON is empty", file=sys.stderr)
+                failed += 1
+
+    return 1, failed
+
+
+def _validate_glb_loadability(path: Path) -> tuple[int, int]:
+    try:
+        doc = _read_glb_json(path)
+        counts = _glb_primitive_counts(doc)
+    except Exception as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1, 1
+    if (
+        counts.get("triangles", 0) <= 0
+        and counts.get("lines", 0) <= 0
+        and counts.get("points", 0) <= 0
+    ):
+        print(f"{path}: GLB contains no triangles, lines, or points", file=sys.stderr)
+        return 1, 1
+    return 1, 0
+
+
+def _validate_glmesh_loadability(path: Path) -> tuple[int, int]:
+    try:
+        counts = _glmesh_primitive_counts(path.read_bytes())
+    except Exception as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1, 1
+    if (
+        counts.get("triangles", 0) <= 0
+        and counts.get("lines", 0) <= 0
+        and counts.get("points", 0) <= 0
+    ):
+        print(f"{path}: GLMESH contains no triangles, lines, or points", file=sys.stderr)
+        return 1, 1
+    return 1, 0
+
+
+def validate_3d3_glb_replacements(
+    input_root: Path,
+    output_root: Path,
+    recursive: bool,
+    require_all: bool,
+    iter_asset_paths: Callable[[Path, bool], list[Path]],
+    detect_format: Callable[[Path], str],
+    asset_output_dir: Callable[[Path, Path, Path, Path, str], Path],
+    load_shape_names_for_3d3: Callable[[Path], Dict[str, str]],
+    require_generated_cache: bool,
+    require_source_proof: bool,
+    allow_custom_glb_differences: bool,
+    loadability_only: bool,
+) -> tuple[int, int]:
+    checked = 0
+    failed = 0
+    checked_json_paths: set[Path] = set()
+    checked_glb_paths: set[Path] = set()
+    checked_glmesh_paths: set[Path] = set()
+
+    if input_root.exists():
+        for src in iter_asset_paths(input_root, recursive=recursive):
+            fmt = detect_format(src)
+            if fmt != "3D3":
+                continue
+
+            relative = src.relative_to(input_root)
+            output_base = asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
+            legacy_base = output_root / relative
+            combined_glb = _first_existing_path(
+                output_base.with_name(output_base.name + ".glb"),
+                legacy_base.with_name(legacy_base.name + ".glb"),
+            )
+            shape_output_dir = combined_glb.parent if combined_glb.exists() else output_base.parent
+            data = src.read_bytes()
+            payload = parse_3d3(data)
+            payload["shape_names"] = load_shape_names_for_3d3(src)
+            json_path = _first_existing_path(
+                output_base.with_name(output_base.name + ".json"),
+                legacy_base.with_name(legacy_base.name + ".json"),
+            )
+            json_checked, json_failed = _validate_3d3_json_index(
+                json_path,
+                payload,
+                data,
+                require_all,
+                loadability_only,
+            )
+            if json_path.exists():
+                checked_json_paths.add(json_path.resolve())
+            checked += json_checked
+            failed += json_failed
+            expected_shapes = export_3d3_shape_gltfs(payload)
+            stale_root_glmesh = sorted(shape_output_dir.glob("shape_*.glmesh"))
+            if stale_root_glmesh:
+                for stale_path in stale_root_glmesh:
+                    print(
+                        f"{stale_path}: stale runtime mesh cache outside cache/ directory",
+                        file=sys.stderr,
+                    )
+                failed += len(stale_root_glmesh)
+
+            if not combined_glb.exists():
+                if require_source_proof and not loadability_only:
+                    print(f"missing replacement GLB: {combined_glb}", file=sys.stderr)
+                    failed += 1
+            else:
+                checked += 1
+                checked_glb_paths.add(combined_glb.resolve())
+                try:
+                    glb = _read_glb_json(combined_glb)
+                except Exception as exc:
+                    print(f"{combined_glb}: {exc}", file=sys.stderr)
+                    failed += 1
+                else:
+                    extras = glb.get("extras", {})
+                    if not isinstance(extras, dict) or extras.get("format") != "3D3":
+                        message = f"{combined_glb}: missing 3D3 extras metadata"
+                        if require_source_proof and not loadability_only:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                        elif not loadability_only:
+                            print(f"warning: {message}", file=sys.stderr)
+                    mesh_count = len(glb.get("meshes", [])) if isinstance(glb.get("meshes"), list) else 0
+                    if mesh_count != len(expected_shapes):
+                        message = (
+                            f"{combined_glb}: mesh count differs from renderable shape count "
+                            f"(glb={mesh_count}, expected={len(expected_shapes)})"
+                        )
+                        if require_source_proof and not loadability_only:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                        elif not loadability_only:
+                            print(f"warning: {message}", file=sys.stderr)
+
+            for shape_index, shape_name, expected_shape_gltf in expected_shapes:
+                label = _safe_output_stem(shape_name)
+                base_shape = f"shape_{shape_index:03d}"
+                base = base_shape if label == base_shape else f"{base_shape}_{label}"
+                shape_glb = shape_output_dir / f"{base}.glb"
+                if not shape_glb.exists():
+                    if require_all:
+                        print(f"missing per-shape GLB: {shape_glb}", file=sys.stderr)
+                        failed += 1
+                    continue
+                checked += 1
+                checked_glb_paths.add(shape_glb.resolve())
+                try:
+                    shape_doc = _read_glb_json(shape_glb)
+                except Exception as exc:
+                    print(f"{shape_glb}: {exc}", file=sys.stderr)
+                    failed += 1
+                    continue
+                shape_extras = shape_doc.get("extras", {})
+                if not isinstance(shape_extras, dict):
+                    message = f"{shape_glb}: missing extras metadata"
+                    if require_source_proof and not loadability_only:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    elif not loadability_only:
+                        print(f"warning: {message}", file=sys.stderr)
+                    shape_extras = {}
+                try:
+                    glb_shape_index = int(shape_extras.get("source_shape_index", -1))
+                except (TypeError, ValueError):
+                    glb_shape_index = -1
+                if glb_shape_index != int(shape_index):
+                    message = (
+                        f"{shape_glb}: source_shape_index mismatch "
+                        f"(glb={shape_extras.get('source_shape_index')}, expected={shape_index})"
+                    )
+                    if require_source_proof and not loadability_only:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    elif not loadability_only:
+                        print(f"warning: {message}", file=sys.stderr)
+                if shape_extras.get("minimized_per_shape_glb") is not True:
+                    message = f"{shape_glb}: per-shape GLB is not marked as minimized"
+                    if require_source_proof and not loadability_only:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    elif not loadability_only:
+                        print(f"warning: {message}", file=sys.stderr)
+                meshes = shape_doc.get("meshes", [])
+                nodes = shape_doc.get("nodes", [])
+                if not isinstance(meshes, list) or len(meshes) != 1:
+                    print(f"{shape_glb}: expected exactly one mesh", file=sys.stderr)
+                    failed += 1
+                if not isinstance(nodes, list) or len(nodes) != 1:
+                    print(f"{shape_glb}: expected exactly one node", file=sys.stderr)
+                    failed += 1
+                primitive_errors = _validate_glb_order_sensitive_primitives(shape_glb, shape_doc)
+                if primitive_errors and not loadability_only:
+                    for error in primitive_errors:
+                        if require_source_proof:
+                            print(error, file=sys.stderr)
+                        else:
+                            print(f"warning: {error}", file=sys.stderr)
+                    if require_source_proof:
+                        failed += len(primitive_errors)
+                expected_counts = _glb_primitive_counts(shape_doc)
+                if (
+                    expected_counts.get("triangles", 0) <= 0
+                    and expected_counts.get("lines", 0) <= 0
+                    and expected_counts.get("points", 0) <= 0
+                ):
+                    print(f"{shape_glb}: per-shape GLB contains no triangles, lines, or points", file=sys.stderr)
+                    failed += 1
+                legacy_generated_counts = _glb_primitive_counts(expected_shape_gltf)
+                if not loadability_only:
+                    message = compare_mapping_exact(
+                        str(shape_glb),
+                        "GLB primitive counts",
+                        expected_counts,
+                        legacy_generated_counts,
+                        "glb",
+                        "original",
+                    )
+                    if message:
+                        if allow_custom_glb_differences:
+                            print(f"warning: {message}", file=sys.stderr)
+                        else:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                # This compares compact source identity metadata, not duplicated
+                # geometry in JSON. It catches source primitive drops/reordering/color
+                # loss in an unmodified conversion while still allowing customizers to
+                # edit the GLB itself as the source of truth.
+                if not loadability_only:
+                    legacy_generated_meta = _glb_source_meta(expected_shape_gltf)
+                    glb_meta_from_source = _glb_source_meta(shape_doc)
+                    message = compare_sequence_exact(
+                        str(shape_glb),
+                        "GLB source primitive metadata",
+                        glb_meta_from_source,
+                        legacy_generated_meta,
+                    )
+                    if message:
+                        if require_source_proof and not allow_custom_glb_differences:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                        else:
+                            print(f"warning: {message}", file=sys.stderr)
+                    color_message = compare_mapping_exact(
+                        str(shape_glb),
+                        "GLB raw face/line/point color usage",
+                        _glb_raw_color_usage(shape_doc),
+                        _glb_raw_color_usage(expected_shape_gltf),
+                        "glb",
+                        "original",
+                    )
+                    if color_message:
+                        if require_source_proof and not allow_custom_glb_differences:
+                            print(color_message, file=sys.stderr)
+                            failed += 1
+                        else:
+                            print(f"warning: {color_message}", file=sys.stderr)
+    
+                shape_glmesh = shape_output_dir / "cache" / f"{base}.glmesh"
+                if not shape_glmesh.exists():
+                    if require_generated_cache:
+                        print(f"missing per-shape runtime mesh cache: {shape_glmesh}", file=sys.stderr)
+                        failed += 1
+                    continue
+                checked += 1
+                checked_glmesh_paths.add(shape_glmesh.resolve())
+                try:
+                    expected_glmesh = glb_to_glmesh_bytes(shape_glb)
+                    actual_glmesh = shape_glmesh.read_bytes()
+                    actual_counts = _glmesh_primitive_counts(actual_glmesh)
+                    glb_meta = _glb_source_meta(shape_doc)
+                    glmesh_meta = _glmesh_source_meta(actual_glmesh)
+                    stream_error = _compare_glmesh_streams(expected_glmesh, actual_glmesh)
+                except Exception as exc:
+                    print(f"{shape_glmesh}: {exc}", file=sys.stderr)
+                    failed += 1
+                    continue
+                if stream_error:
+                    print(f"{shape_glmesh}: runtime mesh stream differs from source GLB: {stream_error}", file=sys.stderr)
+                    failed += 1
+                if glmesh_meta:
+                    message = compare_sequence_exact(
+                        str(shape_glmesh),
+                        "source primitive metadata",
+                        glmesh_meta,
+                        glb_meta,
+                    )
+                else:
+                    message = None
+                if message:
+                    if require_source_proof:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    else:
+                        print(f"warning: {message}", file=sys.stderr)
+                if not glmesh_meta:
+                    message = f"{shape_glmesh}: runtime mesh cache does not preserve source primitive metadata"
+                    if require_source_proof:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    else:
+                        print(f"warning: {message}", file=sys.stderr)
+                for count_key in ("triangles", "lines", "points"):
+                    count_error = compare_count_value(
+                        str(shape_glmesh),
+                        count_key,
+                        actual_counts[count_key],
+                        expected_counts[count_key],
+                        "glmesh",
+                        "glb",
+                    )
+                    if count_error:
+                        print(count_error, file=sys.stderr)
+                        failed += 1
+                if actual_glmesh != expected_glmesh:
+                    print(f"{shape_glmesh}: runtime mesh cache differs from source GLB", file=sys.stderr)
+                    failed += 1
+    
+    if loadability_only:
+        for json_path in sorted(output_root.rglob("*.json")):
+            if json_path.resolve() in checked_json_paths:
+                continue
+            if not json_path.name.upper().endswith(".3D3.JSON"):
+                continue
+            extra_checked, extra_failed = _validate_3d3_json_loadability(json_path)
+            checked += extra_checked
+            failed += extra_failed
+        for glb_path in sorted(output_root.rglob("*.glb")):
+            if glb_path.resolve() in checked_glb_paths:
+                continue
+            extra_checked, extra_failed = _validate_glb_loadability(glb_path)
+            checked += extra_checked
+            failed += extra_failed
+        for glmesh_path in sorted(output_root.rglob("*.glmesh")):
+            if glmesh_path.resolve() in checked_glmesh_paths:
+                continue
+            extra_checked, extra_failed = _validate_glmesh_loadability(glmesh_path)
+            checked += extra_checked
+            failed += extra_failed
+
+    return checked, failed

--- a/tools/f15assets/f15assets/validation_sound.py
+++ b/tools/f15assets/f15assets/validation_sound.py
@@ -1,0 +1,145 @@
+"""Digitized cue WAV replacement validation."""
+
+from __future__ import annotations
+
+import sys
+import wave
+from pathlib import Path
+
+from .sounds import ASOUND_SAMPLE_CUES, DEFAULT_SAMPLE_RATE, DIGITIZED_SAMPLE_BLOB
+from .validation_compare import compare_wav_sample_rate, compare_wav_samples
+from .validation_compare_music import compare_intro_music_json, compare_intro_music_midi
+
+__all__ = ["validate_sound_replacements"]
+
+
+def _read_pcm8_mono_wav(path: Path) -> tuple[int, bytes]:
+    with wave.open(str(path), "rb") as wav:
+        if wav.getnchannels() != 1:
+            raise ValueError(f"expected mono WAV: {path}")
+        if wav.getsampwidth() != 1:
+            raise ValueError(f"expected unsigned 8-bit PCM WAV: {path}")
+        if wav.getcomptype() != "NONE":
+            raise ValueError(f"expected uncompressed PCM WAV: {path}")
+        sample_rate = int(wav.getframerate())
+        samples = wav.readframes(wav.getnframes())
+    return sample_rate, samples
+
+
+def _repo_root_from_tools() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _validate_intro_music_export(sound_root: Path, require_all: bool) -> tuple[int, int]:
+    checked = 0
+    failed = 0
+    json_path = sound_root / "intro_music.asound.json"
+    midi_path = sound_root / "intro_music.mid"
+    if not json_path.exists() and not midi_path.exists():
+        if require_all:
+            print(f"missing intro music ASOUND JSON: {json_path}", file=sys.stderr)
+            print(f"missing intro music MIDI preview: {midi_path}", file=sys.stderr)
+            return checked, 2
+        return checked, failed
+
+    if not json_path.exists():
+        print(f"missing intro music ASOUND JSON: {json_path}", file=sys.stderr)
+        failed += 1
+    else:
+        checked += 1
+        source_text = (_repo_root_from_tools() / "src" / "asound" / "asound_model.c").read_text(encoding="utf-8")
+        errors = compare_intro_music_json(json_path, source_text)
+        for error in errors:
+            print(error, file=sys.stderr)
+        failed += len(errors)
+
+    if midi_path.exists():
+        checked += 1
+    midi_errors = compare_intro_music_midi(midi_path)
+    for error in midi_errors:
+        print(error, file=sys.stderr)
+    failed += len(midi_errors)
+    return checked, failed
+
+
+def validate_sound_replacements(
+    input_root: Path,
+    output_root: Path,
+    require_all: bool,
+    loadability_only: bool = False,
+) -> tuple[int, int]:
+    blob_path = input_root / DIGITIZED_SAMPLE_BLOB
+    sound_root = output_root / "sounds"
+    checked = 0
+    failed = 0
+    checked_wav_paths: set[Path] = set()
+
+    blob = blob_path.read_bytes() if blob_path.exists() else None
+    for cue in ASOUND_SAMPLE_CUES:
+        cue_id = str(cue["id"])
+        wav_path = sound_root / f"{cue_id}.wav"
+        if not wav_path.exists():
+            if require_all:
+                print(f"missing replacement WAV: {wav_path}", file=sys.stderr)
+                failed += 1
+            continue
+
+        checked += 1
+        checked_wav_paths.add(wav_path.resolve())
+        legacy_samples = b""
+        if blob is not None:
+            start = int(cue["source_start"])
+            end = min(int(cue["source_end_inclusive"]) + 1, len(blob))
+            legacy_samples = blob[start:end]
+        try:
+            sample_rate, modern_samples = _read_pcm8_mono_wav(wav_path)
+        except Exception as exc:
+            print(f"{wav_path}: {exc}", file=sys.stderr)
+            failed += 1
+            continue
+
+        if sample_rate <= 0:
+            print(f"{wav_path}: invalid sample rate {sample_rate}", file=sys.stderr)
+            failed += 1
+        if not modern_samples:
+            print(f"{wav_path}: WAV contains no samples", file=sys.stderr)
+            failed += 1
+            continue
+        if not loadability_only and blob is not None:
+            rate_error = compare_wav_sample_rate(str(wav_path), DEFAULT_SAMPLE_RATE, sample_rate)
+            if rate_error:
+                print(rate_error, file=sys.stderr)
+                failed += 1
+            sample_error = compare_wav_samples(str(wav_path), legacy_samples, modern_samples)
+            if sample_error:
+                print(sample_error, file=sys.stderr)
+                failed += 1
+        elif not loadability_only and blob is None:
+            print(
+                f"warning: {blob_path} is missing; validated {wav_path} loadability but skipped legacy sample comparison",
+                file=sys.stderr,
+            )
+
+    if loadability_only and sound_root.exists():
+        for wav_path in sorted(sound_root.glob("voice_cue_*.wav")):
+            if wav_path.resolve() in checked_wav_paths:
+                continue
+            checked += 1
+            try:
+                sample_rate, modern_samples = _read_pcm8_mono_wav(wav_path)
+            except Exception as exc:
+                print(f"{wav_path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+            if sample_rate <= 0:
+                print(f"{wav_path}: invalid sample rate {sample_rate}", file=sys.stderr)
+                failed += 1
+            if not modern_samples:
+                print(f"{wav_path}: WAV contains no samples", file=sys.stderr)
+                failed += 1
+
+    music_checked, music_failed = _validate_intro_music_export(sound_root, require_all)
+    checked += music_checked
+    failed += music_failed
+
+    return checked, failed

--- a/tools/f15assets/f15assets/validation_structured.py
+++ b/tools/f15assets/f15assets/validation_structured.py
@@ -1,0 +1,119 @@
+"""Structured WLD/3DT/3DG JSON replacement validation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Callable
+
+from .terrain import build_3dg, build_3dt
+from .validation_compare import compare_structured_rebuild
+from .world import build_wld
+
+__all__ = ["validate_structured_json_replacements"]
+
+
+def _format_from_structured_json_path(path: Path) -> str | None:
+    name = path.name.upper()
+    for fmt in ("WLD", "3DT", "3DG"):
+        if name.endswith(f".{fmt}.JSON"):
+            return fmt
+    return None
+
+
+def _validate_structured_json_loadability(path: Path, fmt: str, builder: Callable[[dict], bytes]) -> tuple[int, int]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        rebuilt = builder(payload)
+    except Exception as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1, 1
+    if not rebuilt:
+        print(f"{path}: rebuilt {fmt} is empty", file=sys.stderr)
+        return 1, 1
+    return 1, 0
+
+
+def _legacy_structured_json_path(relative: Path, output_root: Path) -> Path:
+    legacy_base = output_root / relative
+    return legacy_base.with_name(legacy_base.name + ".json")
+
+
+def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
+    for path in (primary, *fallbacks):
+        if path.exists():
+            return path
+    return primary
+
+
+def validate_structured_json_replacements(
+    input_root: Path,
+    output_root: Path,
+    recursive: bool,
+    require_all: bool,
+    iter_asset_paths: Callable[[Path, bool], list[Path]],
+    detect_format: Callable[[Path], str],
+    structured_json_path: Callable[[Path, Path, Path, Path, str], Path],
+    loadability_only: bool = False,
+) -> tuple[int, int]:
+    builders = {
+        "WLD": build_wld,
+        "3DT": build_3dt,
+        "3DG": build_3dg,
+    }
+    checked = 0
+    failed = 0
+    checked_json_paths: set[Path] = set()
+
+    if input_root.exists():
+        for src in iter_asset_paths(input_root, recursive=recursive):
+            fmt = detect_format(src)
+            if fmt not in builders:
+                continue
+
+            relative = src.relative_to(input_root)
+            json_path = _first_existing_path(
+                structured_json_path(src, relative, input_root, output_root, fmt),
+                _legacy_structured_json_path(relative, output_root),
+            )
+            if not json_path.exists():
+                if require_all:
+                    print(f"missing replacement JSON: {json_path}", file=sys.stderr)
+                    failed += 1
+                continue
+
+            checked += 1
+            checked_json_paths.add(json_path.resolve())
+            try:
+                payload = json.loads(json_path.read_text(encoding="utf-8"))
+                rebuilt = builders[fmt](payload)
+                if not rebuilt:
+                    print(f"{json_path}: rebuilt {fmt} is empty", file=sys.stderr)
+                    failed += 1
+                    continue
+                if loadability_only:
+                    continue
+                original = src.read_bytes()
+            except Exception as exc:
+                print(f"{json_path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+
+            rebuild_error = compare_structured_rebuild(str(json_path), fmt, original, rebuilt)
+            if rebuild_error:
+                print(rebuild_error, file=sys.stderr)
+                failed += 1
+
+    if loadability_only:
+        for json_path in sorted(output_root.rglob("*.json")):
+            fmt = _format_from_structured_json_path(json_path)
+            if fmt not in builders:
+                continue
+            if json_path.resolve() in checked_json_paths:
+                continue
+            extra_checked, extra_failed = _validate_structured_json_loadability(json_path, fmt, builders[fmt])
+            checked += extra_checked
+            failed += extra_failed
+
+    return checked, failed

--- a/tools/f15assets/map_editor.html
+++ b/tools/f15assets/map_editor.html
@@ -536,10 +536,19 @@
         GULF: "PG",
       }[theaterKey()] || theaterKey() || base;
       const names = [...new Set([
+        `${base}/${modelBase}.3D3.glb`,
+        `${modelBase}/${modelBase}.3D3.glb`,
+        `${base}/${base}.3D3.glb`,
+        `${modelBase}.3D3/${modelBase}.3D3.glb`,
+        `${base}.3D3/${base}.3D3.glb`,
         `${modelBase}.3D3.glb`,
         `${base}.3D3.glb`,
+        `${modelBase}/${modelBase}.glb`,
+        `${base}/${base}.glb`,
         `${modelBase}.glb`,
         `${base}.glb`,
+        `${modelBase}.WLD/${modelBase}.WLD.glb`,
+        `${base}.WLD/${base}.WLD.glb`,
         `${modelBase}.WLD.glb`,
         `${base}.WLD.glb`,
       ])];

--- a/tools/f15assets/model_viewer.html
+++ b/tools/f15assets/model_viewer.html
@@ -284,9 +284,17 @@
     }
 
     function candidates(name) {
+      const dirName = name.replace(/\.(json|glb|gltf)$/i, "");
+      const assetDirName = dirName.replace(/\.(3D3|WLD)$/i, "");
       return [
+        `../../converted_assets_all/${assetDirName}/${name}`,
+        `../../converted_assets_all/${dirName}/${name}`,
         `../../converted_assets_all/${name}`,
+        `/converted_assets_all/${assetDirName}/${name}`,
+        `/converted_assets_all/${dirName}/${name}`,
         `/converted_assets_all/${name}`,
+        `./${assetDirName}/${name}`,
+        `./${dirName}/${name}`,
         `./${name}`,
       ];
     }

--- a/tools/f15assets/tests/test_smoke.py
+++ b/tools/f15assets/tests/test_smoke.py
@@ -7,7 +7,7 @@ import struct
 import tempfile
 import unittest
 
-from f15assets import decode_pic_asset, encode_pic_asset, export_3d3_to_gltf, export_3d3_to_glb
+from f15assets import decode_pic_asset, encode_pic_asset, export_3d3_to_gltf, export_3d3_to_glb, export_3d3_shape_gltfs, export_3d3_gltf_to_glb
 from f15assets import parse_3d3, build_3d3, parse_3dg, build_3dg, parse_3dt, build_3dt, parse_wld, build_wld
 from tools.f15assets import cli as cli_module
 
@@ -414,6 +414,40 @@ class SmokeConvertersTest(unittest.TestCase):
         self.assertEqual(glb[16:20], b"JSON")
         self.assertGreaterEqual(len(glb), 20 + json_chunk_length)
 
+    def test_3d3_shape_glmesh_cache_matches_glb_source(self):
+        render_mode = bytes([0x00])
+        face_info = bytes([0x04] + [0x00] * 32)
+        vertices = bytes(
+            [0x03,
+             0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0xFF, 0xFF, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]
+        )
+        edges = bytes([0x03, 0xFF, 0xFF, 0x00, 0x01, 0xFF, 0xFF, 0x01, 0x02, 0xFF, 0xFF, 0x02, 0x00])
+        primitive = bytes([0x01, 0x05, 0x03, 0x00, 0x01, 0x02, 0x01])
+        shape_data = render_mode + face_info + vertices + edges + primitive
+
+        blob = bytearray()
+        blob.extend((0x33, 0x33))
+        blob.extend((1, 0))
+        blob.extend((0, 0))
+        blob.extend((len(shape_data) & 0xFF, (len(shape_data) >> 8) & 0xFF))
+        blob.extend(shape_data)
+
+        payload = parse_3d3(bytes(blob))
+        shapes = export_3d3_shape_gltfs(payload)
+        self.assertEqual(len(shapes), 1)
+
+        with tempfile.TemporaryDirectory() as workdir:
+            glb_path = pathlib.Path(workdir) / "shape_000.glb"
+            glmesh_path = pathlib.Path(workdir) / "shape_000.glmesh"
+            glb_path.write_bytes(export_3d3_gltf_to_glb(shapes[0][2]))
+            glmesh_path.write_bytes(cli_module._glb_to_glmesh_bytes(glb_path))
+            glmesh = glmesh_path.read_bytes()
+            self.assertEqual(glmesh, cli_module._glb_to_glmesh_bytes(glb_path))
+            self.assertEqual(glmesh[:8], b"F15GLM3\x00")
+            self.assertGreater(len(glmesh), 12)
+
     def test_3d3_to_gltf_tolerates_truncated_shape_payload(self):
         payload = {
             "format": "3D3",
@@ -430,141 +464,6 @@ class SmokeConvertersTest(unittest.TestCase):
             gltf["extras"]["skipped_shapes"][0]["shape_payload"]["render_error"],
             "truncated 3D3 face-normal block",
         )
-
-    def test_yaml_sidecar_export_and_roundtrip(self):
-        try:
-            import yaml
-        except Exception:
-            self.skipTest("PyYAML unavailable")
-
-        payload = {
-            "format": "3DT",
-            "version": 1,
-            "levels": [
-                {
-                    "level": 0,
-                    "objects": [
-                        {
-                            "tile_index": 0,
-                            "objects": [
-                                {"x": 1, "y": 2, "z": 3, "shape_word": 0x00FE},
-                            ],
-                        }
-                    ],
-                },
-                {"level": 1, "objects": []},
-                {"level": 2, "objects": []},
-                {"level": 3, "objects": []},
-                {"level": 4, "objects": []},
-            ],
-        }
-
-        source = build_3dt(payload)
-        decoded = parse_3dt(source)
-        with tempfile.TemporaryDirectory() as workdir:
-            base = pathlib.Path(workdir)
-            yaml_path = base / "shape.yaml"
-            json_path = base / "shape.json"
-
-            json_path.write_text(json.dumps(decoded, indent=2, sort_keys=True), encoding="utf-8")
-            yaml_path.write_text(yaml.safe_dump(decoded, sort_keys=True), encoding="utf-8")
-
-            from_yaml = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-            self.assertEqual(from_yaml["format"], "3DT")
-            self.assertEqual(from_yaml["tile_counts"], decoded["tile_counts"])
-
-            restored = json.loads(json_path.read_text(encoding="utf-8"))
-            self.assertEqual(build_3dt(from_yaml), build_3dt(restored))
-
-    def test_yaml_encode_input_supported(self):
-        try:
-            import yaml
-        except Exception:
-            self.skipTest("PyYAML unavailable")
-
-        payload = {
-            "format": "3DT",
-            "version": 1,
-            "levels": [
-                {
-                    "level": 0,
-                    "objects": [
-                        {
-                            "tile_index": 0,
-                            "objects": [{"x": 9, "y": 8, "z": 7, "shape_word": 0x00AB}],
-                        }
-                    ],
-                },
-                {"level": 1, "objects": []},
-                {"level": 2, "objects": []},
-                {"level": 3, "objects": []},
-                {"level": 4, "objects": []},
-            ],
-        }
-
-        source = build_3dt(payload)
-        parsed = parse_3dt(source)
-
-        with tempfile.TemporaryDirectory() as workdir:
-            yaml_path = pathlib.Path(workdir) / "shape.yaml"
-            with yaml_path.open("w", encoding="utf-8") as f:
-                yaml.safe_dump(parsed, f, sort_keys=True)
-            decoded_yaml = cli_module._read_yaml(yaml_path)
-            self.assertEqual(decoded_yaml["format"], "3DT")
-            self.assertEqual(build_3dt(decoded_yaml), source)
-
-    def test_yaml_sidecar_for_3dg_and_wld(self):
-        try:
-            import yaml
-        except Exception:
-            self.skipTest("PyYAML unavailable")
-
-        grid_payload = {
-            "format": "3DG",
-            "version": 1,
-            "level4_top_grid": [1] * 16,
-            "level3_grid": [2] * 256,
-            "level2_subgrid": [3] * 512,
-            "level1_subgrid": [4] * 512,
-            "level0_subgrid": [5] * 512,
-        }
-        wld_payload = {
-            "format": "WLD",
-            "terrain_target_ids": {"land": 0x11, "water": 0x11},
-            "read_item_size": 0,
-            "ground_unit_count": 0,
-            "world_object_count": 0,
-            "world_objects": [],
-            "flight_unit_count": 0,
-            "flight_units": [],
-            "shape_target_category_table": base64.b64encode(bytes([7] * 100)).decode("ascii"),
-            "kill_tally_or_unit_flags": base64.b64encode(bytes([8] * 100)).decode("ascii"),
-            "mission_object_type_table": base64.b64encode(bytes([9] * 100)).decode("ascii"),
-            "terrain_grid": base64.b64encode(bytes(range(256))).decode("ascii"),
-            "name_table": base64.b64encode(b"ALPHA\x00BRAVO\x00").decode("ascii"),
-            "trailing_bytes": "",
-        }
-
-        grid_bytes = build_3dg(grid_payload)
-        wld_bytes = build_wld(wld_payload)
-        grid_parsed = parse_3dg(grid_bytes)
-        wld_parsed = parse_wld(wld_bytes)
-
-        with tempfile.TemporaryDirectory() as workdir:
-            base = pathlib.Path(workdir)
-            grid_yaml = base / "grid.yaml"
-            wld_yaml = base / "wld.yaml"
-            grid_yaml.write_text(yaml.safe_dump(grid_parsed, sort_keys=True), encoding="utf-8")
-            wld_yaml.write_text(yaml.safe_dump(wld_parsed, sort_keys=True), encoding="utf-8")
-
-            self.assertEqual(
-                build_3dg(cli_module._read_yaml(grid_yaml)),
-                grid_bytes,
-            )
-            self.assertEqual(
-                build_wld(cli_module._read_yaml(wld_yaml)),
-                wld_bytes,
-            )
 
     def test_cli_decode_writes_stable_sidecars(self):
         asset_root = pathlib.Path("/home/xor/games/f15")
@@ -591,12 +490,10 @@ class SmokeConvertersTest(unittest.TestCase):
             base = pathlib.Path(workdir)
 
             json_3d3 = base / "asset_3d3.json"
-            yaml_3d3 = base / "asset_3d3.yaml"
             gltf = base / "asset_3d3.gltf"
 
             if sample_pic is not None:
                 json_pic = base / "asset_pic.json"
-                yaml_pic = base / "asset_pic.yaml"
                 png_pic = base / "asset_pic.png"
                 rc = cli_module.main(
                     [
@@ -605,13 +502,10 @@ class SmokeConvertersTest(unittest.TestCase):
                         str(json_pic),
                         "--png",
                         str(png_pic),
-                        "--yaml",
-                        str(yaml_pic),
                     ]
                 )
                 self.assertEqual(rc, 0)
                 self.assertTrue(json_pic.exists())
-                self.assertTrue(yaml_pic.exists())
                 self.assertTrue(png_pic.exists())
                 payload_pic = json.loads(json_pic.read_text(encoding="utf-8"))
                 self.assertEqual(payload_pic["format"], "PIC")
@@ -623,31 +517,24 @@ class SmokeConvertersTest(unittest.TestCase):
                     str(json_3d3),
                     "--gltf",
                     str(gltf),
-                    "--yaml",
-                    str(yaml_3d3),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_3d3.exists())
-            self.assertTrue(yaml_3d3.exists())
             self.assertTrue(gltf.exists())
             payload = json.loads(json_3d3.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "3D3")
 
             json_3dt = base / "asset_3dt.json"
-            yaml_3dt = base / "asset_3dt.yaml"
             rc = cli_module.main(
                 [
                     "decode",
                     str(sample_3dt),
                     str(json_3dt),
-                    "--yaml",
-                    str(yaml_3dt),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_3dt.exists())
-            self.assertTrue(yaml_3dt.exists())
             payload = json.loads(json_3dt.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "3DT")
 
@@ -658,19 +545,15 @@ class SmokeConvertersTest(unittest.TestCase):
                 self.skipTest("missing .3DG sample")
 
             json_3dg = base / "asset_3dg.json"
-            yaml_3dg = base / "asset_3dg.yaml"
             rc = cli_module.main(
                 [
                     "decode",
                     str(sample_3dg),
                     str(json_3dg),
-                    "--yaml",
-                    str(yaml_3dg),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_3dg.exists())
-            self.assertTrue(yaml_3dg.exists())
             payload = json.loads(json_3dg.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "3DG")
 
@@ -681,19 +564,15 @@ class SmokeConvertersTest(unittest.TestCase):
                 self.skipTest("missing .WLD sample")
 
             json_wld = base / "asset_wld.json"
-            yaml_wld = base / "asset_wld.yaml"
             rc = cli_module.main(
                 [
                     "decode",
                     str(sample_wld),
                     str(json_wld),
-                    "--yaml",
-                    str(yaml_wld),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_wld.exists())
-            self.assertTrue(yaml_wld.exists())
             payload = json.loads(json_wld.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "WLD")
 
@@ -781,29 +660,24 @@ class SmokeConvertersTest(unittest.TestCase):
                     str(source_root),
                     str(output_root),
                     "--recursive",
-                    "--yaml",
                     "--models",
                     "glb",
                 ]
             )
             self.assertEqual(rc, 0)
 
-            self.assertTrue((output_root / "TITLE.json").exists())
-            self.assertTrue((output_root / "TITLE.yaml").exists())
+            self.assertFalse((output_root / "TITLE.json").exists())
             self.assertTrue((output_root / "TITLE.png").exists())
 
-            self.assertTrue((output_root / "SCENERY.3D3.json").exists())
-            self.assertTrue((output_root / "SCENERY.3D3.yaml").exists())
-            self.assertTrue((output_root / "SCENERY.3D3.glb").exists())
+            self.assertTrue((output_root / "SCENERY" / "SCENERY.3D3.json").exists())
+            self.assertTrue((output_root / "SCENERY" / "SCENERY.3D3.glb").exists())
+            self.assertFalse((output_root / "SCENERY" / "shape_000.glb").exists())
 
-            self.assertTrue((output_root / "nested" / "TACTICS.json").exists())
-            self.assertTrue((output_root / "nested" / "TACTICS.yaml").exists())
+            self.assertTrue((output_root / "nested" / "TACTICS" / "TACTICS.3DT.json").exists())
 
-            self.assertTrue((output_root / "nested" / "LANDS.json").exists())
-            self.assertTrue((output_root / "nested" / "LANDS.yaml").exists())
+            self.assertTrue((output_root / "nested" / "LANDS" / "LANDS.3DG.json").exists())
 
-            self.assertTrue((output_root / "WORLD.json").exists())
-            self.assertTrue((output_root / "WORLD.yaml").exists())
+            self.assertTrue((output_root / "WORLD" / "WORLD.WLD.json").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  - Adds runtime loading of modern replacements with original fallback.
  - Adds validation comparing original assets and converted replacements.
  - Supports modern-only asset packs via convert-all.
