### PR TITLE
[review: very high] 7. [debug] Add deterministic blackbox debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
             build: cmake --build build --config Release --parallel
             test: ctest --test-dir build -C Release --output-on-failure
 
+          - name: Windows MSVC x64 Debug
+            os: windows-latest
+            configure: cmake -S . -B build -G "Visual Studio 18 2026" -A x64
+            build: cmake --build build --config Debug --parallel
+            test: ctest --test-dir build -C Debug --output-on-failure
+
           - name: macOS Clang
             os: macos-latest
             configure: cmake -S . -B build
@@ -55,6 +61,13 @@ jobs:
 
       - name: Test
         run: ${{ matrix.test }}
+
+      - name: Upload Windows debug build
+        if: matrix.name == 'Windows MSVC x64 Debug'
+        uses: actions/upload-artifact@v4
+        with:
+          name: f15se2-ex-windows-debug
+          path: build/Debug/f15se2-ex.exe
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,12 @@ jobs:
             build: cmake --build build --config Release --parallel
             test: ctest --test-dir build -C Release --output-on-failure
 
-          - name: Windows MSVC x64 Debug
+          - name: Windows MSVC x64 Blackbox
             os: windows-latest
-            configure: cmake -S . -B build -G "Visual Studio 18 2026" -A x64
-            build: cmake --build build --config Debug --parallel
-            test: ctest --test-dir build -C Debug --output-on-failure
+            configure: cmake -S . -B build -G "Visual Studio 18 2026" -A x64 -DBLACKBOX_AUTO_RECORD=ON
+            build: cmake --build build --config RelWithDebInfo --parallel
+            test: ctest --test-dir build -C RelWithDebInfo --output-on-failure
+            package: true
 
           - name: macOS Clang
             os: macos-latest
@@ -62,12 +63,50 @@ jobs:
       - name: Test
         run: ${{ matrix.test }}
 
-      - name: Upload Windows debug build
-        if: matrix.name == 'Windows MSVC x64 Debug'
+      - name: Package Windows blackbox build
+        if: matrix.package == true
+        shell: pwsh
+        run: |
+          $dist = "build/f15se2-ex-windows-blackbox"
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+          Copy-Item "build/RelWithDebInfo/f15se2-ex.exe" $dist
+          if (Test-Path "build/RelWithDebInfo/f15se2-ex.pdb") {
+            Copy-Item "build/RelWithDebInfo/f15se2-ex.pdb" $dist
+          }
+          $sdl = Get-ChildItem build -Recurse -Filter SDL3.dll |
+            Where-Object { $_.FullName -match 'RelWithDebInfo' } |
+            Select-Object -First 1
+          if (-not $sdl) {
+            throw "SDL3.dll was not produced"
+          }
+          Copy-Item $sdl.FullName $dist
+          Copy-Item "docs/blackbox_debugging.md" $dist
+          @"
+          F-15 SE2 deterministic blackbox test build
+
+          Keep f15se2-ex.exe and SDL3.dll in the same directory.
+
+          Run:
+            f15se2-ex.exe --game C:\path\to\F15
+
+          This build automatically records the session to _blackbox.rec in the
+          current working directory. Rename or move that file before the next
+          run if you want to preserve it.
+
+          Send developers:
+            - _blackbox.rec
+            - the approximate displayed blackbox position where the problem occurs
+            - a description of expected and actual behavior
+
+          See blackbox_debugging.md for replay and diagnostic commands.
+          "@ | Set-Content "$dist/README.txt"
+
+      - name: Upload Windows blackbox build
+        if: matrix.package == true
         uses: actions/upload-artifact@v4
         with:
-          name: f15se2-ex-windows-debug
-          path: build/Debug/f15se2-ex.exe
+          name: f15se2-ex-windows-blackbox
+          path: build/f15se2-ex-windows-blackbox
 
   coverage:
     name: Coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,9 @@ add_behavior_test(eg3drast_internal_behavior_tests SOURCES ${SRC_DIR}/egdata.c)
 add_behavior_test(start_behavior_tests LINK_CORE)
 add_behavior_test(log_behavior_tests LINK_CORE)
 add_behavior_test(vgapal_behavior_tests SOURCES ${SRC_DIR}/vgapal.c DEFS main=vgapal_program_main)
+add_test(NAME blackbox_inspect_tool_tests
+    COMMAND python3 ${TEST_DIR}/blackbox_inspect_tool_tests.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/tools/blackbox_inspect.py)
 #------------------------------------------------------------------------------
 # Coverage/inventory audits (opt-in custom targets; not part of `ctest`).
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,14 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/shared/ovlimpl.c
     ${SRC_DIR}/shared/picimpl.c
     ${SRC_DIR}/shared/timer.c
+    ${SRC_DIR}/shared/blackbox.c
+    ${SRC_DIR}/shared/blackbox_diag.c
+    ${SRC_DIR}/shared/blackbox_snapshot.c
+    ${SRC_DIR}/shared/blackbox_cli.c
+    ${SRC_DIR}/shared/blackbox_gl.c
+    ${SRC_DIR}/shared/blackbox_io.c
+    ${SRC_DIR}/shared/blackbox_state.c
+    ${SRC_DIR}/shared/blackbox_wait.c
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
@@ -449,6 +457,7 @@ add_behavior_test(load_behavior_tests SOURCES
     ${SRC_DIR}/eg3dload.c ${SRC_DIR}/egmath.c ${SRC_DIR}/egdata.c
     ${SRC_DIR}/egfarbuf.c)
 add_behavior_test(shared_timer_behavior_tests LINK_CORE)
+add_behavior_test(blackbox_behavior_tests LINK_CORE)
 add_behavior_test(shared_runtime_behavior_tests SOURCES
     ${SRC_DIR}/shared/cleanup.c ${SRC_DIR}/shared/drawstr.c)
 add_behavior_test(eg3drast_behavior_tests LINK_CORE)
@@ -476,8 +485,6 @@ add_behavior_test(eg3drast_internal_behavior_tests SOURCES ${SRC_DIR}/egdata.c)
 add_behavior_test(start_behavior_tests LINK_CORE)
 add_behavior_test(log_behavior_tests LINK_CORE)
 add_behavior_test(vgapal_behavior_tests SOURCES ${SRC_DIR}/vgapal.c DEFS main=vgapal_program_main)
-
-
 #------------------------------------------------------------------------------
 # Coverage/inventory audits (opt-in custom targets; not part of `ctest`).
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ option(UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
 # `ctest` produces .gcda data that gcovr turns into a report (see the `coverage`
 # target). Used by CI to upload to Codecov.
 option(COVERAGE "Build with gcov code-coverage instrumentation" OFF)
+option(BLACKBOX_AUTO_RECORD
+    "Record to _blackbox.rec by default when no blackbox mode is selected" OFF)
 
 # When ON, skip the interactive menus and drop straight into a hardcoded
 # mission (egame). Handy for iterating on the flight code without clicking
@@ -283,8 +285,12 @@ target_link_libraries(f15se2_core PUBLIC SDL3::SDL3 OpenGL::GL)
 add_executable(f15se2 ${SRC_DIR}/f15.c)
 set_target_properties(f15se2 PROPERTIES OUTPUT_NAME "f15se2-ex")
 target_link_libraries(f15se2 PRIVATE f15se2_core)
-target_compile_definitions(f15se2 PRIVATE
-    $<$<CONFIG:Debug>:F15_BLACKBOX_AUTO_RECORD>)
+if(BLACKBOX_AUTO_RECORD)
+    target_compile_definitions(f15se2 PRIVATE F15_BLACKBOX_AUTO_RECORD)
+else()
+    target_compile_definitions(f15se2 PRIVATE
+        $<$<CONFIG:Debug>:F15_BLACKBOX_AUTO_RECORD>)
+endif()
 
 # Autogenerate header file with version string
 add_custom_target(GenerateVersionHeader ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,7 @@ add_behavior_test(blackbox_behavior_tests LINK_CORE)
 add_behavior_test(blackbox_validation_tests LINK_CORE)
 add_behavior_test(blackbox_gl_behavior_tests SOURCES
     ${SRC_DIR}/shared/blackbox_gl.c ${SRC_DIR}/r2d.c)
+add_behavior_test(r3d_dispatch_behavior_tests SOURCES ${SRC_DIR}/r3d.c)
 add_behavior_test(shared_runtime_behavior_tests SOURCES
     ${SRC_DIR}/shared/cleanup.c ${SRC_DIR}/shared/drawstr.c)
 add_behavior_test(eg3drast_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,8 @@ add_behavior_test(load_behavior_tests SOURCES
 add_behavior_test(shared_timer_behavior_tests LINK_CORE)
 add_behavior_test(blackbox_behavior_tests LINK_CORE)
 add_behavior_test(blackbox_validation_tests LINK_CORE)
+add_behavior_test(blackbox_gl_behavior_tests SOURCES
+    ${SRC_DIR}/shared/blackbox_gl.c ${SRC_DIR}/r2d.c)
 add_behavior_test(shared_runtime_behavior_tests SOURCES
     ${SRC_DIR}/shared/cleanup.c ${SRC_DIR}/shared/drawstr.c)
 add_behavior_test(eg3drast_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ add_behavior_test(load_behavior_tests SOURCES
     ${SRC_DIR}/egfarbuf.c)
 add_behavior_test(shared_timer_behavior_tests LINK_CORE)
 add_behavior_test(blackbox_behavior_tests LINK_CORE)
+add_behavior_test(blackbox_validation_tests LINK_CORE)
 add_behavior_test(shared_runtime_behavior_tests SOURCES
     ${SRC_DIR}/shared/cleanup.c ${SRC_DIR}/shared/drawstr.c)
 add_behavior_test(eg3drast_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,8 +459,7 @@ add_behavior_test(load_behavior_tests SOURCES
 add_behavior_test(shared_timer_behavior_tests LINK_CORE)
 add_behavior_test(blackbox_behavior_tests LINK_CORE)
 add_behavior_test(blackbox_validation_tests LINK_CORE)
-add_behavior_test(blackbox_gl_behavior_tests SOURCES
-    ${SRC_DIR}/shared/blackbox_gl.c ${SRC_DIR}/r2d.c)
+add_behavior_test(blackbox_gl_behavior_tests SOURCES ${SRC_DIR}/shared/blackbox_gl.c)
 add_behavior_test(r3d_dispatch_behavior_tests SOURCES ${SRC_DIR}/r3d.c)
 add_behavior_test(shared_runtime_behavior_tests SOURCES
     ${SRC_DIR}/shared/cleanup.c ${SRC_DIR}/shared/drawstr.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,8 @@ target_link_libraries(f15se2_core PUBLIC SDL3::SDL3 OpenGL::GL)
 add_executable(f15se2 ${SRC_DIR}/f15.c)
 set_target_properties(f15se2 PROPERTIES OUTPUT_NAME "f15se2-ex")
 target_link_libraries(f15se2 PRIVATE f15se2_core)
+target_compile_definitions(f15se2 PRIVATE
+    $<$<CONFIG:Debug>:F15_BLACKBOX_AUTO_RECORD>)
 
 # Autogenerate header file with version string
 add_custom_target(GenerateVersionHeader ALL

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Use it when a gameplay bug needs to be reproduced or inspected later.
 
 Full guide: [docs/blackbox_debugging.md](docs/blackbox_debugging.md)
 
+Debug builds record to `_blackbox.rec` in the current working directory by
+default. Explicit debug, record, or replay options override that behavior.
+
 Record a run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -154,6 +154,47 @@ Building with MSVC should also work.
 
 After building, either drop the resulting binary into a directory with the game assets, use the `--game` command line option or the `F15SE2_DIR` environmental variable to set the assets' location. The game checks MD5 checksums on all asset files to make sure they are not corrupted, and will not start unless all files from the original game match up.
 
+## Deterministic blackbox debugging
+
+The blackbox mode records deterministic 60 Hz ticks, phase changes, input events,
+virtual-stick axes, RNG values, and pre-overlay indexed-page checksums into a text log.
+Use it when a gameplay bug needs to be reproduced or inspected later.
+
+Full guide: [docs/blackbox_debugging.md](docs/blackbox_debugging.md)
+
+Record a run:
+
+```bash
+./build/f15se2-ex --game /path/to/f15 --blackbox-record /tmp/f15.bb --blackbox-seed 7
+```
+
+Replay it:
+
+```bash
+./build/f15se2-ex --game /path/to/f15 --blackbox-replay /tmp/f15.bb
+```
+
+Replay and freeze at a displayed time for inspection:
+
+```bash
+./build/f15se2-ex --game /path/to/f15 --blackbox-replay /tmp/f15.bb --blackbox-pause-tick 12345
+```
+
+Inspect a timeframe around the same displayed time without running the game:
+
+```bash
+python3 tools/blackbox_inspect.py /tmp/f15.bb --around-tick 12345 --before 180 --after 180
+```
+
+The top-left overlay shows one compact decimal number: `seconds * 100 + tick`,
+where the final two digits are `00..59`. Pass that number directly to the
+game and inspector, for example `--around-tick 20545`. Blackbox log event lines
+use internal raw ticks; the full guide explains the conversion and dump format.
+
+During replay, RNG and frame checksum mismatches are logged as blackbox
+divergence errors. The first divergence tick is the best starting point for
+`--blackbox-pause-tick`.
+
 ## Contributor policy
 
 Contributions to this project are very welcome. However, contributors are expected to follow certain rules to keep the project manageable:

--- a/docs/blackbox_debugging.md
+++ b/docs/blackbox_debugging.md
@@ -55,6 +55,19 @@ directory on Linux, macOS, and Windows. Preserve or rename the file before the
 next run when collecting multiple reports. Release builds do not record
 implicitly.
 
+The Windows CI job also produces the distributable
+`f15se2-ex-windows-blackbox` artifact. It is a `RelWithDebInfo` build with
+automatic recording enabled and includes `f15se2-ex.exe`, `SDL3.dll`, debug
+symbols, and these instructions. Unlike an MSVC Debug executable, it does not
+depend on Microsoft's non-redistributable Debug C runtime.
+
+To build the same configuration locally on Windows:
+
+```powershell
+cmake -S . -B build -A x64 -DBLACKBOX_AUTO_RECORD=ON
+cmake --build build --config RelWithDebInfo --parallel
+```
+
 ## Record a run
 
 Use the original game asset directory with `--game`.

--- a/docs/blackbox_debugging.md
+++ b/docs/blackbox_debugging.md
@@ -36,9 +36,24 @@ Use the overlay number directly. A colon form such as `205:45` is not accepted.
 ## Build
 
 ```bash
-cmake -S . -B build -DDOWNLOAD_DEPENDENCIES=ON
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DDOWNLOAD_DEPENDENCIES=ON
 cmake --build build -j2
 ```
+
+For a multi-configuration generator such as Visual Studio, select Debug while
+building:
+
+```powershell
+cmake -S . -B build -A x64
+cmake --build build --config Debug --parallel
+```
+
+Debug builds automatically start a recording at `_blackbox.rec` when no
+`--blackbox-debug`, `--blackbox-record`, or `--blackbox-replay` option was
+specified. The relative path means the file is written to the process working
+directory on Linux, macOS, and Windows. Preserve or rename the file before the
+next run when collecting multiple reports. Release builds do not record
+implicitly.
 
 ## Record a run
 
@@ -54,6 +69,7 @@ Use the original game asset directory with `--game`.
 Notes:
 
 - `--blackbox-seed` selects the deterministic seed; it defaults to `1`.
+- An explicit `--blackbox-record` path replaces the Debug-build default.
 - The output log is text and can be opened in an editor.
 - The top-left overlay uses the displayed-time notation described above.
 

--- a/docs/blackbox_debugging.md
+++ b/docs/blackbox_debugging.md
@@ -1,0 +1,465 @@
+# Deterministic blackbox debugging
+
+The blackbox mode records a deterministic run into a text log that can be
+replayed later. It is intended for bug reports and investigation: record a run
+where a problem happens, inspect the log to find the timeframe, then replay and
+pause near that tick.
+
+## What is recorded
+
+- deterministic 60 Hz tick counter;
+- program phase markers: `start`, `egame`, `end`;
+- BIOS-style key/input events;
+- virtual-stick and joystick axes;
+- deterministic RNG seeds and generated RNG values;
+- pre-overlay indexed-page checksums;
+- build identity and the initial `HallFame` state;
+- gameplay transition markers and subsystem hashes;
+- backend-independent 3D scene submission hashes.
+
+Frame checksums are recorded before the blackbox overlay is drawn, so the
+debug timer itself does not affect divergence checks.
+
+## Time notation
+
+The overlay and all CLI/inspector `*-tick` arguments use **displayed time**, a
+single decimal number calculated as `seconds * 100 + subtick`. The final two
+digits are `00..59`. For example:
+
+- displayed time `20545` means 205 seconds plus 45/60 second;
+- its internal raw tick is `205 * 60 + 45 = 12345`;
+- blackbox event lines store that raw tick (`12345`), while commands accept the
+  displayed value (`20545`).
+
+Use the overlay number directly. A colon form such as `205:45` is not accepted.
+
+## Build
+
+```bash
+cmake -S . -B build -DDOWNLOAD_DEPENDENCIES=ON
+cmake --build build -j2
+```
+
+## Record a run
+
+Use the original game asset directory with `--game`.
+
+```bash
+./build/f15se2-ex \
+  --game /path/to/f15 \
+  --blackbox-record /tmp/f15-run.bb \
+  --blackbox-seed 7
+```
+
+Notes:
+
+- `--blackbox-seed` selects the deterministic seed; it defaults to `1`.
+- The output log is text and can be opened in an editor.
+- The top-left overlay uses the displayed-time notation described above.
+
+## Replay a run
+
+```bash
+./build/f15se2-ex \
+  --game /path/to/f15 \
+  --blackbox-replay /tmp/f15-run.bb
+```
+
+During replay, real gameplay input is ignored. Window/system events such as
+close, focus, and resize still work.
+
+Record/replay sessions are read-only for persistent game state. They suppress
+normal runtime writes such as `HallFame` pilot/progress saves, so a bad run
+cannot mutate the pilot roster while you record or inspect it.
+
+The log also carries the `HallFame` snapshot from record start, or an explicit
+empty snapshot if the recorder had no roster file. Replay reads that captured
+roster state from memory, so another developer does not need the same local
+pilot file and replay will not overwrite theirs.
+
+If replay diverges from the recording, the game logs blackbox errors for the
+first mismatching RNG seed/value, indexed-page checksum, gameplay marker,
+subsystem hash, or render-submission hash.
+
+By default, replay rejects logs recorded by another build. Use
+`--blackbox-replay-ignore-build` only when you intentionally want to find where
+a newer source version starts diverging.
+
+## Pause replay at a tick
+
+Use this after you know roughly where the problem happened.
+
+```bash
+./build/f15se2-ex \
+  --game /path/to/f15 \
+  --blackbox-replay /tmp/f15-run.bb \
+  --blackbox-pause-tick 20545
+```
+
+Use the number shown by the overlay directly. `20545` means 205 seconds plus
+45 ticks; the game converts it internally to raw tick 12345.
+
+### Fast-forward to an investigation window
+
+Replay can run without host presentation or deliberate sleeps until a target
+tick. Simulation, rendering logic, recorded input/RNG consumption, and frame
+hash verification still run normally:
+
+```bash
+./build/f15se2-ex \
+  --game /path/to/f15 \
+  --blackbox-replay /tmp/f15-run.bb \
+  --blackbox-fast-forward-tick 20000 \
+  --blackbox-pause-tick 20545
+```
+
+The pause tick may equal or follow the fast-forward target. It cannot precede
+it, because that would freeze time while host presentation was still disabled.
+
+## Inspect a log without running the game
+
+Show events around the same displayed time:
+
+```bash
+python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
+  --around-tick 20545 \
+  --before 180 \
+  --after 180
+```
+
+## Gameplay diagnostics
+
+Blackbox recordings include deterministic gameplay diagnostics by default. They
+are passive: diagnostics read existing state and renderer submissions but do not
+change simulation state, input, RNG, or rendering.
+
+### Event markers
+
+The simulation-step hook records transitions rather than requiring hooks spread
+through gameplay code:
+
+- `sim_begin`: first captured in-flight simulation state.
+- `view_change`: old and new `ViewMode` values.
+- `target_change`: tracked object, air lock, or ground lock changed.
+- `projectile_launch`: projectile slot became active, with weapon and target.
+- `projectile_remove`: projectile slot became free, with its final identity.
+- `mission_end`: mission state entered its terminal path.
+
+Show markers near displayed time `20545`:
+
+```bash
+python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
+  --around-tick 20545 --before 300 --after 300
+```
+
+Marker lines are replay-checked. A different marker, argument, order, or tick is
+reported as the first marker divergence.
+
+### Subsystem hashes
+
+Every authoritative simulation step records five independent hashes:
+
+- `flight`: player position, attitude, speed, altitude, fuel, and damage state.
+- `camera`: view mode/orientation, camera eye, target point, and camera distance.
+- `objects`: all 20 moving-aircraft/AI object records, field by field.
+- `weapons`: all 12 guided projectiles plus selected weapon and gun state.
+- `target_mission`: target locks, target lead, mission state, remaining enemies,
+  and score state.
+
+Replay compares each subsystem separately. The first error identifies which
+subsystem diverged, its simulation step, and expected/actual hash. This narrows
+investigation before adding temporary logs to gameplay code.
+
+### Manual diagnostic dumps
+
+While blackbox debug, record, or replay mode is active, press `Ctrl+F10`. The
+shortcut is host-only and is never inserted into the game's key buffer, so it
+does not alter deterministic input. It writes to the current directory:
+
+```text
+blackbox-dump-20545.txt
+blackbox-dump-20545.json
+```
+
+The human-readable text dump contains:
+
+- raw tick and displayed time;
+- build provenance, blackbox mode, input/RNG cursors, and timer state;
+- current hashes and readable player/camera/target state;
+- every simulation object and projectile slot;
+- the current render frame's recent scene/object/line submissions;
+- a count if the fixed 512-command diagnostic buffer overflowed.
+
+The versioned JSON snapshot is intended for agents, scripts, and snapshot
+comparison. It serializes fields individually, not as raw C memory, and contains
+the player, camera, target/mission and weapon context together with every field
+of all simulation objects, projectiles, projectile interpolation coordinates,
+and bullet tracks. It also records build provenance, recorder/RNG cursor state,
+timer and interpolation state, waypoints, target-selection slots, and the full
+74-entry mission target table. Stable slot numbers make object arrays
+straightforward to diff between two times or two builds.
+
+#### Text dump format
+
+The `.txt` file is a compact investigation report. Its sections appear in this
+order:
+
+- `raw_tick` and `displayed_time` identify the captured simulation instant.
+- `provenance` identifies the running build and the build that created a replay.
+- `blackbox` reports mode, configured seed, RNG state, frame index, input pump,
+  and event cursors. Mode values are `0` off, `1` debug, `2` record, and `3`
+  replay. Cursors use `consumed/total` notation.
+- `timing` reports timer counters, simulation steps in the current presented
+  frame, Q12 render interpolation alpha, and the game RNG seed.
+- `subsystem` contains separate hashes for flight, objects, weapons, camera,
+  and target/mission state.
+- `flight`, `camera`, and `target` provide the most useful state in readable
+  form.
+- `object[00]` through `object[19]` and `projectile[00]` through
+  `projectile[11]` preserve stable runtime slot numbers.
+- `render` lists up to 512 recent backend-independent render submissions. `S`
+  is a scene/camera command, `O` is an object submission, and `L` is a line.
+  `dropped` reports commands omitted after the fixed diagnostic buffer filled.
+
+The text report is deliberately selective. In particular, complete waypoint,
+mission-target, bullet-track, and interpolation records belong in the JSON
+snapshot.
+
+#### JSON snapshot format
+
+The `.json` file has `format` and `version` fields. Version `1` uses these
+top-level sections:
+
+- `provenance`: current and recorded build identifiers.
+- `time`: raw tick and compact displayed time.
+- `blackbox`: mode, input pump, configured seed, RNG state, frame index, and
+  event cursors. Every cursor is `[consumed, total]`.
+- `timing`: timer installation/counters, frame tick, simulation-step count,
+  Q12 interpolation alpha, and game RNG seed.
+- `flight`, `camera`, `target_mission`, and `weapons`: current high-level game
+  state.
+- `waypoints`: all 4 waypoint records.
+- `target_slots`: both target-selection records.
+- `map_targets`: all 74 mission-map target slots.
+- `sim_objects`: all 20 simulation-object slots.
+- `projectiles`: all 12 guided-projectile slots, including interpolation
+  coordinates.
+- `bullet_tracks`: all 20 bullet-track slots.
+
+Values retain the game's native integer units and raw flag bitfields. The dump
+does not convert coordinates to meters, angles to degrees, or flags to inferred
+names. Inactive and free slots remain present so their indices stay stable in
+diffs. An unsigned tick value of `4294967295` (`0xffffffff`) means that the
+corresponding pause or fast-forward trigger is not configured.
+
+The JSON snapshot does not duplicate the text report's subsystem hashes or
+recent render-command list; use the files together. File names use compact
+displayed time, while `time.raw_tick` stores the underlying 60 Hz tick. A second
+dump at the same displayed time overwrites files with the same names. Scripts
+should address fields by name and slots by index rather than depend on JSON key
+ordering.
+
+Useful queries include:
+
+```bash
+# Establish whether two snapshots came from equivalent replay state.
+jq '{provenance, blackbox, timing}' blackbox-dump-20545.json
+
+# Show active mission-map targets while retaining their slot numbers.
+jq '.map_targets | to_entries[] | select(.value.active != 0)' \
+  blackbox-dump-20545.json
+
+# Inspect one object and one guided projectile.
+jq '{object: .sim_objects[10], projectile: .projectiles[8]}' \
+  blackbox-dump-20545.json
+```
+
+Snapshots are intentionally write-only. Loading a JSON file directly into live
+structures would leave derived caches, model references, and other dependent
+state inconsistent; implementing save/load state is a separate, more invasive
+feature.
+
+Use a dump to inspect a paused replay:
+
+```bash
+./build/f15se2-ex --game /path/to/f15 \
+  --blackbox-replay /tmp/f15-run.bb \
+  --blackbox-fast-forward-tick 20400 \
+  --blackbox-pause-tick 20545
+```
+
+At the paused frame, press `Ctrl+F10`. Read `blackbox-dump-20545.txt` manually or
+diff/process `blackbox-dump-20545.json` with tooling such as `jq`.
+
+For cross-platform automation, prefer a tick-triggered dump over the keyboard
+shortcut:
+
+```bash
+./build/f15se2-ex --game /path/to/f15 \
+  --blackbox-replay /tmp/f15-run.bb \
+  --blackbox-fast-forward-tick 20545 \
+  --blackbox-dump-tick 20545 \
+  --blackbox-pause-tick 20545
+```
+
+`--blackbox-dump-tick` uses the same displayed-time notation as fast-forward
+and pause, emits once when that deterministic tick is reached, and does not
+depend on SDL presentation or desktop keyboard-shortcut handling. It can also
+be used with `--blackbox-debug` or `--blackbox-record`. `Ctrl+F10` remains a
+convenience shortcut, but a desktop environment or laptop firmware may consume
+that key combination. The first valid automatic dump time is `1`; displayed
+time `0` is rejected because game state has not reached a capturable tick.
+
+If `--blackbox-pause-tick` is omitted, replay continues after writing the dump.
+For a single unattended investigation command, set fast-forward, dump, and
+pause to the same displayed time as in the example above.
+
+Compare snapshots from two builds or runs with stable key ordering:
+
+```bash
+jq -S . blackbox-dump-20545.json > /tmp/snapshot-a.json
+jq -S . other/blackbox-dump-20545.json > /tmp/snapshot-b.json
+diff -u /tmp/snapshot-a.json /tmp/snapshot-b.json
+```
+
+Check `provenance`, `blackbox.cursors`, and `timing` first. If those differ, the
+remaining object differences may be consequences rather than the root cause.
+
+### Render-command capture
+
+Compact backend-independent render hashes are recorded by default. They cover
+each `r3d` scene's camera parameters, model submissions, transforms, positions,
+shadows, world-space lines, and line colors. This captures the commands before
+OpenGL/software backend differences.
+
+For geometry, visibility, or z-fighting investigation, record every command:
+
+```bash
+./build/f15se2-ex --game /path/to/f15 \
+  --blackbox-record /tmp/f15-render.bb \
+  --blackbox-capture-render
+```
+
+This produces a substantially larger log containing:
+
+- `render_scene`: scene orientation, position, and main/sub-view flag;
+- `render_object`: stable model-data offset, attitude, position, and shadow flag;
+- `render_line`: both 3D endpoints and final palette color;
+- `render_hash`: scene command counts and combined hash.
+
+Detailed commands are for inspection; replay equivalence uses `render_hash`.
+Because capture occurs in `r3d.c`, the same command stream is observed whether
+the selected backend is `opengl1` or `software`.
+
+### Suggested issue workflow
+
+1. Record a run that reproduces the issue.
+2. Note the displayed time or find the relevant marker with the inspector.
+3. Replay with fast-forward to shortly before that time.
+4. Compare the first subsystem or render-hash divergence, if any.
+5. Pause at the problem time and press `Ctrl+F10` for readable state.
+6. For geometry bugs, make a second short recording with
+   `--blackbox-capture-render` and inspect the model/line submissions.
+7. Apply the fix and replay the same recording as an integration regression.
+
+Useful mappings:
+
+- upside-down external view or broken bearing: `camera` and `target_change`;
+- disappearing missile: `projectile_launch`, `projectile_remove`, and `weapons`;
+- skipped target lock: `target_change` and `target_mission`;
+- invisible aircraft: `objects` versus `render_object` submissions;
+- missing stabilizers, flicker, or z-fighting: detailed render capture and model
+  offsets, then inspect the corresponding model asset/decoder.
+
+Audio state is intentionally outside this diagnostic layer. These dumps can
+correlate gameplay events that request sounds, but they cannot diagnose mixer,
+OPL, sample-playback, or sound-queue state directly.
+
+Show events around the compact displayed time:
+
+```bash
+python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
+  --around-tick 20545
+```
+
+Show an explicit range:
+
+```bash
+python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
+  --from-tick 12000 \
+  --to-tick 12300
+```
+
+Emit JSON for scripts or agents:
+
+```bash
+python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
+  --from-tick 12000 \
+  --to-tick 12300 \
+  --json
+```
+
+## Log format
+
+The log starts with:
+
+```text
+F15SE2_BLACKBOX 5
+seed 7
+build_version v0.9.4-1-g25b4664
+```
+
+Event lines use internal raw ticks, not displayed-time notation:
+
+```text
+phase 0 start
+key 120 487 1f73
+axes 121 128 128 128 128
+rng_seed 240 1234
+rng 240 3558
+frame 241 19 1a2b3c4d
+mutable_file HallFame 258 <hex_bytes>
+marker 240 view_change 128 132 0
+state 240 17 camera 8adf5d9e
+render_hash 240 19 1 12 3 1a2b3c4d
+```
+
+Field meanings:
+
+- `phase <tick> <name>`: executable phase marker.
+- `key <tick> <input_pump> <bios_word_hex>`: BIOS-style key word and the exact
+  shared-input polling call that observed it. The pump sequence remains ordered
+  while static menu/death screens have their 60 Hz timer stopped.
+- `axes <tick> <rawX> <rawY> <joyX> <joyY>`: virtual-stick and joystick axes.
+- `rng_seed <tick> <seed>`: deterministic RNG reseed.
+- `rng <tick> <value>`: deterministic 15-bit RNG output.
+- `frame <tick> <frame_index> <hash>`: pre-overlay indexed-page checksum for a
+  logical game presentation. Window expose/resize redraws are excluded.
+- `build_version <version>`: `git describe` string compiled into the binary.
+- `mutable_file HallFame <size> <hex_bytes>`: captured pilot roster.
+- `marker <tick> <name> <a> <b> <c>`: gameplay transition and arguments.
+- `state <tick> <sim_step> <subsystem> <hash>`: field-by-field subsystem hash.
+- `render_scene`, `render_object`, and `render_line`: detailed submissions,
+  present only when recording with `--blackbox-capture-render`.
+- `render_hash <tick> <frame> <scene> <objects> <lines> <hash>`: compact scene
+  submission summary used for replay comparison.
+
+Replay and the inspector only accept the current `F15SE2_BLACKBOX 5` format.
+Unknown log lines are errors. This is intentional: silently accepting stale or
+malformed troubleshooting logs would make divergence analysis unreliable.
+
+## Limitations
+
+- This is replay-to-tick, not reverse execution. To “rewind”, replay from the
+  start and pause at an earlier tick.
+- Dumps are diagnostic snapshots, not complete save states and cannot be loaded
+  back into the game.
+- Replay is deterministic for the instrumented input/RNG/virtual-timer path.
+  Frame checksums are passive diagnostics: they never resynchronize time or
+  alter execution. They cover the indexed 2D page passed through logical game
+  presents, not host-requested redraws or the full OpenGL framebuffer.
+- Intro audio completion is asynchronous during normal play. Blackbox mode uses
+  the same bounded wait expressed in virtual ticks, so host audio scheduling
+  cannot change menu control flow.
+- Gamepad repeat timing is recorded as resulting key/axis events. Replay does
+  not need the same physical gamepad connected.

--- a/docs/blackbox_debugging.md
+++ b/docs/blackbox_debugging.md
@@ -404,7 +404,7 @@ python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
 The log starts with:
 
 ```text
-F15SE2_BLACKBOX 5
+F15SE2_BLACKBOX 7
 seed 7
 build_version v0.9.4-1-g25b4664
 ```
@@ -413,6 +413,7 @@ Event lines use internal raw ticks, not displayed-time notation:
 
 ```text
 phase 0 start
+timer_pump 0 0
 key 120 487 1f73
 axes 121 128 128 128 128
 rng_seed 240 1234
@@ -427,6 +428,10 @@ render_hash 240 19 1 12 3 1a2b3c4d
 Field meanings:
 
 - `phase <tick> <name>`: executable phase marker.
+- `timer_pump <start_tick> <tick_count>`: number of native 60 Hz ticks produced
+  by one timer-pump call. Zero-count entries preserve the exact polling/render
+  iteration on which the next tick became visible. Replay rejects counts above
+  the native catch-up limit.
 - `key <tick> <input_pump> <bios_word_hex>`: BIOS-style key word and the exact
   shared-input polling call that observed it. The pump sequence remains ordered
   while static menu/death screens have their 60 Hz timer stopped.
@@ -444,7 +449,7 @@ Field meanings:
 - `render_hash <tick> <frame> <scene> <objects> <lines> <hash>`: compact scene
   submission summary used for replay comparison.
 
-Replay and the inspector only accept the current `F15SE2_BLACKBOX 5` format.
+Replay and the inspector only accept the current `F15SE2_BLACKBOX 7` format.
 Unknown log lines are errors. This is intentional: silently accepting stale or
 malformed troubleshooting logs would make divergence analysis unreliable.
 

--- a/docs/blackbox_debugging.md
+++ b/docs/blackbox_debugging.md
@@ -433,7 +433,7 @@ python3 tools/blackbox_inspect.py /tmp/f15-run.bb \
 The log starts with:
 
 ```text
-F15SE2_BLACKBOX 7
+F15SE2_BLACKBOX 8
 seed 7
 build_version v0.9.4-1-g25b4664
 ```
@@ -444,7 +444,7 @@ Event lines use internal raw ticks, not displayed-time notation:
 phase 0 start
 timer_pump 0 0
 key 120 487 1f73
-axes 121 128 128 128 128
+axes 121 240 128 128 128 128
 rng_seed 240 1234
 rng 240 3558
 frame 241 19 1a2b3c4d
@@ -464,7 +464,7 @@ Field meanings:
 - `key <tick> <input_pump> <bios_word_hex>`: BIOS-style key word and the exact
   shared-input polling call that observed it. The pump sequence remains ordered
   while static menu/death screens have their 60 Hz timer stopped.
-- `axes <tick> <rawX> <rawY> <joyX> <joyY>`: virtual-stick and joystick axes.
+- `axes <tick> <inputPump> <rawX> <rawY> <joyX> <joyY>`: virtual-stick and joystick axes, applied at their recorded input poll even when several polls share a tick.
 - `rng_seed <tick> <seed>`: deterministic RNG reseed.
 - `rng <tick> <value>`: deterministic 15-bit RNG output.
 - `frame <tick> <frame_index> <hash>`: pre-overlay indexed-page checksum for a
@@ -478,7 +478,7 @@ Field meanings:
 - `render_hash <tick> <frame> <scene> <objects> <lines> <hash>`: compact scene
   submission summary used for replay comparison.
 
-Replay and the inspector only accept the current `F15SE2_BLACKBOX 7` format.
+Replay and the inspector only accept the current `F15SE2_BLACKBOX 8` format.
 Unknown log lines are errors. This is intentional: silently accepting stale or
 malformed troubleshooting logs would make divergence analysis unreliable.
 

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -30,6 +30,7 @@ extern "C" {
 #include "common.h" /* openFile */
 #include "input.h"  /* input_keyWaiting / input_setMode */
 #include "log.h"
+#include "shared/blackbox.h"
 #include "shared/blackbox_wait.h"
 
 #define ASND_OUT_RATE 44100 /* SDL output sample rate (Hz) */
@@ -232,7 +233,11 @@ int FAR CDECL audio_shutdown(void) {
 }
 
 int FAR CDECL audio_playSound(int soundId) {
-    if (!g_ready) return 0;
+    /* Fast-forward advances many simulated seconds per wall-clock second. Do
+     * not serialize every historical sound update against the real-time audio
+     * callback: audio is not simulation state, and fresh updates resume at the
+     * target tick. This also prevents a backlog of obsolete sounds. */
+    if (!g_ready || blackbox_fastForwarding()) return 0;
     SDL_LockMutex(g_lock);
     int r = sound_driver_dispatch_sound((AsoundU16)soundId);
     SDL_UnlockMutex(g_lock);
@@ -300,7 +305,7 @@ int FAR CDECL audio_playIntro(void) {
 }
 
 int FAR CDECL audio_engineDroneOn(void) {
-    if (!g_ready) return 0;
+    if (!g_ready || blackbox_fastForwarding()) return 0;
     SDL_LockMutex(g_lock);
     sound_driver_enable_drone();
     asopl_set_drone_enable(&g_opl, 1);
@@ -309,7 +314,7 @@ int FAR CDECL audio_engineDroneOn(void) {
 }
 
 int FAR CDECL audio_engineDroneOff(void) {
-    if (!g_ready) return 0;
+    if (!g_ready || blackbox_fastForwarding()) return 0;
     SDL_LockMutex(g_lock);
     sound_driver_disable_drone();
     asopl_set_drone_enable(&g_opl, 0);
@@ -319,7 +324,7 @@ int FAR CDECL audio_engineDroneOff(void) {
 
 int FAR CDECL audio_setEnginePitch(int knots, int thrust) {
     (void)thrust; /* the original ASOUND set_drone_pitch slot used only the first arg */
-    if (!g_ready) return 0;
+    if (!g_ready || blackbox_fastForwarding()) return 0;
     AsoundU16 pitch = (knots < 0) ? 0 : (knots > 0x02bc ? 0x02bc : (AsoundU16)knots);
     SDL_LockMutex(g_lock);
     sound_driver_set_drone_pitch(pitch);
@@ -329,7 +334,7 @@ int FAR CDECL audio_setEnginePitch(int knots, int thrust) {
 }
 
 int FAR CDECL audio_playSample(int sampleIdx) {
-    if (!g_ready) return 0;
+    if (!g_ready || blackbox_fastForwarding()) return 0;
     SDL_LockMutex(g_lock);
     int r = sound_driver_play_sample((AsoundU16)sampleIdx);
     SDL_UnlockMutex(g_lock);

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -30,6 +30,7 @@ extern "C" {
 #include "common.h" /* openFile */
 #include "input.h"  /* input_keyWaiting / input_setMode */
 #include "log.h"
+#include "shared/blackbox_wait.h"
 
 #define ASND_OUT_RATE 44100 /* SDL output sample rate (Hz) */
 #define ASND_TICK_HZ 60     /* sequencer tick = game tick rate */
@@ -264,20 +265,27 @@ int FAR CDECL audio_playIntro(void) {
     SDL_UnlockMutex(g_lock);
 
     input_setMode(INPUT_MODE_MENU);
-    Uint64 deadline = SDL_GetTicksNS() + 15 * SDL_NS_PER_SECOND;
-    while (asnd_introVoicesActive() && !input_keyWaiting() &&
-           SDL_GetTicksNS() < deadline) {
-        SDL_DelayNS(2 * SDL_NS_PER_MS); /* input_keyWaiting() pumps the clock */
-    }
+    if (blackbox_virtualWait(15u * 60u, 1, input_keyWaiting)) {
+        SDL_LockMutex(g_lock);
+        asound_driver_start_intro_rel(sound_driver_state());
+        SDL_UnlockMutex(g_lock);
+        blackbox_virtualWait(2u * 60u, 0, input_keyWaiting);
+    } else {
+        Uint64 deadline = SDL_GetTicksNS() + 15 * SDL_NS_PER_SECOND;
+        while (asnd_introVoicesActive() && !input_keyWaiting() &&
+               SDL_GetTicksNS() < deadline) {
+            SDL_DelayNS(2 * SDL_NS_PER_MS); /* input_keyWaiting() pumps the clock */
+        }
 
-    /* release tail (adlib_start_intro_release), then let it decay out */
-    SDL_LockMutex(g_lock);
-    asound_driver_start_intro_rel(sound_driver_state());
-    SDL_UnlockMutex(g_lock);
-    deadline = SDL_GetTicksNS() + 2 * SDL_NS_PER_SECOND;
-    while (asnd_introVoicesActive() && SDL_GetTicksNS() < deadline) {
-        SDL_DelayNS(2 * SDL_NS_PER_MS);
-        input_keyWaiting();
+        /* release tail (adlib_start_intro_release), then let it decay out */
+        SDL_LockMutex(g_lock);
+        asound_driver_start_intro_rel(sound_driver_state());
+        SDL_UnlockMutex(g_lock);
+        deadline = SDL_GetTicksNS() + 2 * SDL_NS_PER_SECOND;
+        while (asnd_introVoicesActive() && SDL_GetTicksNS() < deadline) {
+            SDL_DelayNS(2 * SDL_NS_PER_MS);
+            input_keyWaiting();
+        }
     }
 
     /* silence the chip (adlib_reset_state) */

--- a/src/egmath.c
+++ b/src/egmath.c
@@ -15,6 +15,7 @@
 #include "slot.h"
 #include "const.h"
 #include "r3d.h"
+#include "strand.h"
 
 #include <dos.h>
 #include <memory.h>
@@ -489,16 +490,18 @@ int16 signOf(int16 value) { /* Original: sgn(x). Return -1, 0, or 1. */
 
 void seedRng(void) {
     if (g_inputDisabled == 0) {
-        g_rngSeed = getTimeOfDay();
+        gameSrandFromClock(&g_rngSeed);
+    } else {
+        gameSrand((uint32)g_rngSeed);
     }
-    srand(g_rngSeed);
 }
 
 // ==== seg000:0xd200 randomRange ====
 int randomRange(int maxVal) { /* Original: rnd(Max). Deterministic ((long)Max * rand()) >> 15 range scaling. */
     enum { RAND_SCALE_SHIFT = 15 };
     /* DOS rand() is 15-bit (RAND_MAX 0x7fff); mask to match so the >>15 scaling yields [0, maxVal). */
-    return (int)(((long)(rand() & 0x7fff) * (long)maxVal) >> RAND_SCALE_SHIFT);
+    int randValue = gameRand15();
+    return (int)(((long)randValue * (long)maxVal) >> RAND_SCALE_SHIFT);
 }
 
 /* One axis of a gun's dispersion, in 16-bit angle units (0x10000 = full turn,

--- a/src/egsys.c
+++ b/src/egsys.c
@@ -8,6 +8,8 @@
 #include "egdata.h"
 #include "inttype.h"
 #include "gfx.h"
+#include "shared/blackbox.h"
+#include "shared/blackbox_diag.h"
 
 /* per-frame work reconstructed in their own TUs (egflight/egtacmap/egframe),
  * not surfaced in a header; declared here for the game loop below. */
@@ -345,10 +347,13 @@ void gameMainLoop(void) {
     objCapture(simPrev, projPrev);
 
     do {
-        uint64 nowNs = timerNowNs();
+        uint64 nowNs;
+        if (blackbox_enabled()) timerPump();
+        nowNs = timerNowNs();
         accumNs += nowNs - prevNs;
         prevNs = nowNs;
-        timerPump(); /* advance the 60 Hz tick counters + per-tick / colour-cycle hook */
+        if (!blackbox_enabled())
+            timerPump(); /* advance the 60 Hz tick counters + per-tick / colour-cycle hook */
 
         steps = 0;
         while (accumNs >= simStepNs) {
@@ -357,6 +362,7 @@ void gameMainLoop(void) {
             objCapture(simPrev, projPrev); /* prev = live = previous step's result */
             stepFlightModel();
             updateFrame();
+            blackbox_diagCaptureSimStep();
             camCapture(&camNext);
             objCapture(simNext, projNext); /* next = live = this step's result */
             if (g_initPhase < 2) {
@@ -381,6 +387,7 @@ void gameMainLoop(void) {
          * and the moving objects. The director/target/crash views track an
          * object, but that object (and the player coords they bear against) are
          * now interpolated too, so the whole view stays coherent and smooth. */
+        blackbox_diagBeginRenderFrame();
         camApplyInterp(&camPrev, &camNext, (int64)accumNs, (int64)simStepNs);
         objApplyInterp(simPrev, simNext, projPrev, projNext, (int64)accumNs, (int64)simStepNs);
         renderFrame();

--- a/src/egsys.c
+++ b/src/egsys.c
@@ -348,6 +348,9 @@ void gameMainLoop(void) {
 
     do {
         uint64 nowNs;
+        /* Record and replay consume the same pump-before-clock sequence. In
+         * record mode the pump is paced by native 60 Hz time; replay consumes
+         * the recorded per-pump tick count. */
         if (blackbox_enabled()) timerPump();
         nowNs = timerNowNs();
         accumNs += nowNs - prevNs;

--- a/src/f15.c
+++ b/src/f15.c
@@ -109,6 +109,11 @@ int main(int argc, char *argv[]) {
             usage(1);
         }
     }
+#ifdef F15_BLACKBOX_AUTO_RECORD
+    /* Debug builds collect a reproducible report by default. Explicit blackbox
+     * modes parsed above always take precedence over this local fallback. */
+    blackbox_cliApplyDebugDefaults(&blackboxOptions);
+#endif
     if (!blackbox_cliStart(&blackboxOptions)) goto shutdown;
 
     if (!verifyGameAssets()) goto shutdown;

--- a/src/f15.c
+++ b/src/f15.c
@@ -21,6 +21,8 @@
 #include "joystick.h"
 #include "r3d.h"
 #include "input.h"
+#include "shared/blackbox.h"
+#include "shared/blackbox_cli.h"
 
 #include <stdio.h>
 #include <stddef.h>
@@ -70,20 +72,24 @@ static void app_quit(void) {
     joy_shutdown();
     r3d_shutdown();
     gfx_videoShutdown();
+    blackbox_shutdown();
     exit(0);
 }
 
 void usage(int errcode) {
     printf("Usage: f15se2-ex [--help] [--nointro] [--game path]\n"
-           "--nointro      Skip intro sequence\n"
-           "--game path    Path to directory containing game assets, can also use\n"
+             "--nointro      Skip intro sequence\n"
+             "--game path    Path to directory containing game assets, can also use\n"
            "               F15SE2_DIR env var, default is current directory\n");
+    blackbox_cliPrintUsage();
     exit(errcode);
 }
 
 int main(int argc, char *argv[]) {
     int16 showIntro = 1;
+    BlackboxCliOptions blackboxOptions;
     log_set_app("f15");
+    blackbox_cliInit(&blackboxOptions);
     if (!setGamePath(getenv("F15SE2_DIR"))) goto shutdown;
     /* process cmdline args */
     for (int i = 1; i < argc; ++i) {
@@ -95,11 +101,15 @@ int main(int argc, char *argv[]) {
             if (!setGamePath(argv[i + 1])) goto shutdown;
             i++;
         }
+        else if (int parsed = blackbox_cliParseOption(&blackboxOptions, argc, argv, &i); parsed != 0) {
+            if (parsed < 0) usage(1);
+        }
         else {
             printf("Unrecognized option: '%s'\n", optStr);
             usage(1);
         }
     }
+    if (!blackbox_cliStart(&blackboxOptions)) goto shutdown;
 
     if (!verifyGameAssets()) goto shutdown;
     gfx_videoInit();
@@ -110,16 +120,19 @@ int main(int argc, char *argv[]) {
     while (true) {
         int err;
         log_set_app("start");
+        blackbox_logPhase("start");
         err = start_main();
         log_set_app("f15");
         if (err != RET_MENU) break;
 
         log_set_app("egame");
+        blackbox_logPhase("egame");
         err = egame_main();
         log_set_app("f15");
         if (err == 0) break;
 
         log_set_app("end");
+        blackbox_logPhase("end");
         err = end_main();
         log_set_app("f15");
         if (err != RET_DEBRIEFING) break;
@@ -129,5 +142,6 @@ shutdown:
     joy_shutdown();
     r3d_shutdown();
     gfx_videoShutdown();
+    blackbox_shutdown();
     return 0;
 }

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -11,6 +11,7 @@
 #include "struct.h"
 #include "log.h"
 #include "version.h"
+#include "shared/blackbox.h"
 #include <dos.h>
 #include <stdio.h>
 
@@ -509,11 +510,17 @@ void gfx_repaint(void) {
      * frame, so skip the bare re-present. Pure-2D screens (menus/briefing/debrief,
      * which block in key-waits and produce no frame of their own) still need it. */
     if (r3dgl_active() && r3dgl_flightLive()) return;
+    /* Expose/resize redraws depend on the host window manager. They may present
+     * pixels, but they are not logical game frames and therefore must not enter
+     * the blackbox frame stream. */
+    blackbox_beginPassivePresent();
     if (g_repaintHook) {
         g_repaintHook();
+        blackbox_endPassivePresent();
         return;
     }
     gfx_presentPage(0);
+    blackbox_endPassivePresent();
 }
 
 

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -676,20 +676,22 @@ static void drawStringCore(int16 *params, const char *string,
             uint8 *glyph = bitmaps + (ch - 0x20) * (uint16)rowSize;
             for (row = 0; row < height; row++) {
                 int py = y + row;
-                uint8 bits;
+                const uint8 bits = glyph[row];
                 uint8 *dstRow;
                 if (py < clipT || py > clipB) continue; /* row outside window */
                 if (py < 0 || py >= surfH) continue;    /* off the surface */
-                bits = glyph[row];
                 dstRow = base + (size_t)py * pitch;
                 for (col = 0; col < 8; col++) {
                     int px = x + col;
-                    if ((bits & 0x80) && px >= clipL && px <= clipR &&
+                    /* Glyph rows are packed MSB first. Test each source bit
+                     * directly so integer promotion cannot affect later
+                     * columns differently between GCC and MSVC. */
+                    if ((bits & (uint8)(0x80u >> col)) != 0 &&
+                        px >= clipL && px <= clipR &&
                         px >= 0 && px < surfW) {
                         if (submit) r2d_submitPoint(px, py, color);
                         else dstRow[px] = (uint8)color;
                     }
-                    bits <<= 1;
                 }
             }
         }

--- a/src/input.c
+++ b/src/input.c
@@ -18,6 +18,8 @@
 #include "const.h"
 #include "gfx.h"
 #include "joystick.h"
+#include "shared/blackbox.h"
+#include "shared/blackbox_diag.h"
 #include <SDL3/SDL.h>
 
 /* Game tick clock (timer.c); pumped here so the window stays responsive and the
@@ -67,6 +69,14 @@ static void ringPush(uint16 word) {
     if (next == ringHead) return; /* full: drop, as the BIOS buffer would */
     keyRing[ringTail] = word;
     ringTail = next;
+    blackbox_recordKey(word);
+}
+
+static void ringPushReplay(uint16 word) {
+    int next = (ringTail + 1) % KEY_RING;
+    if (next == ringHead) return;
+    keyRing[ringTail] = word;
+    ringTail = next;
 }
 
 void input_ringReset(void) {
@@ -84,7 +94,8 @@ uint16 input_readKey(void) {
     uint16 word;
     input_pumpEvents();
     while (ringHead == ringTail) {
-        SDL_Delay(2); /* idle a touch so the wait doesn't peg a core */
+        if (!blackbox_fastForwarding())
+            SDL_Delay(2); /* idle a touch so normal waits don't peg a core */
         input_pumpEvents();
     }
     word = keyRing[ringHead];
@@ -698,10 +709,17 @@ static void pollGamepadMenu(void) {
 
 void input_pumpEvents(void) {
     SDL_Event ev;
+    uint16 replayWord;
     /* Every key-polling wait loop funnels through here, so advance the game
      * clock too: this is what drives the tick counters those loops spin on, and
      * what keeps the window responsive on a poll-only frame. */
     timerPump();
+    /* Key replay is ordered by pump calls, not only by ticks. End/menu phases
+     * can stop the timer and clear the ring between two distinct input polls. */
+    blackbox_noteInputPump();
+    if (blackbox_replaying()) {
+        while (blackbox_replayNextKey(&replayWord)) ringPushReplay(replayWord);
+    }
     while (SDL_PollEvent(&ev)) {
         joy_handleEvent(&ev); /* device hotplug, every phase */
         /* Window / system events are handled here for every phase, before any
@@ -742,6 +760,14 @@ void input_pumpEvents(void) {
                 gfx_toggleFullscreen();
                 break;
             }
+            /* Host-only diagnostic shortcut: never enqueue it as a game key, so
+             * taking a dump cannot perturb the run being investigated. */
+            if (ev.key.scancode == SDL_SCANCODE_F10 && (ev.key.mod & SDL_KMOD_CTRL) &&
+                blackbox_enabled()) {
+                blackbox_diagWriteAutomaticDump();
+                break;
+            }
+            if (blackbox_replaying()) break;
             if (g_mode == INPUT_MODE_FLIGHT) {
                 uint16 word = biosWord(ev.key.scancode, ev.key.mod);
                 if (word) ringPush(word);
@@ -753,7 +779,7 @@ void input_pumpEvents(void) {
             /* Printable characters for menu text entry arrive here already
              * shifted/localized; queue each ASCII byte in AL (AH = 0). Flight
              * takes its letters as commands from biosWord instead. */
-            if (g_mode == INPUT_MODE_MENU) {
+            if (!blackbox_replaying() && g_mode == INPUT_MODE_MENU) {
                 const char *p = ev.text.text;
                 for (; *p; ++p) {
                     unsigned char c = (unsigned char)*p;
@@ -766,10 +792,15 @@ void input_pumpEvents(void) {
         }
     }
 
+    if (blackbox_replaying()) {
+        blackbox_applyReplayAxes(&g_joyRawX, &g_joyRawY, &joyAxes[0], &joyAxes[1]);
+        return;
+    }
     if (g_mode == INPUT_MODE_FLIGHT) {
         updateStick();
         pollGamepadFlight();
     } else {
         pollGamepadMenu();
     }
+    blackbox_recordAxes(g_joyRawX, g_joyRawY, joyAxes[0], joyAxes[1]);
 }

--- a/src/r2d.c
+++ b/src/r2d.c
@@ -8,6 +8,7 @@
 #include <SDL3/SDL.h>
 #include "r2d.h"
 #include "r3d_gl.h"
+#include "shared/blackbox.h"
 
 /* The shared 256-entry VGA palette lives in the software backend (gfx_impl.c).
  * Image blits copy raw indices and never read it, but attaching it keeps an
@@ -308,11 +309,16 @@ void r2d_vectorMarkPresented(void) {
 }
 
 void r2d_present(struct SDL_Surface *page, int shakeOffset) {
+    blackbox_recordFrame(page);
     if (r3dgl_active()) {
+        /* The GL compositor draws its own final overlay after native geometry. */
         r3dgl_present(page, shakeOffset);
-        return;
+    } else if (s_swPresent) {
+        if (blackbox_fastForwarding()) return;
+        blackbox_drawDebugOverlay(page);
+        s_swPresent(page, shakeOffset);
+        blackbox_restoreDebugOverlay(page);
     }
-    if (s_swPresent) s_swPresent(page, shakeOffset);
 }
 
 const char *r2d_backendName(void) {

--- a/src/r3d.c
+++ b/src/r3d.c
@@ -3,6 +3,7 @@
  * environment wins. Software is last and always claims. */
 #include "r3d.h"
 #include "log.h"
+#include "shared/blackbox_diag.h"
 
 #include <SDL3/SDL.h> /* SDL_getenv */
 
@@ -74,7 +75,19 @@ void r3d_shutdown(void) {
 const char *r3d_backendName(void) { return g_r3d ? g_r3d->name() : "none"; }
 R3DMesh r3d_registerMesh(R3DMesh raw) { return g_r3d->registerMesh(raw); }
 void r3d_releaseMesh(R3DMesh mesh) { g_r3d->releaseMesh(mesh); }
-void r3d_beginScene(const R3DScene *scene) { g_r3d->beginScene(scene); }
-void r3d_submit(const R3DSubmit *sub) { g_r3d->submit(sub); }
-void r3d_submitLine(const R3DLine *line) { g_r3d->submitLine(line); }
-void r3d_endScene(void) { g_r3d->endScene(); }
+void r3d_beginScene(const R3DScene *scene) {
+    blackbox_diagRenderBeginScene(scene);
+    g_r3d->beginScene(scene);
+}
+void r3d_submit(const R3DSubmit *sub) {
+    blackbox_diagRenderSubmit(sub);
+    g_r3d->submit(sub);
+}
+void r3d_submitLine(const R3DLine *line) {
+    blackbox_diagRenderLine(line);
+    g_r3d->submitLine(line);
+}
+void r3d_endScene(void) {
+    g_r3d->endScene();
+    blackbox_diagRenderEndScene();
+}

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -35,6 +35,8 @@
 #include "egcode.h"
 #include "egdata.h"
 #include "egtypes.h"
+#include "shared/blackbox_gl.h"
+#include "shared/blackbox.h"
 #include "log.h"
 
 #include <stdlib.h> /* qsort */
@@ -2215,6 +2217,11 @@ void r3dgl_present(SDL_Surface *page, int shakeOffset) {
     s_sceneRendered = 0;
     s_pageComposited = 0;
     r2d_vectorMarkPresented();
+    /* Keep all GL composition and per-frame state transitions deterministic,
+     * but avoid the host-visible overlay/swap cost while catching up. */
+    if (blackbox_fastForwarding()) return;
+    blackbox_drawGlOverlay(page, shakeOffset, s_win, gfx_getPalette(),
+                           overlay2DState);
     SDL_GL_SwapWindow(s_win);
 }
 

--- a/src/shared/blackbox.c
+++ b/src/shared/blackbox.c
@@ -40,6 +40,9 @@ enum {
     BLACKBOX_RAND_MASK = 0x7fff,
     BLACKBOX_MAX_KEY_WORD = 0xffff,
     BLACKBOX_MAX_AXIS_VALUE = 0xff,
+    /* timer.c resynchronizes after 250 ms. At 60 Hz, a valid call can emit at
+     * most the due tick plus fifteen catch-up ticks. */
+    BLACKBOX_MAX_TIMER_PUMP_TICKS = 16,
     BLACKBOX_DEBUG_BG = 0,
     BLACKBOX_DEBUG_FG = 15
 };
@@ -324,6 +327,12 @@ int blackbox_startReplay(const char *path) {
             s_seed = seed ? seed : BLACKBOX_DEFAULT_SEED;
             s_rngState = s_seed;
         } else if (sscanf(line, "timer_pump %u %u", &tick, &tickCount) == 2) {
+            if (tickCount > BLACKBOX_MAX_TIMER_PUMP_TICKS) {
+                log_error("blackbox: invalid timer-pump count in replay log: %s", line);
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
             if (!blackbox_appendTimerPump((uint32)tick, (uint32)tickCount)) {
                 fclose(f);
                 blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);

--- a/src/shared/blackbox.c
+++ b/src/shared/blackbox.c
@@ -35,7 +35,7 @@ void blackbox_diagOnTick(void) __attribute__((weak));
 #endif
 
 enum {
-    BLACKBOX_FILE_VERSION = 5,
+    BLACKBOX_FILE_VERSION = 7,
     BLACKBOX_TIMER_HZ = 60,
     BLACKBOX_RAND_MASK = 0x7fff,
     BLACKBOX_MAX_KEY_WORD = 0xffff,
@@ -74,6 +74,11 @@ typedef struct BlackboxFrameEvent {
     uint32 hash;
 } BlackboxFrameEvent;
 
+typedef struct BlackboxTimerPumpEvent {
+    uint32 startTick;
+    uint32 tickCount;
+} BlackboxTimerPumpEvent;
+
 static BlackboxMode s_mode = BLACKBOX_OFF;
 static FILE *s_file = NULL;
 static uint32 s_tick = 0;
@@ -104,6 +109,11 @@ static size_t s_frameCount = 0;
 static size_t s_frameCapacity = 0;
 static size_t s_framePos = 0;
 static uint32 s_frameIndex = 0;
+static BlackboxTimerPumpEvent *s_timerPumps = NULL;
+static size_t s_timerPumpCount = 0;
+static size_t s_timerPumpCapacity = 0;
+static size_t s_timerPumpPos = 0;
+static int s_reportedTimerPumpDivergence = 0;
 static int s_reportedSeedDivergence = 0;
 static int s_reportedRandDivergence = 0;
 static int s_reportedFrameDivergence = 0;
@@ -136,11 +146,13 @@ static void blackbox_resetReplayData(void) {
     free(s_randEvents);
     free(s_seedEvents);
     free(s_frames);
+    free(s_timerPumps);
     s_keys = NULL;
     s_axes = NULL;
     s_randEvents = NULL;
     s_seedEvents = NULL;
     s_frames = NULL;
+    s_timerPumps = NULL;
     s_keyCount = 0;
     s_keyCapacity = 0;
     s_keyPos = 0;
@@ -157,6 +169,9 @@ static void blackbox_resetReplayData(void) {
     s_frameCapacity = 0;
     s_framePos = 0;
     s_frameIndex = 0;
+    s_timerPumpCount = 0;
+    s_timerPumpCapacity = 0;
+    s_timerPumpPos = 0;
     s_currentAxes.tick = 0;
     s_currentAxes.rawX = 0x80;
     s_currentAxes.rawY = 0x80;
@@ -214,6 +229,15 @@ static int blackbox_appendAxes(uint32 tick, uint8 rawX, uint8 rawY, uint8 joyX, 
     return 1;
 }
 
+static int blackbox_appendTimerPump(uint32 startTick, uint32 tickCount) {
+    if (!reserveEvents((void **)&s_timerPumps, &s_timerPumpCapacity,
+                       s_timerPumpCount, sizeof(*s_timerPumps))) return 0;
+    s_timerPumps[s_timerPumpCount].startTick = startTick;
+    s_timerPumps[s_timerPumpCount].tickCount = tickCount;
+    s_timerPumpCount++;
+    return 1;
+}
+
 static int blackbox_validAxes(unsigned rawX, unsigned rawY, unsigned joyX, unsigned joyY) {
     return rawX <= BLACKBOX_MAX_AXIS_VALUE && rawY <= BLACKBOX_MAX_AXIS_VALUE &&
            joyX <= BLACKBOX_MAX_AXIS_VALUE && joyY <= BLACKBOX_MAX_AXIS_VALUE;
@@ -238,6 +262,7 @@ static void blackbox_resetState(BlackboxMode mode, uint32 seed) {
     s_reportedSeedDivergence = 0;
     s_reportedRandDivergence = 0;
     s_reportedFrameDivergence = 0;
+    s_reportedTimerPumpDivergence = 0;
     s_passivePresentDepth = 0;
     s_overlayPage = NULL;
     s_overlayWidth = 0;
@@ -293,11 +318,17 @@ int blackbox_startReplay(const char *path) {
     }
 
     while (fgets(line, sizeof(line), f)) {
-        unsigned tick, inputPump, word, rawX, rawY, joyX, joyY, seed, frame, hash;
+        unsigned tick, inputPump, word, rawX, rawY, joyX, joyY, seed, frame, hash, tickCount;
         int randValue;
         if (sscanf(line, "seed %u", &seed) == 1) {
             s_seed = seed ? seed : BLACKBOX_DEFAULT_SEED;
             s_rngState = s_seed;
+        } else if (sscanf(line, "timer_pump %u %u", &tick, &tickCount) == 2) {
+            if (!blackbox_appendTimerPump((uint32)tick, (uint32)tickCount)) {
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
         } else if (sscanf(line, "rng_seed %u %u", &tick, &seed) == 2) {
             if (!blackbox_appendSeed((uint32)tick, seed ? (uint32)seed : BLACKBOX_DEFAULT_SEED)) {
                 fclose(f);
@@ -364,9 +395,10 @@ int blackbox_startReplay(const char *path) {
         blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
         return 0;
     }
-    log_info("blackbox: replaying '%s', seed=%u, keys=%u, axes=%u, rng_seeds=%u, rng=%u, frames=%u",
+    log_info("blackbox: replaying '%s', seed=%u, keys=%u, axes=%u, timer_pumps=%u, rng_seeds=%u, rng=%u, frames=%u",
              path, (unsigned)s_seed, (unsigned)s_keyCount, (unsigned)s_axesCount,
-             (unsigned)s_seedCount, (unsigned)s_randCount, (unsigned)s_frameCount);
+             (unsigned)s_timerPumpCount, (unsigned)s_seedCount,
+             (unsigned)s_randCount, (unsigned)s_frameCount);
     return 1;
 }
 
@@ -389,6 +421,10 @@ void blackbox_shutdown(void) {
         log_error("blackbox: replay presented %u of %u recorded frames",
                   (unsigned)s_framePos, (unsigned)s_frameCount);
     }
+    if (blackbox_replaying() && !pausedForInspection && s_timerPumpPos != s_timerPumpCount) {
+        log_error("blackbox: replay consumed %u of %u recorded timer-pump events",
+                  (unsigned)s_timerPumpPos, (unsigned)s_timerPumpCount);
+    }
     if (s_file) {
         fclose(s_file);
         s_file = NULL;
@@ -401,6 +437,9 @@ void blackbox_shutdown(void) {
 int blackbox_enabled(void) { return s_mode != BLACKBOX_OFF; }
 int blackbox_recording(void) { return s_mode == BLACKBOX_RECORD; }
 int blackbox_replaying(void) { return s_mode == BLACKBOX_REPLAY; }
+int blackbox_usesVirtualTime(void) {
+    return s_mode == BLACKBOX_DEBUG || s_mode == BLACKBOX_REPLAY;
+}
 int blackbox_suppressPersistentWrites(void) {
     /* Blackbox record/replay sessions are investigation artifacts, not normal
      * gameplay sessions. Keep player/profile files stable even if the run
@@ -462,6 +501,34 @@ void blackbox_afterTick(void) {
     /* Keep flight diagnostics optional for isolated core/timer tests. The game
      * links the implementation through its simulation and rendering hooks. */
     if (blackbox_diagOnTick) blackbox_diagOnTick();
+}
+
+void blackbox_recordTimerPump(uint32 startTick, uint32 tickCount) {
+    if (!blackbox_recording() || !s_file) return;
+    /* Zero-count entries are essential: they preserve which polling/render
+     * iteration observed the next real 60 Hz tick. */
+    fprintf(s_file, "timer_pump %u %u\n", (unsigned)startTick,
+            (unsigned)tickCount);
+}
+
+uint32 blackbox_replayTimerPump(void) {
+    BlackboxTimerPumpEvent event;
+    if (!blackbox_replaying()) return 0;
+    if (s_timerPumpPos >= s_timerPumpCount) {
+        if (!s_reportedTimerPumpDivergence) {
+            s_reportedTimerPumpDivergence = 1;
+            log_error("blackbox: timer-pump divergence at tick %u: replay advanced past recorded schedule",
+                      (unsigned)s_tick);
+        }
+        return 0;
+    }
+    event = s_timerPumps[s_timerPumpPos++];
+    if (event.startTick != s_tick && !s_reportedTimerPumpDivergence) {
+        s_reportedTimerPumpDivergence = 1;
+        log_error("blackbox: timer-pump divergence at tick %u: expected start tick %u",
+                  (unsigned)s_tick, (unsigned)event.startTick);
+    }
+    return event.tickCount;
 }
 
 void blackbox_noteInputPump(void) {

--- a/src/shared/blackbox.c
+++ b/src/shared/blackbox.c
@@ -1,0 +1,748 @@
+/*
+ * Deterministic blackbox recorder/replayer.
+ *
+ * The log is intentionally text: a developer or future agent can inspect a
+ * problematic timeframe with normal tools, then replay the exact input/RNG
+ * stream. Ticks are the game's deterministic 60 Hz timer ticks, not wall-clock
+ * time. Keys additionally carry an input-pump ordinal because some menu phases
+ * stop the timer while continuing to poll and clear the BIOS-style key buffer.
+ */
+#include "blackbox.h"
+#include "blackbox_diag.h"
+#include "blackbox_internal.h"
+#include "blackbox_state.h"
+#include "log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Core-only tests link blackbox.c without the flight globals that diagnostics
+ * inspect. Weak lifecycle hooks keep that useful isolation; the game itself
+ * pulls blackbox_diag.c through its input, simulation, and r3d call sites. */
+#if defined(__GNUC__) || defined(__clang__)
+#ifdef __cplusplus
+extern "C" {
+#endif
+void blackbox_diagReset(void) __attribute__((weak));
+int blackbox_diagParseReplayLine(const char *line) __attribute__((weak));
+int blackbox_diagValidateReplay(void) __attribute__((weak));
+void blackbox_diagShutdown(int pausedForInspection) __attribute__((weak));
+void blackbox_diagOnTick(void) __attribute__((weak));
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+enum {
+    BLACKBOX_FILE_VERSION = 5,
+    BLACKBOX_TIMER_HZ = 60,
+    BLACKBOX_RAND_MASK = 0x7fff,
+    BLACKBOX_MAX_KEY_WORD = 0xffff,
+    BLACKBOX_MAX_AXIS_VALUE = 0xff,
+    BLACKBOX_DEBUG_BG = 0,
+    BLACKBOX_DEBUG_FG = 15
+};
+
+typedef struct BlackboxKeyEvent {
+    uint32 tick;
+    uint32 inputPump;
+    uint16 word;
+} BlackboxKeyEvent;
+
+typedef struct BlackboxAxesEvent {
+    uint32 tick;
+    uint8 rawX;
+    uint8 rawY;
+    uint8 joyX;
+    uint8 joyY;
+} BlackboxAxesEvent;
+
+typedef struct BlackboxRandEvent {
+    uint32 tick;
+    int value;
+} BlackboxRandEvent;
+
+typedef struct BlackboxSeedEvent {
+    uint32 tick;
+    uint32 seed;
+} BlackboxSeedEvent;
+
+typedef struct BlackboxFrameEvent {
+    uint32 tick;
+    uint32 frame;
+    uint32 hash;
+} BlackboxFrameEvent;
+
+static BlackboxMode s_mode = BLACKBOX_OFF;
+static FILE *s_file = NULL;
+static uint32 s_tick = 0;
+static uint32 s_inputPump = 0;
+static uint32 s_pauseTick = 0xffffffffu;
+static uint32 s_fastForwardTick = 0xffffffffu;
+static uint32 s_seed = BLACKBOX_DEFAULT_SEED;
+static uint32 s_rngState = BLACKBOX_DEFAULT_SEED;
+
+static BlackboxKeyEvent *s_keys = NULL;
+static size_t s_keyCount = 0;
+static size_t s_keyCapacity = 0;
+static size_t s_keyPos = 0;
+static BlackboxAxesEvent *s_axes = NULL;
+static size_t s_axesCount = 0;
+static size_t s_axesCapacity = 0;
+static size_t s_axesPos = 0;
+static BlackboxRandEvent *s_randEvents = NULL;
+static size_t s_randCount = 0;
+static size_t s_randCapacity = 0;
+static size_t s_randPos = 0;
+static BlackboxSeedEvent *s_seedEvents = NULL;
+static size_t s_seedCount = 0;
+static size_t s_seedCapacity = 0;
+static size_t s_seedPos = 0;
+static BlackboxFrameEvent *s_frames = NULL;
+static size_t s_frameCount = 0;
+static size_t s_frameCapacity = 0;
+static size_t s_framePos = 0;
+static uint32 s_frameIndex = 0;
+static int s_reportedSeedDivergence = 0;
+static int s_reportedRandDivergence = 0;
+static int s_reportedFrameDivergence = 0;
+static unsigned s_passivePresentDepth = 0;
+static SDL_Surface *s_overlayPage = NULL;
+static uint8 s_overlayBackup[7][52];
+static int s_overlayWidth = 0;
+static int s_overlayHeight = 0;
+static BlackboxAxesEvent s_currentAxes = {0, 0x80, 0x80, 0x80, 0x80};
+static int s_haveRecordedAxes = 0;
+static BlackboxAxesEvent s_lastRecordedAxes = {0, 0x80, 0x80, 0x80, 0x80};
+
+static int reserveEvents(void **events, size_t *capacity, size_t count,
+                         size_t eventSize) {
+    size_t newCapacity;
+    void *next;
+    if (count < *capacity) return 1;
+    newCapacity = *capacity ? *capacity * 2u : 64u;
+    if (newCapacity <= *capacity || newCapacity > SIZE_MAX / eventSize) return 0;
+    next = realloc(*events, newCapacity * eventSize);
+    if (!next) return 0;
+    *events = next;
+    *capacity = newCapacity;
+    return 1;
+}
+
+static void blackbox_resetReplayData(void) {
+    free(s_keys);
+    free(s_axes);
+    free(s_randEvents);
+    free(s_seedEvents);
+    free(s_frames);
+    s_keys = NULL;
+    s_axes = NULL;
+    s_randEvents = NULL;
+    s_seedEvents = NULL;
+    s_frames = NULL;
+    s_keyCount = 0;
+    s_keyCapacity = 0;
+    s_keyPos = 0;
+    s_axesCount = 0;
+    s_axesCapacity = 0;
+    s_axesPos = 0;
+    s_randCount = 0;
+    s_randCapacity = 0;
+    s_randPos = 0;
+    s_seedCount = 0;
+    s_seedCapacity = 0;
+    s_seedPos = 0;
+    s_frameCount = 0;
+    s_frameCapacity = 0;
+    s_framePos = 0;
+    s_frameIndex = 0;
+    s_currentAxes.tick = 0;
+    s_currentAxes.rawX = 0x80;
+    s_currentAxes.rawY = 0x80;
+    s_currentAxes.joyX = 0x80;
+    s_currentAxes.joyY = 0x80;
+}
+
+static int blackbox_appendSeed(uint32 tick, uint32 seed) {
+    if (!reserveEvents((void **)&s_seedEvents, &s_seedCapacity,
+                       s_seedCount, sizeof(*s_seedEvents))) return 0;
+    s_seedEvents[s_seedCount].tick = tick;
+    s_seedEvents[s_seedCount].seed = seed;
+    s_seedCount++;
+    return 1;
+}
+
+static int blackbox_appendFrame(uint32 tick, uint32 frame, uint32 hash) {
+    if (!reserveEvents((void **)&s_frames, &s_frameCapacity,
+                       s_frameCount, sizeof(*s_frames))) return 0;
+    s_frames[s_frameCount].tick = tick;
+    s_frames[s_frameCount].frame = frame;
+    s_frames[s_frameCount].hash = hash;
+    s_frameCount++;
+    return 1;
+}
+
+static int blackbox_appendRand(uint32 tick, int value) {
+    if (!reserveEvents((void **)&s_randEvents, &s_randCapacity,
+                       s_randCount, sizeof(*s_randEvents))) return 0;
+    s_randEvents[s_randCount].tick = tick;
+    s_randEvents[s_randCount].value = value;
+    s_randCount++;
+    return 1;
+}
+
+static int blackbox_appendKey(uint32 tick, uint32 inputPump, uint16 word) {
+    if (!reserveEvents((void **)&s_keys, &s_keyCapacity,
+                       s_keyCount, sizeof(*s_keys))) return 0;
+    s_keys[s_keyCount].tick = tick;
+    s_keys[s_keyCount].inputPump = inputPump;
+    s_keys[s_keyCount].word = word;
+    s_keyCount++;
+    return 1;
+}
+
+static int blackbox_appendAxes(uint32 tick, uint8 rawX, uint8 rawY, uint8 joyX, uint8 joyY) {
+    if (!reserveEvents((void **)&s_axes, &s_axesCapacity,
+                       s_axesCount, sizeof(*s_axes))) return 0;
+    s_axes[s_axesCount].tick = tick;
+    s_axes[s_axesCount].rawX = rawX;
+    s_axes[s_axesCount].rawY = rawY;
+    s_axes[s_axesCount].joyX = joyX;
+    s_axes[s_axesCount].joyY = joyY;
+    s_axesCount++;
+    return 1;
+}
+
+static int blackbox_validAxes(unsigned rawX, unsigned rawY, unsigned joyX, unsigned joyY) {
+    return rawX <= BLACKBOX_MAX_AXIS_VALUE && rawY <= BLACKBOX_MAX_AXIS_VALUE &&
+           joyX <= BLACKBOX_MAX_AXIS_VALUE && joyY <= BLACKBOX_MAX_AXIS_VALUE;
+}
+
+static void blackbox_resetState(BlackboxMode mode, uint32 seed) {
+    if (s_file) {
+        fclose(s_file);
+        s_file = NULL;
+    }
+    blackbox_resetReplayData();
+    blackbox_state_reset();
+    if (blackbox_diagReset) blackbox_diagReset();
+    s_mode = mode;
+    s_tick = 0;
+    s_inputPump = 0;
+    s_pauseTick = 0xffffffffu;
+    s_fastForwardTick = 0xffffffffu;
+    s_seed = seed ? seed : BLACKBOX_DEFAULT_SEED;
+    s_rngState = s_seed;
+    s_haveRecordedAxes = 0;
+    s_reportedSeedDivergence = 0;
+    s_reportedRandDivergence = 0;
+    s_reportedFrameDivergence = 0;
+    s_passivePresentDepth = 0;
+    s_overlayPage = NULL;
+    s_overlayWidth = 0;
+    s_overlayHeight = 0;
+    s_lastRecordedAxes.tick = 0;
+    s_lastRecordedAxes.rawX = 0x80;
+    s_lastRecordedAxes.rawY = 0x80;
+    s_lastRecordedAxes.joyX = 0x80;
+    s_lastRecordedAxes.joyY = 0x80;
+}
+
+int blackbox_startDebug(uint32 seed) {
+    blackbox_resetState(BLACKBOX_DEBUG, seed);
+    log_info("blackbox: debug deterministic mode, seed=%u", (unsigned)s_seed);
+    return 1;
+}
+
+int blackbox_startRecord(const char *path, uint32 seed) {
+    blackbox_resetState(BLACKBOX_RECORD, seed);
+    s_file = fopen(path, "w");
+    if (!s_file) {
+        log_error("blackbox: unable to open record log '%s'", path);
+        blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+        return 0;
+    }
+    fprintf(s_file, "F15SE2_BLACKBOX %d\n", BLACKBOX_FILE_VERSION);
+    fprintf(s_file, "seed %u\n", (unsigned)s_seed);
+    blackbox_state_writeRecordHeader(s_file);
+    fflush(s_file);
+    log_info("blackbox: recording '%s', seed=%u", path, (unsigned)s_seed);
+    return 1;
+}
+
+int blackbox_startReplay(const char *path) {
+    char line[8192];
+    unsigned version = 0;
+    FILE *f;
+
+    blackbox_resetState(BLACKBOX_REPLAY, BLACKBOX_DEFAULT_SEED);
+    f = fopen(path, "r");
+    if (!f) {
+        log_error("blackbox: unable to open replay log '%s'", path);
+        blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+        return 0;
+    }
+
+    if (!fgets(line, sizeof(line), f) || sscanf(line, "F15SE2_BLACKBOX %u", &version) != 1 ||
+        version != BLACKBOX_FILE_VERSION) {
+        log_error("blackbox: unsupported replay log '%s'", path);
+        fclose(f);
+        blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+        return 0;
+    }
+
+    while (fgets(line, sizeof(line), f)) {
+        unsigned tick, inputPump, word, rawX, rawY, joyX, joyY, seed, frame, hash;
+        int randValue;
+        if (sscanf(line, "seed %u", &seed) == 1) {
+            s_seed = seed ? seed : BLACKBOX_DEFAULT_SEED;
+            s_rngState = s_seed;
+        } else if (sscanf(line, "rng_seed %u %u", &tick, &seed) == 2) {
+            if (!blackbox_appendSeed((uint32)tick, seed ? (uint32)seed : BLACKBOX_DEFAULT_SEED)) {
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+        } else if (sscanf(line, "rng %u %d", &tick, &randValue) == 2) {
+            if (!blackbox_appendRand((uint32)tick, randValue)) {
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+        } else if (sscanf(line, "frame %u %u %x", &tick, &frame, &hash) == 3) {
+            if (!blackbox_appendFrame((uint32)tick, (uint32)frame, (uint32)hash)) {
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+        } else if (sscanf(line, "key %u %u %x", &tick, &inputPump, &word) == 3) {
+            if (word > BLACKBOX_MAX_KEY_WORD) {
+                log_error("blackbox: invalid key word in replay log: %s", line);
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+            if (!blackbox_appendKey((uint32)tick, (uint32)inputPump, (uint16)word)) {
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+        } else if (sscanf(line, "axes %u %u %u %u %u", &tick, &rawX, &rawY, &joyX, &joyY) == 5) {
+            if (!blackbox_validAxes(rawX, rawY, joyX, joyY)) {
+                log_error("blackbox: invalid axes values in replay log: %s", line);
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+            if (!blackbox_appendAxes((uint32)tick, (uint8)rawX, (uint8)rawY, (uint8)joyX, (uint8)joyY)) {
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+        } else if (sscanf(line, "phase %u", &tick) == 1) {
+            /* Phase markers are for human/agent navigation; replay logic does not consume them. */
+        } else {
+            int parsed = blackbox_diagParseReplayLine ? blackbox_diagParseReplayLine(line) : 0;
+            if (parsed == 0) parsed = blackbox_state_parseReplayLine(line);
+            if (parsed > 0) continue;
+            if (parsed < 0) {
+                log_error("blackbox: invalid replay metadata line: %s", line);
+                fclose(f);
+                blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+                return 0;
+            }
+            log_error("blackbox: unknown replay log line: %s", line);
+            fclose(f);
+            blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+            return 0;
+        }
+    }
+    fclose(f);
+    if (!blackbox_state_validateReplay() ||
+        (blackbox_diagValidateReplay && !blackbox_diagValidateReplay())) {
+        blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
+        return 0;
+    }
+    log_info("blackbox: replaying '%s', seed=%u, keys=%u, axes=%u, rng_seeds=%u, rng=%u, frames=%u",
+             path, (unsigned)s_seed, (unsigned)s_keyCount, (unsigned)s_axesCount,
+             (unsigned)s_seedCount, (unsigned)s_randCount, (unsigned)s_frameCount);
+    return 1;
+}
+
+void blackbox_shutdown(void) {
+    int pausedForInspection = blackbox_pauseReached();
+    if (blackbox_diagShutdown) blackbox_diagShutdown(pausedForInspection);
+    if (blackbox_replaying() && !pausedForInspection && s_keyPos != s_keyCount) {
+        log_error("blackbox: replay consumed %u of %u recorded key events",
+                  (unsigned)s_keyPos, (unsigned)s_keyCount);
+    }
+    if (blackbox_replaying() && !pausedForInspection && s_seedPos != s_seedCount) {
+        log_error("blackbox: replay consumed %u of %u recorded RNG seed events",
+                  (unsigned)s_seedPos, (unsigned)s_seedCount);
+    }
+    if (blackbox_replaying() && !pausedForInspection && s_randPos != s_randCount) {
+        log_error("blackbox: replay consumed %u of %u recorded RNG values",
+                  (unsigned)s_randPos, (unsigned)s_randCount);
+    }
+    if (blackbox_replaying() && !pausedForInspection && s_framePos != s_frameCount) {
+        log_error("blackbox: replay presented %u of %u recorded frames",
+                  (unsigned)s_framePos, (unsigned)s_frameCount);
+    }
+    if (s_file) {
+        fclose(s_file);
+        s_file = NULL;
+    }
+    blackbox_resetReplayData();
+    blackbox_state_reset();
+    s_mode = BLACKBOX_OFF;
+}
+
+int blackbox_enabled(void) { return s_mode != BLACKBOX_OFF; }
+int blackbox_recording(void) { return s_mode == BLACKBOX_RECORD; }
+int blackbox_replaying(void) { return s_mode == BLACKBOX_REPLAY; }
+int blackbox_suppressPersistentWrites(void) {
+    /* Blackbox record/replay sessions are investigation artifacts, not normal
+     * gameplay sessions. Keep player/profile files stable even if the run
+     * reaches death, debrief, or any other code path that normally saves
+     * progress. The recorder itself writes its log through fopen(), not through
+     * createFile(), so this does not block the .bb file. */
+    return blackbox_recording() || blackbox_replaying();
+}
+FILE *blackbox_internalRecordFile(void) {
+    return blackbox_recording() ? s_file : NULL;
+}
+void blackbox_setBuildVersion(const char *version) { blackbox_state_setBuildVersion(version); }
+void blackbox_setAllowBuildMismatch(int allow) { blackbox_state_setAllowBuildMismatch(allow); }
+uint32 blackbox_tick(void) { return s_tick; }
+void blackbox_getDebugState(BlackboxDebugState *state) {
+    if (!state) return;
+    state->mode = s_mode;
+    state->tick = s_tick;
+    state->inputPump = s_inputPump;
+    state->pauseTick = s_pauseTick;
+    state->fastForwardTick = s_fastForwardTick;
+    state->configuredSeed = s_seed;
+    state->rngState = s_rngState;
+    state->keyPosition = (uint32)s_keyPos;
+    state->keyCount = (uint32)s_keyCount;
+    state->axesPosition = (uint32)s_axesPos;
+    state->axesCount = (uint32)s_axesCount;
+    state->seedPosition = (uint32)s_seedPos;
+    state->seedCount = (uint32)s_seedCount;
+    state->rngPosition = (uint32)s_randPos;
+    state->rngCount = (uint32)s_randCount;
+    state->framePosition = (uint32)s_framePos;
+    state->frameCount = (uint32)s_frameCount;
+    state->frameIndex = s_frameIndex;
+}
+int blackbox_pauseReached(void) { return blackbox_enabled() && s_tick >= s_pauseTick; }
+int blackbox_fastForwarding(void) {
+    /* UINT32_MAX means the option was not supplied; it must not accidentally
+     * turn every ordinary replay into an almost-permanent fast-forward. */
+    return blackbox_replaying() && s_fastForwardTick != 0xffffffffu &&
+           s_tick < s_fastForwardTick;
+}
+
+void blackbox_setPauseTick(uint32 tick) {
+    s_pauseTick = tick;
+    log_info("blackbox: pause tick=%u", (unsigned)s_pauseTick);
+}
+
+void blackbox_setFastForwardTick(uint32 tick) {
+    s_fastForwardTick = tick;
+    log_info("blackbox: fast-forward tick=%u", (unsigned)s_fastForwardTick);
+}
+
+void blackbox_noteTick(void) {
+    if (blackbox_enabled() && !blackbox_pauseReached()) s_tick++;
+}
+
+void blackbox_afterTick(void) {
+    /* Keep flight diagnostics optional for isolated core/timer tests. The game
+     * links the implementation through its simulation and rendering hooks. */
+    if (blackbox_diagOnTick) blackbox_diagOnTick();
+}
+
+void blackbox_noteInputPump(void) {
+    /* Unlike the 60 Hz timer, this sequence advances in static menus and award
+     * screens. It therefore records which polling call made a key observable,
+     * including calls separated only by a key-buffer clear. */
+    if (blackbox_enabled()) s_inputPump++;
+}
+
+uint64 blackbox_timerNowNs(void) {
+    return (uint64)s_tick * (uint64)(1000000000u / BLACKBOX_TIMER_HZ);
+}
+
+void blackbox_seedRandom(uint32 seed) {
+    s_rngState = seed ? seed : BLACKBOX_DEFAULT_SEED;
+    if (blackbox_recording() && s_file) {
+        fprintf(s_file, "rng_seed %u %u\n", (unsigned)s_tick, (unsigned)s_rngState);
+        fflush(s_file);
+    } else if (blackbox_replaying() && s_seedPos < s_seedCount) {
+        BlackboxSeedEvent expected = s_seedEvents[s_seedPos++];
+        /* Replay consumes the recorded seed stream as the source of truth. Tick
+         * mismatches are still useful diagnostics, but allowing a locally chosen
+         * seed through would make every later RNG value diverge and mask the
+         * first real behavioral difference. */
+        if ((expected.tick != s_tick || expected.seed != s_rngState) &&
+            !s_reportedSeedDivergence) {
+            s_reportedSeedDivergence = 1;
+            log_error("blackbox: RNG seed replay mismatch at tick %u: recorded tick %u seed %u, local seed %u",
+                      (unsigned)s_tick, (unsigned)expected.tick, (unsigned)expected.seed, (unsigned)s_rngState);
+        }
+        s_rngState = expected.seed ? expected.seed : BLACKBOX_DEFAULT_SEED;
+    } else if (blackbox_replaying() && !s_reportedSeedDivergence) {
+        s_reportedSeedDivergence = 1;
+        log_error("blackbox: RNG seed divergence at tick %u: replay seeded past recorded stream with %u",
+                  (unsigned)s_tick, (unsigned)s_rngState);
+    }
+}
+
+uint32 blackbox_seedExternalRandom(uint32 externalSeed) {
+    if (blackbox_recording()) {
+        blackbox_seedRandom(externalSeed);
+    } else if (blackbox_replaying()) {
+        if (s_seedPos < s_seedCount) {
+            BlackboxSeedEvent expected = s_seedEvents[s_seedPos++];
+            /* A wall-clock seed is expected to differ between runs. Its event
+             * position and tick are deterministic; its numeric value is not. */
+            if (expected.tick != s_tick && !s_reportedSeedDivergence) {
+                s_reportedSeedDivergence = 1;
+                log_error("blackbox: external RNG seed replay mismatch at tick %u: recorded tick %u seed %u",
+                          (unsigned)s_tick, (unsigned)expected.tick,
+                          (unsigned)expected.seed);
+            }
+            s_rngState = expected.seed ? expected.seed : BLACKBOX_DEFAULT_SEED;
+        } else if (!s_reportedSeedDivergence) {
+            s_reportedSeedDivergence = 1;
+            log_error("blackbox: external RNG seed divergence at tick %u: replay consumed past recorded stream",
+                      (unsigned)s_tick);
+        }
+    } else if (blackbox_enabled()) {
+        /* Debug mode has no recording to restore, so retain its configured seed
+         * instead of introducing wall-clock state. */
+        s_rngState = s_seed;
+    }
+    return s_rngState;
+}
+
+void blackbox_seedConfiguredRandom(void) {
+    blackbox_seedRandom(s_seed);
+}
+
+int blackbox_rand15(void) {
+    int value;
+    /* ANSI/DOS-style LCG shape: deterministic across platforms, unlike libc rand(). */
+    s_rngState = s_rngState * 1103515245u + 12345u;
+    value = (int)((s_rngState >> 16) & BLACKBOX_RAND_MASK);
+    if (blackbox_recording() && s_file) {
+        fprintf(s_file, "rng %u %d\n", (unsigned)s_tick, value);
+        fflush(s_file);
+    } else if (blackbox_replaying() && s_randPos < s_randCount) {
+        BlackboxRandEvent expected = s_randEvents[s_randPos++];
+        if ((expected.tick != s_tick || expected.value != value) &&
+            !s_reportedRandDivergence) {
+            s_reportedRandDivergence = 1;
+            log_error("blackbox: RNG replay mismatch at tick %u: recorded tick %u value %d, local value %d",
+                      (unsigned)s_tick, (unsigned)expected.tick, expected.value, value);
+        }
+        value = expected.value;
+    } else if (blackbox_replaying() && !s_reportedRandDivergence) {
+        s_reportedRandDivergence = 1;
+        log_error("blackbox: RNG divergence at tick %u: replay consumed past recorded stream, got %d",
+                  (unsigned)s_tick, value);
+    }
+    return value;
+}
+
+int blackbox_randomActive(void) {
+    return blackbox_enabled();
+}
+
+void blackbox_logPhase(const char *phase) {
+    if (!blackbox_recording() || !s_file) return;
+    fprintf(s_file, "phase %u %s\n", (unsigned)s_tick, phase ? phase : "unknown");
+    fflush(s_file);
+}
+
+void blackbox_recordKey(uint16 word) {
+    if (!blackbox_recording() || !s_file) return;
+    fprintf(s_file, "key %u %u %04x\n", (unsigned)s_tick,
+            (unsigned)s_inputPump, (unsigned)word);
+    fflush(s_file);
+}
+
+int blackbox_replayNextKey(uint16 *word) {
+    if (!blackbox_replaying() || s_keyPos >= s_keyCount) return 0;
+    if (s_keys[s_keyPos].inputPump > s_inputPump) return 0;
+    *word = s_keys[s_keyPos].word;
+    s_keyPos++;
+    return 1;
+}
+
+void blackbox_recordAxes(uint8 rawX, uint8 rawY, uint8 joyX, uint8 joyY) {
+    if (!blackbox_recording() || !s_file) return;
+    if (s_haveRecordedAxes &&
+        s_lastRecordedAxes.rawX == rawX && s_lastRecordedAxes.rawY == rawY &&
+        s_lastRecordedAxes.joyX == joyX && s_lastRecordedAxes.joyY == joyY) {
+        return;
+    }
+    s_haveRecordedAxes = 1;
+    s_lastRecordedAxes.tick = s_tick;
+    s_lastRecordedAxes.rawX = rawX;
+    s_lastRecordedAxes.rawY = rawY;
+    s_lastRecordedAxes.joyX = joyX;
+    s_lastRecordedAxes.joyY = joyY;
+    fprintf(s_file, "axes %u %u %u %u %u\n",
+            (unsigned)s_tick, (unsigned)rawX, (unsigned)rawY, (unsigned)joyX, (unsigned)joyY);
+    fflush(s_file);
+}
+
+void blackbox_applyReplayAxes(uint8 *rawX, uint8 *rawY, uint8 *joyX, uint8 *joyY) {
+    if (!blackbox_replaying()) return;
+    while (s_axesPos < s_axesCount && s_axes[s_axesPos].tick <= s_tick) {
+        s_currentAxes = s_axes[s_axesPos];
+        s_axesPos++;
+    }
+    *rawX = s_currentAxes.rawX;
+    *rawY = s_currentAxes.rawY;
+    *joyX = s_currentAxes.joyX;
+    *joyY = s_currentAxes.joyY;
+}
+
+static uint32 blackbox_hashSurface(SDL_Surface *page) {
+    uint32 hash = 2166136261u;
+    if (!page || page->format != SDL_PIXELFORMAT_INDEX8) return 0;
+    if (SDL_MUSTLOCK(page) && !SDL_LockSurface(page)) return 0;
+    for (int y = 0; y < page->h; y++) {
+        const uint8 *row = (const uint8 *)page->pixels + (size_t)y * page->pitch;
+        for (int x = 0; x < page->w; x++) {
+            hash ^= row[x];
+            hash *= 16777619u;
+        }
+    }
+    if (SDL_MUSTLOCK(page)) SDL_UnlockSurface(page);
+    return hash;
+}
+
+void blackbox_recordFrame(SDL_Surface *page) {
+    uint32 hash;
+    /* Frame hashes diagnose divergence; they must never drive the clock or
+     * otherwise affect execution. In particular, host window expose events are
+     * intentionally excluded because their timing is outside the recording. */
+    if (!blackbox_enabled() || !page || s_passivePresentDepth != 0) return;
+    hash = blackbox_hashSurface(page);
+    if (blackbox_recording() && s_file) {
+        fprintf(s_file, "frame %u %u %08x\n", (unsigned)s_tick, (unsigned)s_frameIndex, (unsigned)hash);
+        fflush(s_file);
+    } else if (blackbox_replaying() && s_framePos < s_frameCount) {
+        BlackboxFrameEvent expected = s_frames[s_framePos++];
+        if ((expected.frame != s_frameIndex || expected.tick != s_tick ||
+             expected.hash != hash) && !s_reportedFrameDivergence) {
+            s_reportedFrameDivergence = 1;
+            log_error("blackbox: frame divergence at tick %u frame %u: expected tick %u frame %u hash %08x, got %08x",
+                      (unsigned)s_tick, (unsigned)s_frameIndex, (unsigned)expected.tick,
+                      (unsigned)expected.frame, (unsigned)expected.hash, (unsigned)hash);
+        }
+    } else if (blackbox_replaying() && !s_reportedFrameDivergence) {
+        s_reportedFrameDivergence = 1;
+        log_error("blackbox: frame divergence at tick %u frame %u: replay presented past recorded stream, hash %08x",
+                  (unsigned)s_tick, (unsigned)s_frameIndex, (unsigned)hash);
+    }
+    s_frameIndex++;
+}
+
+void blackbox_beginPassivePresent(void) {
+    s_passivePresentDepth++;
+}
+
+void blackbox_endPassivePresent(void) {
+    if (s_passivePresentDepth != 0) s_passivePresentDepth--;
+}
+
+static const unsigned char kDigits[10][5] = {
+    {7, 5, 5, 5, 7}, {2, 6, 2, 2, 7}, {7, 1, 7, 4, 7}, {7, 1, 7, 1, 7}, {5, 5, 7, 1, 1},
+    {7, 4, 7, 1, 7}, {7, 4, 7, 5, 7}, {7, 1, 1, 1, 1}, {7, 5, 7, 5, 7}, {7, 5, 7, 1, 7}
+};
+
+static void putPixel(SDL_Surface *page, int x, int y, uint8 color) {
+    if (x < 0 || y < 0 || x >= page->w || y >= page->h) return;
+    ((uint8 *)page->pixels)[(size_t)y * page->pitch + x] = color;
+}
+
+static void drawDigit(SDL_Surface *page, int x, int y, int digit, uint8 color) {
+    int row, col;
+    for (row = 0; row < 5; row++) {
+        unsigned char bits = kDigits[digit][row];
+        for (col = 0; col < 3; col++) {
+            if (bits & (1u << (2 - col))) putPixel(page, x + col, y + row, color);
+        }
+    }
+}
+
+void blackbox_drawDebugOverlay(SDL_Surface *page) {
+    char text[16];
+    int i, x;
+    uint32 tick = s_tick;
+    uint64 displayedTime;
+
+    if (!blackbox_enabled() || !page || page->format != SDL_PIXELFORMAT_INDEX8 ||
+        s_overlayPage) return;
+    if (SDL_MUSTLOCK(page) && !SDL_LockSurface(page)) return;
+
+    s_overlayPage = page;
+    s_overlayWidth = page->w < 52 ? page->w : 52;
+    s_overlayHeight = page->h < 7 ? page->h : 7;
+    for (int y = 0; y < s_overlayHeight; y++) {
+        memcpy(s_overlayBackup[y],
+               (uint8 *)page->pixels + (size_t)y * page->pitch,
+               (size_t)s_overlayWidth);
+    }
+
+    for (int y = 0; y < 7 && y < page->h; y++) {
+        for (int px = 0; px < 52 && px < page->w; px++) putPixel(page, px, y, BLACKBOX_DEBUG_BG);
+    }
+
+    displayedTime = (uint64)(tick / BLACKBOX_TIMER_HZ) * 100u +
+                    (uint64)(tick % BLACKBOX_TIMER_HZ);
+    snprintf(text, sizeof(text), "%llu", (unsigned long long)displayedTime);
+    x = 1;
+    for (i = 0; text[i]; i++) {
+        if (text[i] >= '0' && text[i] <= '9') {
+            drawDigit(page, x, 1, text[i] - '0', BLACKBOX_DEBUG_FG);
+            x += 4;
+        }
+    }
+
+    if (SDL_MUSTLOCK(page)) SDL_UnlockSurface(page);
+}
+
+void blackbox_restoreDebugOverlay(SDL_Surface *page) {
+    if (!page || page != s_overlayPage) return;
+    if (SDL_MUSTLOCK(page) && !SDL_LockSurface(page)) return;
+    for (int y = 0; y < s_overlayHeight; y++) {
+        memcpy((uint8 *)page->pixels + (size_t)y * page->pitch,
+               s_overlayBackup[y], (size_t)s_overlayWidth);
+    }
+    if (SDL_MUSTLOCK(page)) SDL_UnlockSurface(page);
+    s_overlayPage = NULL;
+    s_overlayWidth = 0;
+    s_overlayHeight = 0;
+}
+
+void blackbox_captureMutableFile(const char *name, const uint8 *data, uint32 size) {
+    if (!blackbox_recording() || !s_file) return;
+    blackbox_state_recordMutableFile(s_file, name, data, size);
+}
+
+int blackbox_shouldCaptureMutableFile(const char *name) {
+    if (!blackbox_recording()) return 0;
+    return blackbox_state_shouldCaptureMutableFile(name);
+}
+
+int blackbox_replayMutableFile(const char *name, const uint8 **data, uint32 *size) {
+    if (!blackbox_replaying()) return 0;
+    return blackbox_state_getReplayMutableFile(name, data, size);
+}

--- a/src/shared/blackbox.c
+++ b/src/shared/blackbox.c
@@ -35,7 +35,7 @@ void blackbox_diagOnTick(void) __attribute__((weak));
 #endif
 
 enum {
-    BLACKBOX_FILE_VERSION = 7,
+    BLACKBOX_FILE_VERSION = 8,
     BLACKBOX_TIMER_HZ = 60,
     BLACKBOX_RAND_MASK = 0x7fff,
     BLACKBOX_MAX_KEY_WORD = 0xffff,
@@ -55,6 +55,7 @@ typedef struct BlackboxKeyEvent {
 
 typedef struct BlackboxAxesEvent {
     uint32 tick;
+    uint32 inputPump;
     uint8 rawX;
     uint8 rawY;
     uint8 joyX;
@@ -125,9 +126,9 @@ static SDL_Surface *s_overlayPage = NULL;
 static uint8 s_overlayBackup[7][52];
 static int s_overlayWidth = 0;
 static int s_overlayHeight = 0;
-static BlackboxAxesEvent s_currentAxes = {0, 0x80, 0x80, 0x80, 0x80};
+static BlackboxAxesEvent s_currentAxes = {0, 0, 0x80, 0x80, 0x80, 0x80};
 static int s_haveRecordedAxes = 0;
-static BlackboxAxesEvent s_lastRecordedAxes = {0, 0x80, 0x80, 0x80, 0x80};
+static BlackboxAxesEvent s_lastRecordedAxes = {0, 0, 0x80, 0x80, 0x80, 0x80};
 
 static int reserveEvents(void **events, size_t *capacity, size_t count,
                          size_t eventSize) {
@@ -220,10 +221,12 @@ static int blackbox_appendKey(uint32 tick, uint32 inputPump, uint16 word) {
     return 1;
 }
 
-static int blackbox_appendAxes(uint32 tick, uint8 rawX, uint8 rawY, uint8 joyX, uint8 joyY) {
+static int blackbox_appendAxes(uint32 tick, uint32 inputPump,
+                                uint8 rawX, uint8 rawY, uint8 joyX, uint8 joyY) {
     if (!reserveEvents((void **)&s_axes, &s_axesCapacity,
                        s_axesCount, sizeof(*s_axes))) return 0;
     s_axes[s_axesCount].tick = tick;
+    s_axes[s_axesCount].inputPump = inputPump;
     s_axes[s_axesCount].rawX = rawX;
     s_axes[s_axesCount].rawY = rawY;
     s_axes[s_axesCount].joyX = joyX;
@@ -368,14 +371,15 @@ int blackbox_startReplay(const char *path) {
                 blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
                 return 0;
             }
-        } else if (sscanf(line, "axes %u %u %u %u %u", &tick, &rawX, &rawY, &joyX, &joyY) == 5) {
+        } else if (sscanf(line, "axes %u %u %u %u %u %u", &tick, &inputPump, &rawX, &rawY, &joyX, &joyY) == 6) {
             if (!blackbox_validAxes(rawX, rawY, joyX, joyY)) {
                 log_error("blackbox: invalid axes values in replay log: %s", line);
                 fclose(f);
                 blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
                 return 0;
             }
-            if (!blackbox_appendAxes((uint32)tick, (uint8)rawX, (uint8)rawY, (uint8)joyX, (uint8)joyY)) {
+            if (!blackbox_appendAxes((uint32)tick, (uint32)inputPump,
+                                     (uint8)rawX, (uint8)rawY, (uint8)joyX, (uint8)joyY)) {
                 fclose(f);
                 blackbox_resetState(BLACKBOX_OFF, BLACKBOX_DEFAULT_SEED);
                 return 0;
@@ -671,14 +675,18 @@ void blackbox_recordAxes(uint8 rawX, uint8 rawY, uint8 joyX, uint8 joyY) {
     s_lastRecordedAxes.rawY = rawY;
     s_lastRecordedAxes.joyX = joyX;
     s_lastRecordedAxes.joyY = joyY;
-    fprintf(s_file, "axes %u %u %u %u %u\n",
-            (unsigned)s_tick, (unsigned)rawX, (unsigned)rawY, (unsigned)joyX, (unsigned)joyY);
+    fprintf(s_file, "axes %u %u %u %u %u %u\n",
+            (unsigned)s_tick, (unsigned)s_inputPump,
+            (unsigned)rawX, (unsigned)rawY, (unsigned)joyX, (unsigned)joyY);
     fflush(s_file);
 }
 
 void blackbox_applyReplayAxes(uint8 *rawX, uint8 *rawY, uint8 *joyX, uint8 *joyY) {
     if (!blackbox_replaying()) return;
-    while (s_axesPos < s_axesCount && s_axes[s_axesPos].tick <= s_tick) {
+    /* Several input polls can share a tick. Do not prefetch a later stick
+     * position before the poll that exposed it during recording. */
+    while (s_axesPos < s_axesCount && s_axes[s_axesPos].tick <= s_tick &&
+           s_axes[s_axesPos].inputPump <= s_inputPump) {
         s_currentAxes = s_axes[s_axesPos];
         s_axesPos++;
     }

--- a/src/shared/blackbox.h
+++ b/src/shared/blackbox.h
@@ -1,0 +1,93 @@
+#ifndef F15_SE2_BLACKBOX_H
+#define F15_SE2_BLACKBOX_H
+
+#include "inttype.h"
+#include <SDL3/SDL.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum BlackboxMode {
+    BLACKBOX_OFF = 0,
+    BLACKBOX_DEBUG,
+    BLACKBOX_RECORD,
+    BLACKBOX_REPLAY
+} BlackboxMode;
+
+typedef struct BlackboxDebugState {
+    BlackboxMode mode;
+    uint32 tick;
+    uint32 inputPump;
+    uint32 pauseTick;
+    uint32 fastForwardTick;
+    uint32 configuredSeed;
+    uint32 rngState;
+    uint32 keyPosition, keyCount;
+    uint32 axesPosition, axesCount;
+    uint32 seedPosition, seedCount;
+    uint32 rngPosition, rngCount;
+    uint32 framePosition, frameCount, frameIndex;
+} BlackboxDebugState;
+
+enum {
+    BLACKBOX_DEFAULT_SEED = 1
+};
+
+int blackbox_startDebug(uint32 seed);
+int blackbox_startRecord(const char *path, uint32 seed);
+int blackbox_startReplay(const char *path);
+void blackbox_shutdown(void);
+void blackbox_setPauseTick(uint32 tick);
+void blackbox_setFastForwardTick(uint32 tick);
+void blackbox_setBuildVersion(const char *version);
+void blackbox_setAllowBuildMismatch(int allow);
+
+int blackbox_enabled(void);
+int blackbox_recording(void);
+int blackbox_replaying(void);
+int blackbox_suppressPersistentWrites(void);
+uint32 blackbox_tick(void);
+void blackbox_getDebugState(BlackboxDebugState *state);
+int blackbox_pauseReached(void);
+/* True only while replay is advancing toward an explicitly requested tick. */
+int blackbox_fastForwarding(void);
+
+void blackbox_noteTick(void);
+/* Called after the timer's optional gameplay hook has completed. */
+void blackbox_afterTick(void);
+/* Count shared input-pump calls separately from timer ticks. Static menu phases
+ * continue polling input even when their 60 Hz timer is not installed. */
+void blackbox_noteInputPump(void);
+uint64 blackbox_timerNowNs(void);
+
+void blackbox_seedRandom(uint32 seed);
+/* Seeds originating outside deterministic state (currently the DOS time-of-day
+ * clock) are recorded once and restored verbatim on replay. */
+uint32 blackbox_seedExternalRandom(uint32 externalSeed);
+void blackbox_seedConfiguredRandom(void);
+int blackbox_rand15(void);
+int blackbox_randomActive(void);
+void blackbox_logPhase(const char *phase);
+
+void blackbox_recordKey(uint16 word);
+int blackbox_replayNextKey(uint16 *word);
+void blackbox_recordAxes(uint8 rawX, uint8 rawY, uint8 joyX, uint8 joyY);
+void blackbox_applyReplayAxes(uint8 *rawX, uint8 *rawY, uint8 *joyX, uint8 *joyY);
+
+void blackbox_recordFrame(SDL_Surface *page);
+/* Window-system repaint requests are presentation side effects, not game
+ * frames. Keep them out of the deterministic checksum stream. Calls may nest. */
+void blackbox_beginPassivePresent(void);
+void blackbox_endPassivePresent(void);
+void blackbox_drawDebugOverlay(SDL_Surface *page);
+void blackbox_restoreDebugOverlay(SDL_Surface *page);
+int blackbox_shouldCaptureMutableFile(const char *name);
+void blackbox_captureMutableFile(const char *name, const uint8 *data, uint32 size);
+int blackbox_replayMutableFile(const char *name, const uint8 **data, uint32 *size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_H */

--- a/src/shared/blackbox.h
+++ b/src/shared/blackbox.h
@@ -46,6 +46,9 @@ void blackbox_setAllowBuildMismatch(int allow);
 int blackbox_enabled(void);
 int blackbox_recording(void);
 int blackbox_replaying(void);
+/* Debug/replay own a synthetic clock. Recording observes the native 60 Hz
+ * clock so enabling a recorder cannot change gameplay speed. */
+int blackbox_usesVirtualTime(void);
 int blackbox_suppressPersistentWrites(void);
 uint32 blackbox_tick(void);
 void blackbox_getDebugState(BlackboxDebugState *state);
@@ -56,6 +59,11 @@ int blackbox_fastForwarding(void);
 void blackbox_noteTick(void);
 /* Called after the timer's optional gameplay hook has completed. */
 void blackbox_afterTick(void);
+/* Record/replay the number of native 60 Hz ticks produced by one timerPump()
+ * invocation. This preserves real-time recording without making replay depend
+ * on host speed or renderer timing. */
+void blackbox_recordTimerPump(uint32 startTick, uint32 tickCount);
+uint32 blackbox_replayTimerPump(void);
 /* Count shared input-pump calls separately from timer ticks. Static menu phases
  * continue polling input even when their 60 Hz timer is not installed. */
 void blackbox_noteInputPump(void);

--- a/src/shared/blackbox_cli.c
+++ b/src/shared/blackbox_cli.c
@@ -62,6 +62,12 @@ void blackbox_cliInit(BlackboxCliOptions *options) {
     options->dumpTick = 0xffffffffu;
 }
 
+void blackbox_cliApplyDebugDefaults(BlackboxCliOptions *options) {
+    if (!options || options->debug || options->recordPath || options->replayPath)
+        return;
+    options->recordPath = BLACKBOX_DEFAULT_RECORD_PATH;
+}
+
 void blackbox_cliPrintUsage(void) {
     printf("                  [--blackbox-debug] [--blackbox-seed n]\n"
            "                  [--blackbox-record path | --blackbox-replay path]\n"

--- a/src/shared/blackbox_cli.c
+++ b/src/shared/blackbox_cli.c
@@ -1,0 +1,183 @@
+#include "blackbox_cli.h"
+
+#include "blackbox.h"
+#include "blackbox_diag.h"
+#include "version.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int parseUint32Option(const char *option, const char *value,
+                             uint32 *result) {
+    char *end = NULL;
+    unsigned long parsed;
+    if (!value || value[0] == '-') {
+        fprintf(stderr, "Invalid value for %s: %s\n", option,
+                value ? value : "(null)");
+        return 0;
+    }
+    errno = 0;
+    parsed = strtoul(value, &end, 0);
+    if (errno || end == value || *end != '\0' || parsed > 0xfffffffful) {
+        fprintf(stderr, "Invalid value for %s: %s\n", option, value);
+        return 0;
+    }
+    *result = (uint32)parsed;
+    return 1;
+}
+
+static int parseDisplayedTimeOption(const char *option, const char *value,
+                                    uint32 *result) {
+    uint32 displayed;
+    uint32 subtick;
+    if (!parseUint32Option(option, value, &displayed)) return 0;
+    subtick = displayed % 100u;
+    if (subtick >= 60u) {
+        fprintf(stderr, "Invalid value for %s: %s (last two digits must be 00..59)\n",
+                option, value);
+        return 0;
+    }
+    /* The UI shows seconds*100 + 1/60-second remainder. Convert that compact
+     * decimal notation back to the raw deterministic tick used internally. */
+    *result = (displayed / 100u) * 60u + subtick;
+    return 1;
+}
+
+static const char *requiredArgument(const char *option, int argc, char **argv,
+                                    int *index) {
+    if (*index + 1 >= argc) {
+        fprintf(stderr, "Option requires an argument: %s\n", option);
+        return NULL;
+    }
+    return argv[++*index];
+}
+
+void blackbox_cliInit(BlackboxCliOptions *options) {
+    memset(options, 0, sizeof(*options));
+    options->seed = BLACKBOX_DEFAULT_SEED;
+    options->pauseTick = 0xffffffffu;
+    options->fastForwardTick = 0xffffffffu;
+    options->dumpTick = 0xffffffffu;
+}
+
+void blackbox_cliPrintUsage(void) {
+    printf("                  [--blackbox-debug] [--blackbox-seed n]\n"
+           "                  [--blackbox-record path | --blackbox-replay path]\n"
+           "--blackbox-debug       Deterministic debug mode with top-left tick time\n"
+           "--blackbox-seed n      Deterministic RNG seed for debug/record mode, default 1\n"
+           "--blackbox-record path Record tick-stamped input/RNG blackbox log\n"
+           "--blackbox-replay path Replay a previously recorded blackbox log\n"
+           "--blackbox-replay-ignore-build\n"
+           "                      Replay even when the log was recorded by a different build\n"
+           "--blackbox-capture-render\n"
+           "                      Record every 3D scene/object/line submission (large log)\n"
+           "--blackbox-fast-forward-tick n\n"
+           "                      Replay at maximum speed until displayed time n\n"
+           "--blackbox-dump-tick n Write text and JSON snapshots at displayed time n\n"
+           "--blackbox-pause-tick n Freeze at displayed time n (seconds*100 + tick)\n");
+}
+
+int blackbox_cliParseOption(BlackboxCliOptions *options, int argc,
+                            char **argv, int *index) {
+    const char *option = argv[*index];
+    const char *argument;
+    if (strcmp(option, "--blackbox-debug") == 0) {
+        options->debug = 1;
+        return 1;
+    }
+    if (strcmp(option, "--blackbox-replay-ignore-build") == 0) {
+        options->ignoreBuild = 1;
+        return 1;
+    }
+    if (strcmp(option, "--blackbox-capture-render") == 0) {
+        options->captureRender = 1;
+        return 1;
+    }
+    if (strcmp(option, "--blackbox-record") == 0 ||
+        strcmp(option, "--blackbox-replay") == 0) {
+        argument = requiredArgument(option, argc, argv, index);
+        if (!argument) return -1;
+        if (strcmp(option, "--blackbox-record") == 0)
+            options->recordPath = argument;
+        else
+            options->replayPath = argument;
+        return 1;
+    }
+    if (strcmp(option, "--blackbox-seed") == 0 ||
+        strcmp(option, "--blackbox-pause-tick") == 0 ||
+        strcmp(option, "--blackbox-dump-tick") == 0 ||
+        strcmp(option, "--blackbox-fast-forward-tick") == 0) {
+        argument = requiredArgument(option, argc, argv, index);
+        if (!argument) return -1;
+        uint32 *destination = &options->pauseTick;
+        if (strcmp(option, "--blackbox-seed") == 0)
+            destination = &options->seed;
+        else if (strcmp(option, "--blackbox-fast-forward-tick") == 0)
+            destination = &options->fastForwardTick;
+        else if (strcmp(option, "--blackbox-dump-tick") == 0)
+            destination = &options->dumpTick;
+        if (strcmp(option, "--blackbox-seed") == 0) {
+            if (!parseUint32Option(option, argument, destination)) return -1;
+        } else if (!parseDisplayedTimeOption(option, argument, destination)) {
+            return -1;
+        }
+        if (strcmp(option, "--blackbox-dump-tick") == 0 && *destination == 0) {
+            fprintf(stderr, "Invalid value for %s: %s (first capturable tick is 1)\n",
+                    option, argument);
+            return -1;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+int blackbox_cliStart(const BlackboxCliOptions *options) {
+    blackbox_setBuildVersion(F15_VERSION);
+    blackbox_setAllowBuildMismatch(options->ignoreBuild);
+    if (options->recordPath && options->replayPath) {
+        fprintf(stderr, "Choose only one of --blackbox-record or --blackbox-replay\n");
+        return 0;
+    }
+    if (options->fastForwardTick != 0xffffffffu && !options->replayPath) {
+        fprintf(stderr, "--blackbox-fast-forward-tick requires --blackbox-replay\n");
+        return 0;
+    }
+    if (options->captureRender && !options->recordPath) {
+        fprintf(stderr, "--blackbox-capture-render requires --blackbox-record\n");
+        return 0;
+    }
+    if (options->dumpTick != 0xffffffffu && !options->debug &&
+        !options->recordPath && !options->replayPath) {
+        fprintf(stderr, "--blackbox-dump-tick requires blackbox debug, record, or replay mode\n");
+        return 0;
+    }
+    if (options->fastForwardTick != 0xffffffffu &&
+        options->pauseTick != 0xffffffffu &&
+        options->pauseTick < options->fastForwardTick) {
+        fprintf(stderr, "--blackbox-pause-tick cannot precede --blackbox-fast-forward-tick\n");
+        return 0;
+    }
+    if (options->dumpTick != 0xffffffffu &&
+        options->pauseTick != 0xffffffffu &&
+        options->pauseTick < options->dumpTick) {
+        fprintf(stderr, "--blackbox-pause-tick cannot precede --blackbox-dump-tick\n");
+        return 0;
+    }
+    if (options->replayPath) {
+        if (!blackbox_startReplay(options->replayPath)) return 0;
+    } else if (options->recordPath) {
+        if (!blackbox_startRecord(options->recordPath, options->seed)) return 0;
+    } else if (options->debug) {
+        if (!blackbox_startDebug(options->seed)) return 0;
+    }
+    if (options->pauseTick != 0xffffffffu)
+        blackbox_setPauseTick(options->pauseTick);
+    if (options->fastForwardTick != 0xffffffffu)
+        blackbox_setFastForwardTick(options->fastForwardTick);
+    if (options->dumpTick != 0xffffffffu)
+        blackbox_diagSetDumpTick(options->dumpTick);
+    blackbox_diagSetRenderCapture(options->captureRender);
+    return 1;
+}

--- a/src/shared/blackbox_cli.c
+++ b/src/shared/blackbox_cli.c
@@ -9,17 +9,19 @@
 #include <stdlib.h>
 #include <string.h>
 
+static const uint32 UNSCHEDULED_TICK = 0xffffffffu;
+enum { TICKS_PER_SECOND = 60, DISPLAYED_SECOND_UNITS = 100 };
+
 static int parseUint32Option(const char *option, const char *value,
                              uint32 *result) {
     char *end = NULL;
-    unsigned long parsed;
     if (!value || value[0] == '-') {
         fprintf(stderr, "Invalid value for %s: %s\n", option,
                 value ? value : "(null)");
         return 0;
     }
     errno = 0;
-    parsed = strtoul(value, &end, 0);
+    const unsigned long parsed = strtoul(value, &end, 0);
     if (errno || end == value || *end != '\0' || parsed > 0xfffffffful) {
         fprintf(stderr, "Invalid value for %s: %s\n", option, value);
         return 0;
@@ -30,18 +32,17 @@ static int parseUint32Option(const char *option, const char *value,
 
 static int parseDisplayedTimeOption(const char *option, const char *value,
                                     uint32 *result) {
-    uint32 displayed;
-    uint32 subtick;
+    uint32 displayed = 0;
     if (!parseUint32Option(option, value, &displayed)) return 0;
-    subtick = displayed % 100u;
-    if (subtick >= 60u) {
+    const uint32 subtick = displayed % DISPLAYED_SECOND_UNITS;
+    if (subtick >= TICKS_PER_SECOND) {
         fprintf(stderr, "Invalid value for %s: %s (last two digits must be 00..59)\n",
                 option, value);
         return 0;
     }
     /* The UI shows seconds*100 + 1/60-second remainder. Convert that compact
      * decimal notation back to the raw deterministic tick used internally. */
-    *result = (displayed / 100u) * 60u + subtick;
+    *result = (displayed / DISPLAYED_SECOND_UNITS) * TICKS_PER_SECOND + subtick;
     return 1;
 }
 
@@ -57,9 +58,9 @@ static const char *requiredArgument(const char *option, int argc, char **argv,
 void blackbox_cliInit(BlackboxCliOptions *options) {
     memset(options, 0, sizeof(*options));
     options->seed = BLACKBOX_DEFAULT_SEED;
-    options->pauseTick = 0xffffffffu;
-    options->fastForwardTick = 0xffffffffu;
-    options->dumpTick = 0xffffffffu;
+    options->pauseTick = UNSCHEDULED_TICK;
+    options->fastForwardTick = UNSCHEDULED_TICK;
+    options->dumpTick = UNSCHEDULED_TICK;
 }
 
 void blackbox_cliApplyDebugDefaults(BlackboxCliOptions *options) {
@@ -140,13 +141,17 @@ int blackbox_cliParseOption(BlackboxCliOptions *options, int argc,
 }
 
 int blackbox_cliStart(const BlackboxCliOptions *options) {
+    const bool hasFastForward = options->fastForwardTick != UNSCHEDULED_TICK;
+    const bool hasPause = options->pauseTick != UNSCHEDULED_TICK;
+    const bool hasDump = options->dumpTick != UNSCHEDULED_TICK;
+    const bool hasSession = options->debug || options->recordPath || options->replayPath;
     blackbox_setBuildVersion(F15_VERSION);
     blackbox_setAllowBuildMismatch(options->ignoreBuild);
     if (options->recordPath && options->replayPath) {
         fprintf(stderr, "Choose only one of --blackbox-record or --blackbox-replay\n");
         return 0;
     }
-    if (options->fastForwardTick != 0xffffffffu && !options->replayPath) {
+    if (hasFastForward && !options->replayPath) {
         fprintf(stderr, "--blackbox-fast-forward-tick requires --blackbox-replay\n");
         return 0;
     }
@@ -154,19 +159,16 @@ int blackbox_cliStart(const BlackboxCliOptions *options) {
         fprintf(stderr, "--blackbox-capture-render requires --blackbox-record\n");
         return 0;
     }
-    if (options->dumpTick != 0xffffffffu && !options->debug &&
-        !options->recordPath && !options->replayPath) {
+    if (hasDump && !hasSession) {
         fprintf(stderr, "--blackbox-dump-tick requires blackbox debug, record, or replay mode\n");
         return 0;
     }
-    if (options->fastForwardTick != 0xffffffffu &&
-        options->pauseTick != 0xffffffffu &&
+    if (hasFastForward && hasPause &&
         options->pauseTick < options->fastForwardTick) {
         fprintf(stderr, "--blackbox-pause-tick cannot precede --blackbox-fast-forward-tick\n");
         return 0;
     }
-    if (options->dumpTick != 0xffffffffu &&
-        options->pauseTick != 0xffffffffu &&
+    if (hasDump && hasPause &&
         options->pauseTick < options->dumpTick) {
         fprintf(stderr, "--blackbox-pause-tick cannot precede --blackbox-dump-tick\n");
         return 0;
@@ -178,11 +180,11 @@ int blackbox_cliStart(const BlackboxCliOptions *options) {
     } else if (options->debug) {
         if (!blackbox_startDebug(options->seed)) return 0;
     }
-    if (options->pauseTick != 0xffffffffu)
+    if (hasPause)
         blackbox_setPauseTick(options->pauseTick);
-    if (options->fastForwardTick != 0xffffffffu)
+    if (hasFastForward)
         blackbox_setFastForwardTick(options->fastForwardTick);
-    if (options->dumpTick != 0xffffffffu)
+    if (hasDump)
         blackbox_diagSetDumpTick(options->dumpTick);
     blackbox_diagSetRenderCapture(options->captureRender);
     return 1;

--- a/src/shared/blackbox_cli.h
+++ b/src/shared/blackbox_cli.h
@@ -1,0 +1,33 @@
+#ifndef F15_SE2_BLACKBOX_CLI_H
+#define F15_SE2_BLACKBOX_CLI_H
+
+#include "inttype.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct BlackboxCliOptions {
+    const char *recordPath;
+    const char *replayPath;
+    uint32 seed;
+    uint32 pauseTick;
+    uint32 fastForwardTick;
+    uint32 dumpTick;
+    int debug;
+    int ignoreBuild;
+    int captureRender;
+} BlackboxCliOptions;
+
+void blackbox_cliInit(BlackboxCliOptions *options);
+void blackbox_cliPrintUsage(void);
+/* Returns 1 when recognized, 0 when not a blackbox option, and -1 on error. */
+int blackbox_cliParseOption(BlackboxCliOptions *options, int argc,
+                            char **argv, int *index);
+int blackbox_cliStart(const BlackboxCliOptions *options);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_CLI_H */

--- a/src/shared/blackbox_cli.h
+++ b/src/shared/blackbox_cli.h
@@ -19,7 +19,11 @@ typedef struct BlackboxCliOptions {
     int captureRender;
 } BlackboxCliOptions;
 
+#define BLACKBOX_DEFAULT_RECORD_PATH "_blackbox.rec"
+
 void blackbox_cliInit(BlackboxCliOptions *options);
+/* Enable the implicit debug-build recording only when no blackbox mode was selected. */
+void blackbox_cliApplyDebugDefaults(BlackboxCliOptions *options);
 void blackbox_cliPrintUsage(void);
 /* Returns 1 when recognized, 0 when not a blackbox option, and -1 on error. */
 int blackbox_cliParseOption(BlackboxCliOptions *options, int argc,

--- a/src/shared/blackbox_diag.c
+++ b/src/shared/blackbox_diag.c
@@ -1,0 +1,545 @@
+/* Deterministic gameplay diagnostics layered on the blackbox stream.
+ *
+ * This file deliberately reads game state without owning or changing it. The
+ * only gameplay hook is one call after each authoritative simulation step; 3D
+ * capture sits at the existing backend-independent r3d dispatch seam. */
+#include "blackbox_diag.h"
+
+#include "blackbox.h"
+#include "blackbox_internal.h"
+#include "blackbox_snapshot.h"
+#include "blackbox_state.h"
+#include "egdata.h"
+#include "log.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+    DIAG_OBJECT_COUNT = 20,
+    DIAG_PROJECTILE_COUNT = 12,
+    DIAG_RENDER_COMMANDS = 512,
+    DIAG_NAME_SIZE = 32
+};
+
+typedef struct MarkerEvent {
+    uint32 tick;
+    char name[DIAG_NAME_SIZE];
+    int32 a, b, c;
+} MarkerEvent;
+
+typedef struct StateEvent {
+    uint32 tick;
+    uint32 step;
+    char name[DIAG_NAME_SIZE];
+    uint32 hash;
+} StateEvent;
+
+typedef struct RenderEvent {
+    uint32 tick;
+    uint32 frame;
+    uint32 scene;
+    uint32 objects;
+    uint32 lines;
+    uint32 hash;
+} RenderEvent;
+
+typedef struct RenderCommand {
+    char type;
+    int32 v[8];
+} RenderCommand;
+
+static MarkerEvent *s_markers;
+static size_t s_markerCount, s_markerCapacity, s_markerPos;
+static StateEvent *s_states;
+static size_t s_stateCount, s_stateCapacity, s_statePos;
+static RenderEvent *s_renders;
+static size_t s_renderCount, s_renderCapacity, s_renderPos;
+static uint32 s_simStep;
+static uint32 s_renderFrame;
+static uint32 s_renderScene;
+static uint32 s_dumpTick = 0xffffffffu;
+static int s_dumpWritten;
+static uint32 s_sceneObjects;
+static uint32 s_sceneLines;
+static uint32 s_sceneHash;
+static int s_captureRenderCommands;
+static int s_stateBaseline;
+static int s_reportedMarkerDivergence;
+static int s_reportedStateDivergence;
+static int s_reportedRenderDivergence;
+static ViewMode s_prevViewMode;
+static int16 s_prevTrackedEnemy;
+static int16 s_prevAirLock;
+static int16 s_prevGroundLock;
+static uint8 s_prevMissionEnded;
+static int16 s_prevProjectileTtl[DIAG_PROJECTILE_COUNT];
+static RenderCommand s_recentCommands[DIAG_RENDER_COMMANDS];
+static size_t s_recentCommandCount;
+static size_t s_recentCommandDropped;
+
+extern uint8 timerCounter;
+extern uint8 timerCounter2;
+extern uint8 timerCounter3;
+extern uint8 timerCounter4;
+extern uint8 timerHandlerInstalled;
+
+static int reserve(void **items, size_t *capacity, size_t count, size_t size) {
+    size_t nextCapacity;
+    void *next;
+    if (count < *capacity) return 1;
+    nextCapacity = *capacity ? *capacity * 2u : 128u;
+    if (nextCapacity <= *capacity || nextCapacity > SIZE_MAX / size) return 0;
+    next = realloc(*items, nextCapacity * size);
+    if (!next) return 0;
+    *items = next;
+    *capacity = nextCapacity;
+    return 1;
+}
+
+static uint32 hashAdd(uint32 hash, uint32 value) {
+    int i;
+    for (i = 0; i < 4; i++) {
+        hash ^= value & 0xffu;
+        hash *= 16777619u;
+        value >>= 8;
+    }
+    return hash;
+}
+
+static uint32 hashFlight(void) {
+    uint32 h = 2166136261u;
+    h = hashAdd(h, (uint32)g_ViewX); h = hashAdd(h, (uint32)g_ViewY);
+    h = hashAdd(h, (uint16)g_viewZ); h = hashAdd(h, (uint16)g_ourHead);
+    h = hashAdd(h, (uint16)g_ourPitch); h = hashAdd(h, (uint16)g_ourRoll);
+    h = hashAdd(h, (uint32)g_velocity); h = hashAdd(h, (uint16)g_knots);
+    h = hashAdd(h, (uint32)g_altitude); h = hashAdd(h, (uint16)g_fuelRemaining);
+    h = hashAdd(h, (uint16)g_damageTakenFlag); h = hashAdd(h, (uint16)g_playerPlaneFlags);
+    return h;
+}
+
+static uint32 hashCamera(void) {
+    uint32 h = 2166136261u;
+    h = hashAdd(h, (uint16)g_viewMode); h = hashAdd(h, (uint16)g_viewHeading);
+    h = hashAdd(h, (uint16)g_viewPitch); h = hashAdd(h, (uint16)g_viewRoll);
+    h = hashAdd(h, (uint32)g_camEyeX); h = hashAdd(h, (uint32)g_camEyeY);
+    h = hashAdd(h, (uint16)g_camEyeZ); h = hashAdd(h, (uint32)g_viewTargetX);
+    h = hashAdd(h, (uint32)g_viewTargetY); h = hashAdd(h, (uint16)g_viewTargetAlt);
+    h = hashAdd(h, (uint16)g_viewTargetObj); h = hashAdd(h, (uint16)g_externalCamDist);
+    return h;
+}
+
+static uint32 hashObjects(void) {
+    uint32 h = 2166136261u;
+    int i;
+    for (i = 0; i < DIAG_OBJECT_COUNT; i++) {
+        const struct SimObject *o = &g_simObjects[i];
+        h = hashAdd(h, (uint16)o->objType); h = hashAdd(h, o->posX);
+        h = hashAdd(h, o->posY); h = hashAdd(h, (uint16)o->alt);
+        h = hashAdd(h, (uint32)o->worldX); h = hashAdd(h, (uint32)o->worldY);
+        h = hashAdd(h, (uint16)o->heading.w); h = hashAdd(h, (uint16)o->pitch);
+        h = hashAdd(h, (uint16)o->bank.w); h = hashAdd(h, (uint16)o->spec);
+        h = hashAdd(h, o->flags.w); h = hashAdd(h, (uint16)o->speed);
+        h = hashAdd(h, (uint16)o->timer); h = hashAdd(h, (uint16)o->weaponType);
+        h = hashAdd(h, (uint16)o->damage);
+    }
+    return h;
+}
+
+static uint32 hashWeapons(void) {
+    uint32 h = 2166136261u;
+    int i;
+    for (i = 0; i < DIAG_PROJECTILE_COUNT; i++) {
+        const struct Projectile *p = &g_projectiles[i];
+        h = hashAdd(h, p->mapX); h = hashAdd(h, p->mapY);
+        h = hashAdd(h, (uint16)p->alt); h = hashAdd(h, (uint16)p->speed);
+        h = hashAdd(h, (uint16)p->worldX); h = hashAdd(h, (uint16)p->worldY);
+        h = hashAdd(h, (uint16)p->worldZ); h = hashAdd(h, (uint16)p->ttl);
+        h = hashAdd(h, (uint16)p->specIdx); h = hashAdd(h, (uint16)p->weaponIdx);
+        h = hashAdd(h, (uint16)p->targetLock); h = hashAdd(h, (uint16)p->targetRef);
+        h = hashAdd(h, (uint32)p->fineX); h = hashAdd(h, (uint32)p->fineY);
+    }
+    h = hashAdd(h, (uint16)g_gunAmmo); h = hashAdd(h, (uint16)g_currentWeaponType);
+    h = hashAdd(h, (uint16)g_lastMissileSlot); h = hashAdd(h, (uint16)g_fireCooldown);
+    return h;
+}
+
+static uint32 hashTargetMission(void) {
+    uint32 h = 2166136261u;
+    h = hashAdd(h, (uint16)g_trackedEnemyIdx); h = hashAdd(h, (uint16)g_airTargetLock);
+    h = hashAdd(h, (uint16)g_groundTargetLock); h = hashAdd(h, (uint16)g_aamLockActive);
+    h = hashAdd(h, (uint16)g_targetInHudFlag); h = hashAdd(h, (uint16)g_targetLeadAngle);
+    h = hashAdd(h, (uint16)g_missionStatus); h = hashAdd(h, (uint16)g_missionTick);
+    h = hashAdd(h, g_missionEndedFlag[0]); h = hashAdd(h, (uint16)g_enemyAirRemaining);
+    h = hashAdd(h, (uint16)g_enemyGroundRemaining); h = hashAdd(h, (uint16)g_finalThreatScore);
+    if (gameData) {
+        h = hashAdd(h, gameData->totalScore); h = hashAdd(h, (uint16)gameData->campaignProgress);
+    }
+    return h;
+}
+
+static void emitState(const char *name, uint32 hash) {
+    FILE *file = blackbox_internalRecordFile();
+    if (blackbox_recording() && file) {
+        fprintf(file, "state %u %u %s %08x\n", (unsigned)blackbox_tick(),
+                (unsigned)s_simStep, name, (unsigned)hash);
+    } else if (blackbox_replaying() && s_stateCount) {
+        if (s_statePos < s_stateCount) {
+            const StateEvent *e = &s_states[s_statePos++];
+            if (!s_reportedStateDivergence &&
+                (e->tick != blackbox_tick() || e->step != s_simStep ||
+                 strcmp(e->name, name) != 0 || e->hash != hash)) {
+                s_reportedStateDivergence = 1;
+                log_error("blackbox: subsystem divergence at tick %u step %u %s: expected tick %u step %u %s %08x, got %08x",
+                          (unsigned)blackbox_tick(), (unsigned)s_simStep, name,
+                          (unsigned)e->tick, (unsigned)e->step, e->name,
+                          (unsigned)e->hash, (unsigned)hash);
+            }
+        } else if (!s_reportedStateDivergence) {
+            s_reportedStateDivergence = 1;
+            log_error("blackbox: subsystem hash stream exhausted at tick %u", (unsigned)blackbox_tick());
+        }
+    }
+}
+
+void blackbox_diagMarker(const char *name, int32 a, int32 b, int32 c) {
+    FILE *file = blackbox_internalRecordFile();
+    if (!blackbox_enabled() || !name || !*name) return;
+    if (blackbox_recording() && file) {
+        fprintf(file, "marker %u %s %d %d %d\n", (unsigned)blackbox_tick(),
+                name, (int)a, (int)b, (int)c);
+    } else if (blackbox_replaying() && s_markerCount) {
+        if (s_markerPos < s_markerCount) {
+            const MarkerEvent *e = &s_markers[s_markerPos++];
+            if (!s_reportedMarkerDivergence &&
+                (e->tick != blackbox_tick() || strcmp(e->name, name) != 0 ||
+                 e->a != a || e->b != b || e->c != c)) {
+                s_reportedMarkerDivergence = 1;
+                log_error("blackbox: marker divergence at tick %u %s(%d,%d,%d): expected tick %u %s(%d,%d,%d)",
+                          (unsigned)blackbox_tick(), name, (int)a, (int)b, (int)c,
+                          (unsigned)e->tick, e->name, (int)e->a, (int)e->b, (int)e->c);
+            }
+        } else if (!s_reportedMarkerDivergence) {
+            s_reportedMarkerDivergence = 1;
+            log_error("blackbox: marker stream exhausted at tick %u", (unsigned)blackbox_tick());
+        }
+    }
+}
+
+static void captureBaseline(void) {
+    int i;
+    s_prevViewMode = g_viewMode;
+    s_prevTrackedEnemy = g_trackedEnemyIdx;
+    s_prevAirLock = g_airTargetLock;
+    s_prevGroundLock = g_groundTargetLock;
+    s_prevMissionEnded = g_missionEndedFlag[0];
+    for (i = 0; i < DIAG_PROJECTILE_COUNT; i++) s_prevProjectileTtl[i] = g_projectiles[i].ttl;
+    s_stateBaseline = 1;
+}
+
+void blackbox_diagCaptureSimStep(void) {
+    int i;
+    if (!blackbox_enabled()) return;
+    s_simStep++;
+    if (!s_stateBaseline) {
+        captureBaseline();
+        blackbox_diagMarker("sim_begin", g_viewMode, g_planeCount, g_missionStatus);
+    } else {
+        if (s_prevViewMode != g_viewMode)
+            blackbox_diagMarker("view_change", s_prevViewMode, g_viewMode, 0);
+        if (s_prevTrackedEnemy != g_trackedEnemyIdx || s_prevAirLock != g_airTargetLock ||
+            s_prevGroundLock != g_groundTargetLock)
+            blackbox_diagMarker("target_change", g_trackedEnemyIdx, g_airTargetLock, g_groundTargetLock);
+        for (i = 0; i < DIAG_PROJECTILE_COUNT; i++) {
+            if (s_prevProjectileTtl[i] == 0 && g_projectiles[i].ttl != 0)
+                blackbox_diagMarker("projectile_launch", i, g_projectiles[i].weaponIdx,
+                                    g_projectiles[i].targetLock);
+            else if (s_prevProjectileTtl[i] != 0 && g_projectiles[i].ttl == 0)
+                blackbox_diagMarker("projectile_remove", i, g_projectiles[i].weaponIdx,
+                                    g_projectiles[i].targetLock);
+        }
+        if (!s_prevMissionEnded && g_missionEndedFlag[0])
+            blackbox_diagMarker("mission_end", g_missionStatus, commData ? commData->landingType : 0, 0);
+        captureBaseline();
+    }
+    emitState("flight", hashFlight());
+    emitState("camera", hashCamera());
+    emitState("objects", hashObjects());
+    emitState("weapons", hashWeapons());
+    emitState("target_mission", hashTargetMission());
+}
+
+static int32 meshOffset(R3DMesh mesh) {
+    uintptr_t p = (uintptr_t)mesh;
+    uintptr_t base = (uintptr_t)g_world3dData;
+    if (p < base || p >= base + WORLD3D_DATA_SIZE) return -1;
+    return (int32)(p - base);
+}
+
+static void rememberCommand(char type, const int32 *values, int count) {
+    RenderCommand *cmd;
+    int i;
+    if (s_recentCommandCount >= DIAG_RENDER_COMMANDS) {
+        s_recentCommandDropped++;
+        return;
+    }
+    cmd = &s_recentCommands[s_recentCommandCount++];
+    cmd->type = type;
+    for (i = 0; i < 8; i++) cmd->v[i] = i < count ? values[i] : 0;
+}
+
+void blackbox_diagBeginRenderFrame(void) {
+    if (!blackbox_enabled()) return;
+    s_renderFrame++;
+    s_renderScene = 0;
+    s_recentCommandCount = 0;
+    s_recentCommandDropped = 0;
+}
+
+void blackbox_diagRenderBeginScene(const R3DScene *scene) {
+    FILE *file = blackbox_internalRecordFile();
+    int32 values[8];
+    if (!blackbox_enabled() || !scene) return;
+    s_renderScene++;
+    s_sceneObjects = s_sceneLines = 0;
+    s_sceneHash = 2166136261u;
+    values[0] = scene->angleX; values[1] = scene->angleY; values[2] = scene->angleZ;
+    values[3] = scene->posX; values[4] = scene->posY; values[5] = scene->posZ;
+    values[6] = scene->renderScene;
+    rememberCommand('S', values, 7);
+    for (int i = 0; i < 7; i++) s_sceneHash = hashAdd(s_sceneHash, (uint32)values[i]);
+    if (blackbox_recording() && s_captureRenderCommands && file)
+        fprintf(file, "render_scene %u %u %u %d %d %d %d %d %d %d\n",
+                (unsigned)blackbox_tick(), (unsigned)s_renderFrame, (unsigned)s_renderScene,
+                values[0], values[1], values[2], values[3], values[4], values[5], values[6]);
+}
+
+void blackbox_diagRenderSubmit(const R3DSubmit *sub) {
+    FILE *file = blackbox_internalRecordFile();
+    int32 values[8];
+    if (!blackbox_enabled() || !sub) return;
+    values[0] = meshOffset(sub->mesh); values[1] = sub->yaw; values[2] = sub->pitch;
+    values[3] = sub->roll; values[4] = sub->posX; values[5] = sub->posY;
+    values[6] = sub->posZ; values[7] = sub->shadow;
+    rememberCommand('O', values, 8);
+    for (int i = 0; i < 8; i++) s_sceneHash = hashAdd(s_sceneHash, (uint32)values[i]);
+    s_sceneObjects++;
+    if (blackbox_recording() && s_captureRenderCommands && file)
+        fprintf(file, "render_object %u %u %u %u %d %d %d %d %d %d %d %d\n",
+                (unsigned)blackbox_tick(), (unsigned)s_renderFrame, (unsigned)s_renderScene,
+                (unsigned)s_sceneObjects, values[0], values[1], values[2], values[3],
+                values[4], values[5], values[6], values[7]);
+}
+
+void blackbox_diagRenderLine(const R3DLine *line) {
+    FILE *file = blackbox_internalRecordFile();
+    int32 values[8];
+    if (!blackbox_enabled() || !line) return;
+    values[0] = (int32)line->baseXA; values[1] = (int32)line->camXA;
+    values[2] = (int32)line->camYA; values[3] = (int32)line->baseXB;
+    values[4] = (int32)line->camXB; values[5] = (int32)line->camYB;
+    values[6] = line->color;
+    rememberCommand('L', values, 7);
+    for (int i = 0; i < 7; i++) s_sceneHash = hashAdd(s_sceneHash, (uint32)values[i]);
+    s_sceneLines++;
+    if (blackbox_recording() && s_captureRenderCommands && file)
+        fprintf(file, "render_line %u %u %u %u %d %d %d %d %d %d %d\n",
+                (unsigned)blackbox_tick(), (unsigned)s_renderFrame, (unsigned)s_renderScene,
+                (unsigned)s_sceneLines, values[0], values[1], values[2], values[3],
+                values[4], values[5], values[6]);
+}
+
+void blackbox_diagRenderEndScene(void) {
+    FILE *file = blackbox_internalRecordFile();
+    RenderEvent got;
+    if (!blackbox_enabled()) return;
+    got.tick = blackbox_tick(); got.frame = s_renderFrame; got.scene = s_renderScene;
+    got.objects = s_sceneObjects; got.lines = s_sceneLines; got.hash = s_sceneHash;
+    if (blackbox_recording() && file) {
+        fprintf(file, "render_hash %u %u %u %u %u %08x\n", (unsigned)got.tick,
+                (unsigned)got.frame, (unsigned)got.scene, (unsigned)got.objects,
+                (unsigned)got.lines, (unsigned)got.hash);
+    } else if (blackbox_replaying() && s_renderCount) {
+        if (s_renderPos < s_renderCount) {
+            const RenderEvent *e = &s_renders[s_renderPos++];
+            if (!s_reportedRenderDivergence && memcmp(e, &got, sizeof(got)) != 0) {
+                s_reportedRenderDivergence = 1;
+                log_error("blackbox: render submission divergence at tick %u frame %u scene %u: expected %u objects/%u lines hash %08x, got %u/%u %08x",
+                          (unsigned)got.tick, (unsigned)got.frame, (unsigned)got.scene,
+                          (unsigned)e->objects, (unsigned)e->lines, (unsigned)e->hash,
+                          (unsigned)got.objects, (unsigned)got.lines, (unsigned)got.hash);
+            }
+        } else if (!s_reportedRenderDivergence) {
+            s_reportedRenderDivergence = 1;
+            log_error("blackbox: render hash stream exhausted at tick %u", (unsigned)got.tick);
+        }
+    }
+}
+
+int blackbox_diagWriteDump(const char *path) {
+    FILE *f;
+    int i;
+    BlackboxDebugState debug;
+    if (!path || !*path) return 0;
+    f = fopen(path, "w");
+    if (!f) return 0;
+    blackbox_getDebugState(&debug);
+    fprintf(f, "F15SE2 diagnostic dump\nraw_tick=%u displayed_time=%u\n",
+            (unsigned)blackbox_tick(),
+            (unsigned)((blackbox_tick() / 60u) * 100u + blackbox_tick() % 60u));
+    fprintf(f, "provenance build=%s replay_build=%s mode=%d\n",
+            blackbox_state_currentBuildVersion(),
+            blackbox_state_replayBuildVersion(), (int)debug.mode);
+    fprintf(f, "blackbox input_pump=%u seed=%u rng_state=%u cursors=key:%u/%u axes:%u/%u seed:%u/%u rng:%u/%u frame:%u/%u index:%u\n",
+            (unsigned)debug.inputPump, (unsigned)debug.configuredSeed,
+            (unsigned)debug.rngState, (unsigned)debug.keyPosition,
+            (unsigned)debug.keyCount, (unsigned)debug.axesPosition,
+            (unsigned)debug.axesCount, (unsigned)debug.seedPosition,
+            (unsigned)debug.seedCount, (unsigned)debug.rngPosition,
+            (unsigned)debug.rngCount, (unsigned)debug.framePosition,
+            (unsigned)debug.frameCount, (unsigned)debug.frameIndex);
+    fprintf(f, "timing installed=%u counters=%u,%u,%u,%u frame_tick=%d sim_steps=%d render_alpha_q12=%d game_rng_seed=%d\n",
+            (unsigned)timerHandlerInstalled, (unsigned)timerCounter,
+            (unsigned)timerCounter2, (unsigned)timerCounter3,
+            (unsigned)timerCounter4, (int)frameTick, g_simStepsThisFrame,
+            g_renderAlphaQ12, (int)g_rngSeed);
+    fprintf(f, "subsystem flight=%08x camera=%08x objects=%08x weapons=%08x target_mission=%08x\n",
+            (unsigned)hashFlight(), (unsigned)hashCamera(), (unsigned)hashObjects(),
+            (unsigned)hashWeapons(), (unsigned)hashTargetMission());
+    fprintf(f, "flight view=(%d,%d,%d) pose=(%d,%d,%d) speed=%d knots=%d altitude=%u fuel=%d\n",
+            (int)g_ViewX, (int)g_ViewY, (int)g_viewZ, (int)g_ourHead,
+            (int)g_ourPitch, (int)g_ourRoll, g_velocity, (int)g_knots,
+            (unsigned)g_altitude, (int)g_fuelRemaining);
+    fprintf(f, "camera mode=%d eye=(%d,%d,%d) view=(%d,%d,%d) target=(%d,%d,%d,obj=%d)\n",
+            (int)g_viewMode, (int)g_camEyeX, (int)g_camEyeY, (int)g_camEyeZ,
+            (int)g_viewHeading, (int)g_viewPitch, (int)g_viewRoll,
+            (int)g_viewTargetX, (int)g_viewTargetY, (int)g_viewTargetAlt,
+            (int)g_viewTargetObj);
+    fprintf(f, "target tracked=%d air_lock=%d ground_lock=%d aam=%d mission_status=%d ended=%u\n",
+            (int)g_trackedEnemyIdx, (int)g_airTargetLock, (int)g_groundTargetLock,
+            (int)g_aamLockActive, (int)g_missionStatus, (unsigned)g_missionEndedFlag[0]);
+    for (i = 0; i < DIAG_OBJECT_COUNT; i++) {
+        const struct SimObject *o = &g_simObjects[i];
+        fprintf(f, "object[%02d] type=%d flags=%04x pos=(%d,%d,%d) pose=(%d,%d,%d) spec=%d speed=%d timer=%d damage=%d\n",
+                i, (int)o->objType, (unsigned)o->flags.w, (int)o->worldX,
+                (int)o->worldY, (int)o->alt, (int)o->heading.w, (int)o->pitch,
+                (int)o->bank.w, (int)o->spec, (int)o->speed, (int)o->timer,
+                (int)o->damage);
+    }
+    for (i = 0; i < DIAG_PROJECTILE_COUNT; i++) {
+        const struct Projectile *p = &g_projectiles[i];
+        fprintf(f, "projectile[%02d] ttl=%d weapon=%d spec=%d target=%d ref=%d pos=(%d,%d,%d) fine=(%d,%d)\n",
+                i, (int)p->ttl, (int)p->weaponIdx, (int)p->specIdx,
+                (int)p->targetLock, (int)p->targetRef, (int)p->mapX,
+                (int)p->mapY, (int)p->alt, (int)p->fineX, (int)p->fineY);
+    }
+    fprintf(f, "render frame=%u commands=%u dropped=%u\n", (unsigned)s_renderFrame,
+            (unsigned)s_recentCommandCount, (unsigned)s_recentCommandDropped);
+    for (i = 0; i < (int)s_recentCommandCount; i++) {
+        const RenderCommand *cmd = &s_recentCommands[i];
+        fprintf(f, "render[%03d] %c %d %d %d %d %d %d %d %d\n", i, cmd->type,
+                cmd->v[0], cmd->v[1], cmd->v[2], cmd->v[3], cmd->v[4], cmd->v[5],
+                cmd->v[6], cmd->v[7]);
+    }
+    fclose(f);
+    log_info("blackbox: wrote diagnostic dump '%s'", path);
+    return 1;
+}
+
+void blackbox_diagWriteAutomaticDump(void) {
+    char textPath[96];
+    char jsonPath[96];
+    uint32 tick = blackbox_tick();
+    uint32 shown = (tick / 60u) * 100u + tick % 60u;
+    snprintf(textPath, sizeof(textPath), "blackbox-dump-%u.txt", (unsigned)shown);
+    snprintf(jsonPath, sizeof(jsonPath), "blackbox-dump-%u.json", (unsigned)shown);
+    if (!blackbox_diagWriteDump(textPath))
+        log_error("blackbox: cannot write diagnostic dump '%s'", textPath);
+    if (!blackbox_snapshotWriteJson(jsonPath))
+        log_error("blackbox: cannot write state snapshot '%s'", jsonPath);
+    else
+        log_info("blackbox: wrote state snapshot '%s'", jsonPath);
+}
+
+void blackbox_diagSetDumpTick(uint32 tick) {
+    s_dumpTick = tick;
+    s_dumpWritten = 0;
+    log_info("blackbox: automatic dump tick=%u", (unsigned)tick);
+}
+
+void blackbox_diagOnTick(void) {
+    /* timerPump calls this after the optional per-tick gameplay hook. Capturing
+     * here is deterministic, works in menus and flight, and does not depend on
+     * renderer presentation or host timing. */
+    if (!s_dumpWritten && s_dumpTick != 0xffffffffu &&
+        blackbox_tick() >= s_dumpTick) {
+        s_dumpWritten = 1;
+        blackbox_diagWriteAutomaticDump();
+    }
+}
+
+void blackbox_diagSetRenderCapture(int enabled) { s_captureRenderCommands = enabled != 0; }
+
+void blackbox_diagReset(void) {
+    free(s_markers); free(s_states); free(s_renders);
+    s_markers = NULL; s_states = NULL; s_renders = NULL;
+    s_markerCount = s_markerCapacity = s_markerPos = 0;
+    s_stateCount = s_stateCapacity = s_statePos = 0;
+    s_renderCount = s_renderCapacity = s_renderPos = 0;
+    s_dumpTick = 0xffffffffu;
+    s_dumpWritten = 0;
+    s_simStep = s_renderFrame = s_renderScene = 0;
+    s_sceneObjects = s_sceneLines = 0; s_sceneHash = 0;
+    s_captureRenderCommands = 0; s_stateBaseline = 0;
+    s_reportedMarkerDivergence = s_reportedStateDivergence = s_reportedRenderDivergence = 0;
+    s_recentCommandCount = s_recentCommandDropped = 0;
+}
+
+int blackbox_diagParseReplayLine(const char *line) {
+    unsigned tick, step, frame, scene, objects, lines, hash;
+    int a, b, c;
+    char name[DIAG_NAME_SIZE];
+    if (sscanf(line, "marker %u %31s %d %d %d", &tick, name, &a, &b, &c) == 5) {
+        MarkerEvent *e;
+        if (!reserve((void **)&s_markers, &s_markerCapacity, s_markerCount, sizeof(*s_markers))) return -1;
+        e = &s_markers[s_markerCount++]; e->tick = tick;
+        strcpy(e->name, name); e->a = a; e->b = b; e->c = c;
+        return 1;
+    }
+    if (sscanf(line, "state %u %u %31s %x", &tick, &step, name, &hash) == 4) {
+        StateEvent *e;
+        if (!reserve((void **)&s_states, &s_stateCapacity, s_stateCount, sizeof(*s_states))) return -1;
+        e = &s_states[s_stateCount++]; e->tick = tick; e->step = step;
+        strcpy(e->name, name); e->hash = hash;
+        return 1;
+    }
+    if (sscanf(line, "render_hash %u %u %u %u %u %x", &tick, &frame, &scene, &objects, &lines, &hash) == 6) {
+        RenderEvent *e;
+        if (!reserve((void **)&s_renders, &s_renderCapacity, s_renderCount, sizeof(*s_renders))) return -1;
+        e = &s_renders[s_renderCount++]; e->tick = tick; e->frame = frame;
+        e->scene = scene; e->objects = objects; e->lines = lines; e->hash = hash;
+        return 1;
+    }
+    /* Detailed commands are retained for human/agent inspection. Replay proves
+     * equivalence with the compact render_hash emitted at every scene end. */
+    if (strncmp(line, "render_scene ", 13) == 0 ||
+        strncmp(line, "render_object ", 14) == 0 ||
+        strncmp(line, "render_line ", 12) == 0) return 1;
+    return 0;
+}
+
+int blackbox_diagValidateReplay(void) { return 1; }
+
+void blackbox_diagShutdown(int pausedForInspection) {
+    if (blackbox_replaying() && !pausedForInspection) {
+        if (s_markerCount && s_markerPos != s_markerCount)
+            log_error("blackbox: replay consumed %u of %u diagnostic markers", (unsigned)s_markerPos, (unsigned)s_markerCount);
+        if (s_stateCount && s_statePos != s_stateCount)
+            log_error("blackbox: replay consumed %u of %u subsystem hashes", (unsigned)s_statePos, (unsigned)s_stateCount);
+        if (s_renderCount && s_renderPos != s_renderCount)
+            log_error("blackbox: replay consumed %u of %u render hashes", (unsigned)s_renderPos, (unsigned)s_renderCount);
+    }
+    blackbox_diagReset();
+}

--- a/src/shared/blackbox_diag.c
+++ b/src/shared/blackbox_diag.c
@@ -381,6 +381,7 @@ void blackbox_diagRenderEndScene(void) {
 int blackbox_diagWriteDump(const char *path) {
     FILE *f;
     int i;
+    int writeFailed = 0;
     BlackboxDebugState debug;
     if (!path || !*path) return 0;
     f = fopen(path, "w");
@@ -443,7 +444,10 @@ int blackbox_diagWriteDump(const char *path) {
                 cmd->v[0], cmd->v[1], cmd->v[2], cmd->v[3], cmd->v[4], cmd->v[5],
                 cmd->v[6], cmd->v[7]);
     }
-    fclose(f);
+    /* Buffered output may fail before close or only during its final flush.
+     * Do not tell the caller a partial diagnostic file was written safely. */
+    writeFailed = ferror(f);
+    if (fclose(f) != 0 || writeFailed) return 0;
     log_info("blackbox: wrote diagnostic dump '%s'", path);
     return 1;
 }

--- a/src/shared/blackbox_diag.h
+++ b/src/shared/blackbox_diag.h
@@ -1,0 +1,38 @@
+#ifndef F15_SE2_BLACKBOX_DIAG_H
+#define F15_SE2_BLACKBOX_DIAG_H
+
+#include "inttype.h"
+#include "r3d.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void blackbox_diagReset(void);
+int blackbox_diagParseReplayLine(const char *line);
+int blackbox_diagValidateReplay(void);
+void blackbox_diagShutdown(int pausedForInspection);
+void blackbox_diagSetRenderCapture(int enabled);
+void blackbox_diagSetDumpTick(uint32 tick);
+void blackbox_diagOnTick(void);
+
+/* Generic marker for future focused instrumentation. The default flight hook
+ * already emits view/target/projectile/mission transitions automatically. */
+void blackbox_diagMarker(const char *name, int32 a, int32 b, int32 c);
+void blackbox_diagCaptureSimStep(void);
+
+void blackbox_diagBeginRenderFrame(void);
+void blackbox_diagRenderBeginScene(const R3DScene *scene);
+void blackbox_diagRenderSubmit(const R3DSubmit *submit);
+void blackbox_diagRenderLine(const R3DLine *line);
+void blackbox_diagRenderEndScene(void);
+
+/* Writes a human-readable snapshot. Ctrl+F10 calls the automatic-name variant. */
+int blackbox_diagWriteDump(const char *path);
+void blackbox_diagWriteAutomaticDump(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_DIAG_H */

--- a/src/shared/blackbox_gl.c
+++ b/src/shared/blackbox_gl.c
@@ -1,0 +1,77 @@
+#include "blackbox_gl.h"
+
+#include "blackbox.h"
+#include "r2d.h"
+
+#include <SDL3/SDL_opengl.h>
+#include <stdio.h>
+
+static const unsigned char kDigits[10][5] = {
+    {7, 5, 5, 5, 7}, {2, 6, 2, 2, 7}, {7, 1, 7, 4, 7}, {7, 1, 7, 1, 7}, {5, 5, 7, 1, 1},
+    {7, 4, 7, 1, 7}, {7, 4, 7, 5, 7}, {7, 1, 1, 1, 1}, {7, 5, 7, 5, 7}, {7, 5, 7, 1, 7}
+};
+
+static void drawCell(float x, float y, float w, float h) {
+    glVertex2f(x, y);
+    glVertex2f(x + w, y);
+    glVertex2f(x + w, y + h);
+    glVertex2f(x, y + h);
+}
+
+static void drawDigit(float x, float y, float w, float h, int digit) {
+    int row, col;
+    for (row = 0; row < 5; row++) {
+        unsigned char bits = kDigits[digit][row];
+        for (col = 0; col < 3; col++) {
+            if (bits & (1u << (2 - col)))
+                drawCell(x + (float)col * w, y + (float)row * h, w, h);
+        }
+    }
+}
+
+void blackbox_drawGlOverlay(SDL_Surface *page, int shakeOffset, SDL_Window *window,
+                            SDL_Palette *palette,
+                            BlackboxGlSetupFn setupOverlayState) {
+    char text[16];
+    int winW, winH, i;
+    float x, y, cellW, cellH, bgX, bgY, bgW, bgH;
+    R2DMapping mapping;
+    SDL_Color foreground;
+    uint32 tick;
+    uint64 displayedTime;
+
+    if (!blackbox_enabled() || !page || !window || !palette ||
+        !setupOverlayState) return;
+    SDL_GetWindowSizeInPixels(window, &winW, &winH);
+    r2d_computeMapping(page->w, page->h, winW, winH, 0, &mapping);
+
+    cellW = mapping.scaleX;
+    cellH = mapping.scaleY;
+    bgX = (float)mapping.offX - (float)shakeOffset * mapping.scaleX;
+    bgY = (float)mapping.offY;
+    bgW = 52.0f * mapping.scaleX;
+    bgH = 7.0f * mapping.scaleY;
+    x = bgX + mapping.scaleX;
+    y = bgY + mapping.scaleY;
+
+    setupOverlayState();
+    glDisable(GL_BLEND);
+    glColor3ub(0, 0, 0);
+    glBegin(GL_QUADS);
+    drawCell(bgX, bgY, bgW, bgH);
+    glEnd();
+
+    tick = blackbox_tick();
+    displayedTime = (uint64)(tick / 60u) * 100u + (uint64)(tick % 60u);
+    snprintf(text, sizeof(text), "%llu", (unsigned long long)displayedTime);
+    foreground = palette->colors[15];
+    glColor3ub(foreground.r, foreground.g, foreground.b);
+    glBegin(GL_QUADS);
+    for (i = 0; text[i]; i++) {
+        if (text[i] >= '0' && text[i] <= '9') {
+            drawDigit(x, y, cellW, cellH, text[i] - '0');
+            x += 4.0f * cellW;
+        }
+    }
+    glEnd();
+}

--- a/src/shared/blackbox_gl.h
+++ b/src/shared/blackbox_gl.h
@@ -1,0 +1,22 @@
+#ifndef F15_SE2_BLACKBOX_GL_H
+#define F15_SE2_BLACKBOX_GL_H
+
+#include <SDL3/SDL.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*BlackboxGlSetupFn)(void);
+
+/* Draws the timer after the flight compositor, where the indexed-page overlay
+ * would otherwise be covered by native OpenGL geometry. */
+void blackbox_drawGlOverlay(SDL_Surface *page, int shakeOffset, SDL_Window *window,
+                            SDL_Palette *palette,
+                            BlackboxGlSetupFn setupOverlayState);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_GL_H */

--- a/src/shared/blackbox_internal.h
+++ b/src/shared/blackbox_internal.h
@@ -1,0 +1,10 @@
+#ifndef F15_SE2_BLACKBOX_INTERNAL_H
+#define F15_SE2_BLACKBOX_INTERNAL_H
+
+#include <stdio.h>
+
+/* Private seam used by diagnostic modules. Keeping the recorder's FILE hidden
+ * from gameplay code lets new diagnostics remain separate from blackbox.c. */
+FILE *blackbox_internalRecordFile(void);
+
+#endif /* F15_SE2_BLACKBOX_INTERNAL_H */

--- a/src/shared/blackbox_io.c
+++ b/src/shared/blackbox_io.c
@@ -1,0 +1,63 @@
+#include "blackbox_io.h"
+
+#include "blackbox.h"
+#include "log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static const unsigned char kEmptySnapshotByte = 0;
+
+static void captureMutableFile(const char *name, const char *path) {
+    FILE *file;
+    long fileSize;
+    unsigned char *data;
+
+    if (!blackbox_shouldCaptureMutableFile(name)) return;
+    file = fopen(path, "rb");
+    if (!file) {
+        /* Absence is state too: replay must not fall back to another machine's
+         * local pilot roster when the recording started without one. */
+        blackbox_captureMutableFile(name, NULL, 0);
+        return;
+    }
+    if (fseek(file, 0, SEEK_END) != 0 || (fileSize = ftell(file)) < 0 ||
+        fseek(file, 0, SEEK_SET) != 0 || (unsigned long)fileSize > 0xfffffffful) {
+        log_error("blackbox: unable to size mutable file %s", name);
+        fclose(file);
+        return;
+    }
+    data = fileSize ? (unsigned char *)malloc((size_t)fileSize) : NULL;
+    if ((fileSize && !data) ||
+        (fileSize && fread(data, 1, (size_t)fileSize, file) != (size_t)fileSize)) {
+        log_error("blackbox: unable to capture mutable file %s", name);
+        free(data);
+        fclose(file);
+        return;
+    }
+    blackbox_captureMutableFile(name, data, (uint32)fileSize);
+    free(data);
+    fclose(file);
+}
+
+SDL_IOStream *blackbox_openReadPath(const char *name, const char *resolvedPath) {
+    const uint8 *replayData = NULL;
+    uint32 replaySize = 0;
+    if (blackbox_replayMutableFile(name, &replayData, &replaySize)) {
+        log_info("blackbox: replay loaded %s from captured mutable state", name);
+        return SDL_IOFromConstMem(replaySize ? replayData : &kEmptySnapshotByte,
+                                  replaySize);
+    }
+    captureMutableFile(name, resolvedPath);
+    return SDL_IOFromFile(resolvedPath, "rb");
+}
+
+SDL_IOStream *blackbox_openWritePath(const char *name, const char *resolvedPath) {
+    if (blackbox_suppressPersistentWrites()) {
+        /* A successful disposable stream preserves the caller's normal path;
+         * returning NULL would incorrectly turn every save into an I/O error. */
+        log_info("blackbox: redirected write to %s into memory", name);
+        return SDL_IOFromDynamicMem();
+    }
+    return SDL_IOFromFile(resolvedPath, "wb");
+}

--- a/src/shared/blackbox_io.h
+++ b/src/shared/blackbox_io.h
@@ -1,0 +1,20 @@
+#ifndef F15_SE2_BLACKBOX_IO_H
+#define F15_SE2_BLACKBOX_IO_H
+
+#include <SDL3/SDL.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Blackbox-aware file seams. Outside record/replay these are ordinary SDL file
+ * opens. During replay mutable snapshots are served from memory; writes use a
+ * disposable successful stream so game control flow remains unchanged. */
+SDL_IOStream *blackbox_openReadPath(const char *name, const char *resolvedPath);
+SDL_IOStream *blackbox_openWritePath(const char *name, const char *resolvedPath);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_IO_H */

--- a/src/shared/blackbox_snapshot.c
+++ b/src/shared/blackbox_snapshot.c
@@ -1,0 +1,239 @@
+/* Versioned JSON snapshot for offline blackbox investigation.
+ *
+ * Fields are serialized individually instead of dumping struct bytes. This
+ * avoids compiler padding, host endianness, pointer values, and uninitialized
+ * storage, while retaining every field of the runtime object records. */
+#include "blackbox_snapshot.h"
+
+#include "blackbox.h"
+#include "blackbox_state.h"
+#include "egdata.h"
+
+#include <stdio.h>
+
+enum {
+    SNAPSHOT_FORMAT_VERSION = 1,
+    SNAPSHOT_OBJECT_COUNT = 20,
+    SNAPSHOT_PROJECTILE_COUNT = 12,
+    SNAPSHOT_BULLET_COUNT = 20
+};
+
+extern uint8 timerCounter;
+extern uint8 timerCounter2;
+extern uint8 timerCounter3;
+extern uint8 timerCounter4;
+extern uint8 timerHandlerInstalled;
+
+static unsigned displayedTime(unsigned tick) {
+    return (tick / 60u) * 100u + tick % 60u;
+}
+
+static const char *modeName(BlackboxMode mode) {
+    switch (mode) {
+    case BLACKBOX_DEBUG: return "debug";
+    case BLACKBOX_RECORD: return "record";
+    case BLACKBOX_REPLAY: return "replay";
+    default: return "off";
+    }
+}
+
+static void writeJsonString(FILE *f, const char *value) {
+    const unsigned char *p = (const unsigned char *)(value ? value : "");
+    fputc('"', f);
+    for (; *p; p++) {
+        if (*p == '"' || *p == '\\') {
+            fputc('\\', f);
+            fputc(*p, f);
+        } else if (*p < 0x20) {
+            fprintf(f, "\\u%04x", (unsigned)*p);
+        } else {
+            fputc(*p, f);
+        }
+    }
+    fputc('"', f);
+}
+
+static void writeMissionTables(FILE *f) {
+    int i, j;
+    fputs("  \"waypoints\": [", f);
+    for (i = 0; i < 4; i++) {
+        fprintf(f, "%s{\"slot\":%d,\"map_x\":%u,\"map_y\":%u}",
+                i ? "," : "", i, (unsigned)waypoints[i].mapX,
+                (unsigned)waypoints[i].mapY);
+    }
+    fputs("],\n  \"target_slots\": [\n", f);
+    for (i = 0; i < 2; i++) {
+        const struct TargetSlot *slot = &g_targetSlots[i];
+        fprintf(f,
+                "    {\"slot\":%d,\"state\":%d,\"plane_index\":%d,"
+                "\"view_index\":%d,\"flags\":%d,\"seed_noise\":%d,\"unused\":[",
+                i, (int)slot->state, (int)slot->planeIndex,
+                (int)slot->viewIndex, (int)slot->flags, (int)slot->seedNoise);
+        for (j = 0; j < 4; j++) fprintf(f, "%s%d", j ? "," : "", (int)slot->unused[j]);
+        fprintf(f, "]}%s\n", i == 1 ? "" : ",");
+    }
+    fputs("  ],\n  \"map_targets\": [\n", f);
+    for (i = 0; i < 74; i++) {
+        const struct MapTarget *target = &g_planeTable.planes[i];
+        fprintf(f,
+                "    {\"slot\":%d,\"position\":{\"map_x\":%u,\"map_y\":%u},"
+                "\"active\":%d,\"flags\":%d,\"alert_level\":%d,"
+                "\"threat_timer\":%d,\"name_index\":%d,"
+                "\"secondary_name_index\":%d}%s\n",
+                i, (unsigned)target->mapX, (unsigned)target->mapY,
+                (int)target->active, (int)target->flags,
+                (int)target->alertLevel, (int)target->threatTimer,
+                (int)target->nameIndex, (int)target->secondaryNameIndex,
+                i == 73 ? "" : ",");
+    }
+    fputs("  ],\n", f);
+}
+
+static void writeSimObjects(FILE *f) {
+    int i;
+    fputs("  \"sim_objects\": [\n", f);
+    for (i = 0; i < SNAPSHOT_OBJECT_COUNT; i++) {
+        const struct SimObject *o = &g_simObjects[i];
+        fprintf(f,
+                "    {\"slot\":%d,\"obj_type\":%d,"
+                "\"position\":{\"coarse_x\":%u,\"coarse_y\":%u,"
+                "\"world_x\":%d,\"world_y\":%d,\"altitude\":%d},"
+                "\"orientation\":{\"heading\":%d,\"pitch\":%d,\"bank\":%d},"
+                "\"spec\":%d,\"flags\":%u,\"speed\":%d,\"timer\":%d,"
+                "\"weapon_type\":%d,\"terrain_color\":%d,\"damage\":%d}%s\n",
+                i, (int)o->objType, (unsigned)o->posX, (unsigned)o->posY,
+                (int)o->worldX, (int)o->worldY, (int)o->alt,
+                (int)o->heading.w, (int)o->pitch, (int)o->bank.w,
+                (int)o->spec, (unsigned)o->flags.w, (int)o->speed,
+                (int)o->timer, (int)o->weaponType, (int)o->terrainColor,
+                (int)o->damage, i + 1 == SNAPSHOT_OBJECT_COUNT ? "" : ",");
+    }
+    fputs("  ],\n", f);
+}
+
+static void writeProjectiles(FILE *f) {
+    int i;
+    fputs("  \"projectiles\": [\n", f);
+    for (i = 0; i < SNAPSHOT_PROJECTILE_COUNT; i++) {
+        const struct Projectile *p = &g_projectiles[i];
+        fprintf(f,
+                "    {\"slot\":%d,\"position\":{\"map_x\":%u,\"map_y\":%u,"
+                "\"fine_x\":%d,\"fine_y\":%d,\"interpolated_x\":%d,"
+                "\"interpolated_y\":%d,\"altitude\":%d},"
+                "\"orientation\":{\"world_x\":%d,\"world_y\":%d,\"world_z\":%d},"
+                "\"speed\":%d,\"ttl\":%d,\"spec_index\":%d,"
+                "\"weapon_index\":%d,\"target_lock\":%d,\"target_ref\":%d}%s\n",
+                i, (unsigned)p->mapX, (unsigned)p->mapY, (int)p->fineX,
+                (int)p->fineY, (int)g_projInterpX[i], (int)g_projInterpY[i],
+                (int)p->alt, (int)p->worldX, (int)p->worldY, (int)p->worldZ,
+                (int)p->speed, (int)p->ttl, (int)p->specIdx,
+                (int)p->weaponIdx, (int)p->targetLock, (int)p->targetRef,
+                i + 1 == SNAPSHOT_PROJECTILE_COUNT ? "" : ",");
+    }
+    fputs("  ],\n", f);
+}
+
+static void writeBullets(FILE *f) {
+    int i;
+    fputs("  \"bullet_tracks\": [\n", f);
+    for (i = 0; i < SNAPSHOT_BULLET_COUNT; i++) {
+        const struct BulletTrack *b = &bulletTracks[i];
+        fprintf(f,
+                "    {\"slot\":%d,\"position\":{\"x\":%d,\"y\":%d,\"altitude\":%d},"
+                "\"velocity\":{\"x\":%d,\"y\":%d,\"z\":%d}}%s\n",
+                i, (int)b->posX, (int)b->posY, (int)b->alt,
+                (int)b->velX, (int)b->velY, (int)b->velZ,
+                i + 1 == SNAPSHOT_BULLET_COUNT ? "" : ",");
+    }
+    fputs("  ]\n", f);
+}
+
+int blackbox_snapshotWriteJson(const char *path) {
+    FILE *f;
+    unsigned tick;
+    int closeResult;
+    BlackboxDebugState debug;
+    if (!path || !*path) return 0;
+    f = fopen(path, "w");
+    if (!f) return 0;
+
+    tick = (unsigned)blackbox_tick();
+    blackbox_getDebugState(&debug);
+    fprintf(f, "{\n  \"format\":\"f15se2-blackbox-state\",\n  \"version\":%d,\n",
+            SNAPSHOT_FORMAT_VERSION);
+    fputs("  \"provenance\":{\"build_version\":", f);
+    writeJsonString(f, blackbox_state_currentBuildVersion());
+    fputs(",\"replay_build_version\":", f);
+    writeJsonString(f, blackbox_state_replayBuildVersion());
+    fputs("},\n", f);
+    fprintf(f, "  \"time\":{\"raw_tick\":%u,\"displayed\":%u},\n",
+            tick, displayedTime(tick));
+    fprintf(f,
+            "  \"blackbox\":{\"mode\":\"%s\",\"input_pump\":%u,"
+            "\"configured_seed\":%u,\"rng_state\":%u,"
+            "\"pause_tick\":%u,\"fast_forward_tick\":%u,"
+            "\"cursors\":{\"keys\":[%u,%u],\"axes\":[%u,%u],"
+            "\"seeds\":[%u,%u],\"rng\":[%u,%u],\"frames\":[%u,%u],"
+            "\"frame_index\":%u}},\n",
+            modeName(debug.mode), (unsigned)debug.inputPump,
+            (unsigned)debug.configuredSeed, (unsigned)debug.rngState,
+            (unsigned)debug.pauseTick, (unsigned)debug.fastForwardTick,
+            (unsigned)debug.keyPosition, (unsigned)debug.keyCount,
+            (unsigned)debug.axesPosition, (unsigned)debug.axesCount,
+            (unsigned)debug.seedPosition, (unsigned)debug.seedCount,
+            (unsigned)debug.rngPosition, (unsigned)debug.rngCount,
+            (unsigned)debug.framePosition, (unsigned)debug.frameCount,
+            (unsigned)debug.frameIndex);
+    fprintf(f,
+            "  \"timing\":{\"timer_installed\":%u,\"counters\":[%u,%u,%u,%u],"
+            "\"frame_tick\":%d,\"sim_steps_this_frame\":%d,"
+            "\"render_alpha_q12\":%d,\"game_rng_seed\":%d},\n",
+            (unsigned)timerHandlerInstalled, (unsigned)timerCounter,
+            (unsigned)timerCounter2, (unsigned)timerCounter3,
+            (unsigned)timerCounter4, (int)frameTick, g_simStepsThisFrame,
+            g_renderAlphaQ12, (int)g_rngSeed);
+    fprintf(f,
+            "  \"flight\":{\"position\":{\"x\":%d,\"y\":%d,\"altitude\":%d},"
+            "\"orientation\":{\"heading\":%d,\"pitch\":%d,\"roll\":%d},"
+            "\"velocity\":%d,\"knots\":%d,\"fuel_remaining\":%d,"
+            "\"damage_flag\":%d,\"plane_flags\":%d},\n",
+            (int)g_ViewX, (int)g_ViewY, (int)g_viewZ, (int)g_ourHead,
+            (int)g_ourPitch, (int)g_ourRoll, g_velocity, (int)g_knots,
+            (int)g_fuelRemaining, (int)g_damageTakenFlag, (int)g_playerPlaneFlags);
+    fprintf(f,
+            "  \"camera\":{\"mode\":%d,\"eye\":{\"x\":%d,\"y\":%d,\"z\":%d},"
+            "\"orientation\":{\"heading\":%d,\"pitch\":%d,\"roll\":%d},"
+            "\"target\":{\"x\":%d,\"y\":%d,\"altitude\":%d,\"object\":%d},"
+            "\"external_distance\":%d},\n",
+            (int)g_viewMode, (int)g_camEyeX, (int)g_camEyeY, (int)g_camEyeZ,
+            (int)g_viewHeading, (int)g_viewPitch, (int)g_viewRoll,
+            (int)g_viewTargetX, (int)g_viewTargetY, (int)g_viewTargetAlt,
+            (int)g_viewTargetObj, (int)g_externalCamDist);
+    fprintf(f,
+            "  \"target_mission\":{\"tracked_enemy\":%d,\"air_lock\":%d,"
+            "\"ground_lock\":%d,\"aam_lock_active\":%d,\"target_in_hud\":%d,"
+            "\"target_lead_angle\":%d,\"mission_status\":%d,\"mission_tick\":%d,"
+            "\"mission_ended\":%u,\"enemy_air_remaining\":%d,"
+            "\"enemy_ground_remaining\":%d,\"final_threat_score\":%d},\n",
+            (int)g_trackedEnemyIdx, (int)g_airTargetLock,
+            (int)g_groundTargetLock, (int)g_aamLockActive,
+            (int)g_targetInHudFlag, (int)g_targetLeadAngle,
+            (int)g_missionStatus, (int)g_missionTick,
+            (unsigned)g_missionEndedFlag[0], (int)g_enemyAirRemaining,
+            (int)g_enemyGroundRemaining, (int)g_finalThreatScore);
+    fprintf(f,
+            "  \"weapons\":{\"gun_ammo\":%d,\"current_type\":%d,"
+            "\"last_missile_slot\":%d,\"fire_cooldown\":%d,"
+            "\"active_bullet_tracks\":%d},\n",
+            (int)g_gunAmmo, (int)g_currentWeaponType,
+            (int)g_lastMissileSlot, (int)g_fireCooldown,
+            (int)g_bulletTrackCount);
+    writeMissionTables(f);
+    writeSimObjects(f);
+    writeProjectiles(f);
+    writeBullets(f);
+    fputs("}\n", f);
+
+    closeResult = fclose(f);
+    return closeResult == 0;
+}

--- a/src/shared/blackbox_snapshot.c
+++ b/src/shared/blackbox_snapshot.c
@@ -152,6 +152,7 @@ int blackbox_snapshotWriteJson(const char *path) {
     FILE *f;
     unsigned tick;
     int closeResult;
+    int writeFailed = 0;
     BlackboxDebugState debug;
     if (!path || !*path) return 0;
     f = fopen(path, "w");
@@ -234,6 +235,8 @@ int blackbox_snapshotWriteJson(const char *path) {
     writeBullets(f);
     fputs("}\n", f);
 
+    /* An earlier failed write need not make fclose fail too. */
+    writeFailed = ferror(f);
     closeResult = fclose(f);
-    return closeResult == 0;
+    return closeResult == 0 && !writeFailed;
 }

--- a/src/shared/blackbox_snapshot.h
+++ b/src/shared/blackbox_snapshot.h
@@ -1,0 +1,17 @@
+#ifndef F15_SE2_BLACKBOX_SNAPSHOT_H
+#define F15_SE2_BLACKBOX_SNAPSHOT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Write a stable, machine-readable view of authoritative gameplay objects.
+ * This is deliberately write-only: restoring these fields without rebuilding
+ * derived caches and pointers would create invalid runtime state. */
+int blackbox_snapshotWriteJson(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_SNAPSHOT_H */

--- a/src/shared/blackbox_state.c
+++ b/src/shared/blackbox_state.c
@@ -1,0 +1,182 @@
+/*
+ * Portable blackbox state metadata.
+ *
+ * Keep mutable-state capture separate from the event recorder. The replay core
+ * records deterministic input/timer/RNG events; this file records the external
+ * state needed to make those events meaningful on another developer machine.
+ */
+#include "blackbox_state.h"
+#include "log.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct BlackboxMutableFile {
+    char name[32];
+    uint8 *data;
+    uint32 size;
+    int recorded;
+} BlackboxMutableFile;
+
+static const char *s_currentBuildVersion = "unknown";
+static char s_replayBuildVersion[128];
+static int s_haveReplayBuildVersion = 0;
+static int s_allowBuildMismatch = 0;
+static BlackboxMutableFile s_hallfame;
+
+static int sameName(const char *a, const char *b) {
+    unsigned char ca, cb;
+    if (!a || !b) return 0;
+    do {
+        ca = (unsigned char)*a++;
+        cb = (unsigned char)*b++;
+        if (tolower(ca) != tolower(cb)) return 0;
+    } while (ca && cb);
+    return 1;
+}
+
+static unsigned char hexDigit(unsigned value) {
+    static const char digits[] = "0123456789abcdef";
+    return (unsigned char)digits[value & 0xfu];
+}
+
+static int fromHexDigit(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static void freeMutableFile(BlackboxMutableFile *file) {
+    free(file->data);
+    file->data = NULL;
+    file->name[0] = '\0';
+    file->size = 0;
+    file->recorded = 0;
+}
+
+void blackbox_state_reset(void) {
+    s_replayBuildVersion[0] = '\0';
+    s_haveReplayBuildVersion = 0;
+    freeMutableFile(&s_hallfame);
+}
+
+void blackbox_state_setBuildVersion(const char *version) {
+    s_currentBuildVersion = (version && version[0]) ? version : "unknown";
+}
+
+void blackbox_state_setAllowBuildMismatch(int allow) {
+    s_allowBuildMismatch = allow != 0;
+}
+
+const char *blackbox_state_currentBuildVersion(void) {
+    return s_currentBuildVersion;
+}
+
+const char *blackbox_state_replayBuildVersion(void) {
+    return s_haveReplayBuildVersion ? s_replayBuildVersion : "";
+}
+
+void blackbox_state_writeRecordHeader(FILE *file) {
+    if (!file) return;
+    fprintf(file, "build_version %s\n", s_currentBuildVersion);
+}
+
+int blackbox_state_shouldCaptureMutableFile(const char *name) {
+    return sameName(name, "HallFame") && !s_hallfame.recorded;
+}
+
+void blackbox_state_recordMutableFile(FILE *file, const char *name, const uint8 *data, uint32 size) {
+    uint32 i;
+    if (!file || !name || (!data && size != 0) || !blackbox_state_shouldCaptureMutableFile(name)) return;
+    fprintf(file, "mutable_file HallFame %u ", (unsigned)size);
+    if (size == 0) fputc('-', file);
+    for (i = 0; i < size; i++) {
+        fputc(hexDigit(data[i] >> 4), file);
+        fputc(hexDigit(data[i]), file);
+    }
+    fputc('\n', file);
+    fflush(file);
+    s_hallfame.recorded = 1;
+}
+
+static int parseMutableFile(const char *name, unsigned size, const char *hex) {
+    uint8 *data;
+    unsigned i;
+    size_t encodedSize;
+    if (!sameName(name, "HallFame")) return -1;
+    if (size == 0) {
+        if (strcmp(hex, "-") != 0) return -1;
+        encodedSize = 0;
+    } else {
+        encodedSize = (size_t)size * 2u;
+        if (strlen(hex) != encodedSize) return -1;
+    }
+    data = (uint8 *)malloc(size ? size : 1u);
+    if (!data) return -1;
+    for (i = 0; i < size; i++) {
+        int hi = fromHexDigit(hex[i * 2u]);
+        int lo = fromHexDigit(hex[i * 2u + 1u]);
+        if (hi < 0 || lo < 0) {
+            free(data);
+            return -1;
+        }
+        data[i] = (uint8)((hi << 4) | lo);
+    }
+    freeMutableFile(&s_hallfame);
+    strncpy(s_hallfame.name, "HallFame", sizeof(s_hallfame.name) - 1u);
+    s_hallfame.name[sizeof(s_hallfame.name) - 1u] = '\0';
+    s_hallfame.data = data;
+    s_hallfame.size = (uint32)size;
+    s_hallfame.recorded = 1;
+    return 1;
+}
+
+int blackbox_state_parseReplayLine(const char *line) {
+    char build[128];
+    char name[32];
+    char hex[8192];
+    unsigned size;
+
+    if (sscanf(line, "build_version %127s", build) == 1) {
+        strncpy(s_replayBuildVersion, build, sizeof(s_replayBuildVersion) - 1u);
+        s_replayBuildVersion[sizeof(s_replayBuildVersion) - 1u] = '\0';
+        s_haveReplayBuildVersion = 1;
+        return 1;
+    }
+
+    if (sscanf(line, "mutable_file %31s %u %8191s", name, &size, hex) == 3) {
+        return parseMutableFile(name, size, hex);
+    }
+
+    return 0;
+}
+
+int blackbox_state_validateReplay(void) {
+    if (!s_haveReplayBuildVersion) {
+        log_error("blackbox: replay log has no build_version metadata");
+        return 0;
+    }
+    if (strcmp(s_replayBuildVersion, s_currentBuildVersion) != 0) {
+        if (!s_allowBuildMismatch) {
+            log_error("blackbox: build mismatch: log=%s current=%s; use --blackbox-replay-ignore-build to inspect anyway",
+                      s_replayBuildVersion, s_currentBuildVersion);
+            return 0;
+        }
+        log_info("blackbox: ignoring build mismatch: log=%s current=%s",
+                 s_replayBuildVersion, s_currentBuildVersion);
+    }
+    if (!s_hallfame.recorded) {
+        log_error("blackbox: replay log has no HallFame snapshot");
+        return 0;
+    }
+    return 1;
+}
+
+int blackbox_state_getReplayMutableFile(const char *name, const uint8 **data, uint32 *size) {
+    if (!sameName(name, "HallFame") || !s_hallfame.recorded) return 0;
+    *data = s_hallfame.data;
+    *size = s_hallfame.size;
+    return 1;
+}

--- a/src/shared/blackbox_state.h
+++ b/src/shared/blackbox_state.h
@@ -1,0 +1,28 @@
+#ifndef F15_SE2_BLACKBOX_STATE_H
+#define F15_SE2_BLACKBOX_STATE_H
+
+#include "inttype.h"
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void blackbox_state_reset(void);
+void blackbox_state_setBuildVersion(const char *version);
+void blackbox_state_setAllowBuildMismatch(int allow);
+const char *blackbox_state_currentBuildVersion(void);
+const char *blackbox_state_replayBuildVersion(void);
+void blackbox_state_writeRecordHeader(FILE *file);
+int blackbox_state_parseReplayLine(const char *line);
+int blackbox_state_validateReplay(void);
+int blackbox_state_shouldCaptureMutableFile(const char *name);
+void blackbox_state_recordMutableFile(FILE *file, const char *name, const uint8 *data, uint32 size);
+int blackbox_state_getReplayMutableFile(const char *name, const uint8 **data, uint32 *size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_STATE_H */

--- a/src/shared/blackbox_wait.c
+++ b/src/shared/blackbox_wait.c
@@ -7,6 +7,9 @@
 int blackbox_virtualWait(uint32 durationTicks, int stopOnInput,
                          BlackboxPollInputFn pollInput) {
     uint32 startTick;
+    /* Record and replay must execute the same polling path. Record-mode timer
+     * pumps are native 60 Hz, so this remains real-time without making the
+     * number of input polls depend on a separate host-clock wait loop. */
     if (!blackbox_enabled()) return 0;
 
     startTick = blackbox_tick();

--- a/src/shared/blackbox_wait.c
+++ b/src/shared/blackbox_wait.c
@@ -1,0 +1,19 @@
+#include "blackbox_wait.h"
+
+#include "blackbox.h"
+
+#include <SDL3/SDL.h>
+
+int blackbox_virtualWait(uint32 durationTicks, int stopOnInput,
+                         BlackboxPollInputFn pollInput) {
+    uint32 startTick;
+    if (!blackbox_enabled()) return 0;
+
+    startTick = blackbox_tick();
+    while (blackbox_tick() - startTick < durationTicks) {
+        if (pollInput && pollInput() && stopOnInput) break;
+        /* Keep the host responsive without using elapsed host time as state. */
+        if (!blackbox_fastForwarding()) SDL_DelayNS(2 * SDL_NS_PER_MS);
+    }
+    return 1;
+}

--- a/src/shared/blackbox_wait.h
+++ b/src/shared/blackbox_wait.h
@@ -1,0 +1,22 @@
+#ifndef F15_SE2_BLACKBOX_WAIT_H
+#define F15_SE2_BLACKBOX_WAIT_H
+
+#include "inttype.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef bool (*BlackboxPollInputFn)(void);
+
+/* Runs a bounded wait on blackbox virtual time. Returns zero outside blackbox
+ * mode so the caller can retain its normal wall-clock implementation. */
+int blackbox_virtualWait(uint32 durationTicks, int stopOnInput,
+                         BlackboxPollInputFn pollInput);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F15_SE2_BLACKBOX_WAIT_H */

--- a/src/shared/file_io.c
+++ b/src/shared/file_io.c
@@ -3,6 +3,7 @@
  */
 
 #include "inttype.h"
+#include "blackbox_io.h"
 #include "log.h"
 #include <SDL3/SDL.h>
 #include <quickdigest5.hpp>
@@ -62,13 +63,15 @@ static string resolveCasePath(const char *filename, const bool require = false) 
 SDL_IOStream *openFile(const char *filename, int mode) {
     (void)mode; /* the resident open service only distinguished read vs. write;
                  * every openFile caller in the game opens an asset for reading */
-    return SDL_IOFromFile(resolveCasePath(filename).c_str(), "rb");
+    const string path = resolveCasePath(filename);
+    return blackbox_openReadPath(filename, path.c_str());
 }
 
 /* Create or truncate a file for writing. Returns the stream, or NULL on failure. */
 SDL_IOStream *createFile(const char *filename, int attr) {
     (void)attr;
-    return SDL_IOFromFile(resolveCasePath(filename).c_str(), "wb");
+    const string path = resolveCasePath(filename);
+    return blackbox_openWritePath(filename, path.c_str());
 }
 
 void fileClose(SDL_IOStream *io) {

--- a/src/shared/ovlimpl.c
+++ b/src/shared/ovlimpl.c
@@ -7,6 +7,7 @@
 #include "comm.h"
 #include "const.h"
 #include "input.h"
+#include "shared/blackbox.h"
 #include <dos.h>
 #include <SDL3/SDL.h>
 
@@ -28,7 +29,7 @@ int far cdecl misc_checkKeyBuf(void) {
      * waits advance the clock (via the pump) without pegging a core. egame's
      * per-frame loop uses INPUT_MODE_FLIGHT, so it is unaffected. */
     bool waiting = input_keyWaiting();
-    SDL_DelayNS(SDL_NS_PER_MS);
+    if (!blackbox_fastForwarding()) SDL_DelayNS(SDL_NS_PER_MS);
     return waiting ? 0 : 0xFFFF;
 }
 

--- a/src/shared/timer.c
+++ b/src/shared/timer.c
@@ -38,6 +38,17 @@ static void(FAR *gameTickHook)(void) = 0;
 static Uint64 nextTickNs; /* clock time the next pending tick is due */
 static bool timerRunning = false;
 
+static void advanceTimerTick(int trackBlackbox) {
+    timerCounter++;
+    timerCounter2++;
+    timerCounter3++;
+    timerCounter4++;
+    if (trackBlackbox) blackbox_noteTick();
+    if (gameTickHook != 0)
+        gameTickHook();
+    if (trackBlackbox) blackbox_afterTick();
+}
+
 void setTimerTickHook(void(far *fn)(void)) {
     gameTickHook = fn;
 }
@@ -46,39 +57,41 @@ void setTimerTickHook(void(far *fn)(void)) {
  * per 1/60 s tick. Safe to call as often as a spin loop likes. */
 void timerPump(void) {
     Uint64 now;
+    uint32 pumpStartTick;
+    uint32 pumpedTicks = 0;
     if (!timerRunning) return;
-    if (blackbox_enabled()) {
-        if (blackbox_pauseReached()) return;
-        timerCounter++;
-        timerCounter2++;
-        timerCounter3++;
-        timerCounter4++;
-        blackbox_noteTick();
-        if (gameTickHook != 0)
-            gameTickHook();
-        /* A tick snapshot must observe the completed per-tick game update, not
-         * the state between incrementing the clock and running its hook. */
-        blackbox_afterTick();
+    if (blackbox_replaying()) {
+        uint32 replayTicks = blackbox_replayTimerPump();
+        while (replayTicks-- != 0 && !blackbox_pauseReached())
+            advanceTimerTick(1);
         return;
     }
+    if (blackbox_usesVirtualTime()) {
+        if (blackbox_pauseReached()) return;
+        advanceTimerTick(1);
+        return;
+    }
+    pumpStartTick = blackbox_tick();
     now = SDL_GetTicksNS();
     if (now > nextTickNs + MAX_CATCHUP_NS)
         nextTickNs = now; /* fell too far behind: resync, don't burst */
     while (now >= nextTickNs) {
+        if (blackbox_recording() && blackbox_pauseReached()) break;
         nextTickNs += TICK_NS;
-        timerCounter++;
-        timerCounter2++;
-        timerCounter3++;
-        timerCounter4++;
-        if (gameTickHook != 0)
-            gameTickHook();
+        advanceTimerTick(blackbox_recording());
+        pumpedTicks++;
     }
+    if (blackbox_recording())
+        blackbox_recordTimerPump(pumpStartTick, pumpedTicks);
 }
 
 /* Monotonic clock in nanoseconds, for the render loop's fixed-timestep sim
  * pacing and interpolation alpha (same clock timerPump advances the 60 Hz ticks
  * from, so sim cadence and tick counters stay coherent). */
 uint64 timerNowNs(void) {
+    /* Recording is paced by native ticks, but simulation observes the same
+     * tick-derived clock as replay. Host scheduling jitter must not change how
+     * many fixed simulation steps a recorded frame performs. */
     if (blackbox_enabled()) return blackbox_timerNowNs();
     return SDL_GetTicksNS();
 }

--- a/src/shared/timer.c
+++ b/src/shared/timer.c
@@ -14,6 +14,7 @@
  */
 
 #include "inttype.h"
+#include "blackbox.h"
 #include <dos.h>
 #include <SDL3/SDL.h>
 
@@ -46,6 +47,20 @@ void setTimerTickHook(void(far *fn)(void)) {
 void timerPump(void) {
     Uint64 now;
     if (!timerRunning) return;
+    if (blackbox_enabled()) {
+        if (blackbox_pauseReached()) return;
+        timerCounter++;
+        timerCounter2++;
+        timerCounter3++;
+        timerCounter4++;
+        blackbox_noteTick();
+        if (gameTickHook != 0)
+            gameTickHook();
+        /* A tick snapshot must observe the completed per-tick game update, not
+         * the state between incrementing the clock and running its hook. */
+        blackbox_afterTick();
+        return;
+    }
     now = SDL_GetTicksNS();
     if (now > nextTickNs + MAX_CATCHUP_NS)
         nextTickNs = now; /* fell too far behind: resync, don't burst */
@@ -64,6 +79,7 @@ void timerPump(void) {
  * pacing and interpolation alpha (same clock timerPump advances the 60 Hz ticks
  * from, so sim cadence and tick counters stay coherent). */
 uint64 timerNowNs(void) {
+    if (blackbox_enabled()) return blackbox_timerNowNs();
     return SDL_GetTicksNS();
 }
 
@@ -71,7 +87,7 @@ uint64 timerNowNs(void) {
  * clock and yield the CPU so the wait doesn't peg a core. */
 void timerYield(void) {
     timerPump();
-    SDL_DelayNS(SDL_NS_PER_MS);
+    if (!blackbox_fastForwarding()) SDL_DelayNS(SDL_NS_PER_MS);
 }
 
 void setTimerIrqHandler(void) {

--- a/src/stgen.c
+++ b/src/stgen.c
@@ -200,8 +200,8 @@ counterMore1k:
     missionTarget2X = worldObjects[targets[1].targetIdx].x_coord;
     missionTarget2Y = worldObjects[targets[1].targetIdx].y_coord;
     if (missionPick == 2) {
-        missionTarget2X += (rand() & 0x1000) - 0x800;
-        missionTarget2Y += (rand() & 0x1000) - 0x800;
+        missionTarget2X += (gameRand15() & 0x1000) - 0x800;
+        missionTarget2Y += (gameRand15() & 0x1000) - 0x800;
     }
     if (targets[0].missionCode & 0x10) {
         missionTargetX = ((missionTargetX >> 0xa) << 0xa) + 0x200;

--- a/src/stmain.c
+++ b/src/stmain.c
@@ -9,6 +9,7 @@
 #include "stalloc.h"
 #include "stcode.h"
 #include "stdata.h"
+#include "strand.h"
 #include "stgen.h"
 #include "stinit.h"
 #include "stmissn.h"
@@ -94,7 +95,7 @@ int start_main(void) {
     gameData->campaignProgress = 0;
     gameData->rand = 12345;
     joyAxes[0] = joyAxes[1] = JOY_CENTER;
-    srand(gameData->rand);
+    gameSrand(gameData->rand);
     missionGenerate();
 #else
     difficulty = gameData->difficulty;
@@ -126,9 +127,9 @@ int start_main(void) {
     /* Check if same diff and thea picked as last time */
     if (gameData->difficulty == difficulty && gameData->theater == theater && missionPick == -1 && askRepeatMission() != 0)
         goto doSrand;
-    gameData->rand = rand();
+    gameData->rand = gameRand();
 doSrand:
-    srand(gameData->rand);
+    gameSrand(gameData->rand);
     missionDecode();
     missionGenerate();
 #endif

--- a/src/stmissn.c
+++ b/src/stmissn.c
@@ -12,6 +12,7 @@
 #include "stdata.h"
 #include "stgen.h"
 #include "stmissn.h"
+#include "shared/blackbox.h"
 #include "stpilot.h"
 #include "stsprit.h"
 #include "sttypes.h"
@@ -151,7 +152,7 @@ int joyOrKey() {
 }
 
 void waitMdaCgaStatus(int16 iter) {
-    SDL_Delay(1000 * iter / 60);
+    if (!blackbox_fastForwarding()) SDL_Delay(1000 * iter / 60);
 }
 
 void drawLine(const int16 *pageNum, int x1, int y1, int x2, int y2, int color) {

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -301,6 +301,8 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
 void loadHallfame(void) {
     int slotIdx;
     SDL_IOStream *handle;
+    selectedPilotIdx = 0;
+    memset(hallfameBuf, 0, HALLFAME_RECORDSZ * HALLFAME_SLOTS);
     handle = openFile("HallFame", 0);
     fileRead(&selectedPilotIdx, 2, 1, handle);
     slotIdx = 0;

--- a/src/strand.c
+++ b/src/strand.c
@@ -1,14 +1,46 @@
 /* Random number utilities */
 #include "strand.h"
 #include "shared/common.h"
+#include "shared/blackbox.h"
 
 #include <dos.h>
 
 void seedRandom() {
+    if (blackbox_randomActive()) {
+        blackbox_seedConfiguredRandom();
+        return;
+    }
     srand(getTimeOfDay());
+}
+
+void gameSrand(uint32 seed) {
+    if (blackbox_randomActive()) {
+        blackbox_seedRandom(seed);
+    } else {
+        srand(seed);
+    }
+}
+
+void gameSrandFromClock(int16 *seed) {
+    if (blackbox_randomActive()) {
+        int16 clockSeed = blackbox_recording() ? (int16)getTimeOfDay() : 0;
+        uint32 externalSeed = (uint32)clockSeed;
+        *seed = (int16)blackbox_seedExternalRandom(externalSeed);
+    } else {
+        *seed = getTimeOfDay();
+        srand(*seed);
+    }
+}
+
+int gameRand(void) {
+    return blackbox_randomActive() ? blackbox_rand15() : rand();
+}
+
+int gameRand15(void) {
+    return blackbox_randomActive() ? blackbox_rand15() : (rand() & 0x7fff);
 }
 
 int16 randMul(uint16 arg) {
     /* DOS rand() is 15-bit (RAND_MAX 0x7fff); mask to match so the >>15 scaling yields [0, arg). */
-    return ((rand() & 0x7fff) * (int32)arg) >> 0xf;
+    return (gameRand15() * (int32)arg) >> 0xf;
 }

--- a/src/strand.h
+++ b/src/strand.h
@@ -4,6 +4,10 @@
 #include "inttype.h"
 
 void seedRandom();
+void gameSrand(uint32 seed);
+void gameSrandFromClock(int16 *seed);
+int gameRand(void);
+int gameRand15(void);
 int16 randMul(uint16);
 
 #endif /* F15_SE2_STRAND */

--- a/tests/blackbox_behavior_tests.cpp
+++ b/tests/blackbox_behavior_tests.cpp
@@ -8,9 +8,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <string>
-#include <unistd.h>
 
 namespace {
 
@@ -42,10 +42,14 @@ void require(bool condition, const char *message) {
 }
 
 std::string tempLogPath() {
-    char path[] = "/tmp/f15-blackbox-test-XXXXXX";
-    int fd = mkstemp(path);
-    if (fd >= 0) close(fd);
-    return std::string(path);
+    static unsigned sequence = 0;
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() /
+        ("f15-blackbox-test-" + std::to_string(SDL_GetTicksNS()) + "-" +
+         std::to_string(sequence++));
+    FILE *file = std::fopen(path.string().c_str(), "wb");
+    if (file) std::fclose(file);
+    return path.string();
 }
 
 } // namespace

--- a/tests/blackbox_behavior_tests.cpp
+++ b/tests/blackbox_behavior_tests.cpp
@@ -190,6 +190,8 @@ int main() {
     require(blackbox_replayNextKey(&word) != 0 && word == kBiosWord,
             "replay emits the recorded BIOS key on the matching input poll");
     blackbox_diagMarker("test_event", 1, 2, 3);
+    blackbox_diagMarker("test_event", 1, 2, 3);
+    blackbox_diagCaptureSimStep();
     blackbox_diagCaptureSimStep();
     {
         R3DScene scene = {nullptr, 1, 2, 3, 4, 5, 6, 1};
@@ -199,6 +201,7 @@ int main() {
         blackbox_diagRenderBeginScene(&scene);
         blackbox_diagRenderSubmit(&submit);
         blackbox_diagRenderLine(&line);
+        blackbox_diagRenderEndScene();
         blackbox_diagRenderEndScene();
     }
     uint8 rawX = 0x80, rawY = 0x80, joyX = 0x80, joyY = 0x80;

--- a/tests/blackbox_behavior_tests.cpp
+++ b/tests/blackbox_behavior_tests.cpp
@@ -250,7 +250,7 @@ int main() {
     {
         FILE *tickMismatchLog = std::fopen(badPath.c_str(), "w");
         require(tickMismatchLog != nullptr, "test can create an RNG replay log");
-        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nrng_seed 9 4321\nrng 9 2468\n", tickMismatchLog);
+        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nrng_seed 9 4321\nrng 9 2468\n", tickMismatchLog);
         std::fclose(tickMismatchLog);
         require(blackbox_startReplay(badPath.c_str()) != 0,
                 "replay accepts a log with captured RNG events");
@@ -372,7 +372,7 @@ int main() {
     {
         FILE *badLog = std::fopen(badPath.c_str(), "w");
         require(badLog != nullptr, "test can create a malformed replay log");
-        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nkey 1 1 10000\n", badLog);
+        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nkey 1 1 10000\n", badLog);
         std::fclose(badLog);
         require(blackbox_startReplay(badPath.c_str()) == 0,
                 "replay rejects out-of-range BIOS key words instead of truncating them");
@@ -381,7 +381,7 @@ int main() {
     {
         FILE *badLog = std::fopen(badPath.c_str(), "w");
         require(badLog != nullptr, "test can create a malformed snapshot log");
-        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 1 00ff\n", badLog);
+        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 1 00ff\n", badLog);
         std::fclose(badLog);
         require(blackbox_startReplay(badPath.c_str()) == 0,
                 "replay rejects mutable snapshots with trailing data");
@@ -390,7 +390,7 @@ int main() {
     {
         FILE *largeLog = std::fopen(badPath.c_str(), "w");
         require(largeLog != nullptr, "test can create a multi-capacity replay log");
-        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 0 -\n", largeLog);
+        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 0 -\n", largeLog);
         for (int i = 0; i < 130; i++)
             std::fprintf(largeLog, "key 0 0 %04x\n", i + 1);
         std::fclose(largeLog);

--- a/tests/blackbox_behavior_tests.cpp
+++ b/tests/blackbox_behavior_tests.cpp
@@ -1,0 +1,404 @@
+#include "shared/blackbox.h"
+#include "shared/blackbox_cli.h"
+#include "shared/blackbox_diag.h"
+#include "shared/blackbox_wait.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+enum BlackboxTestConstant : int {
+    kSeed = BLACKBOX_DEFAULT_SEED,
+    kOtherSeed = 4321,
+    kBiosWord = 0x1f73,
+    kRawX = 0x40,
+    kRawY = 0xc0,
+    kJoyX = 0x30,
+    kJoyY = 0xd0,
+    kTestFailureExitCode = 1,
+};
+
+const unsigned char kHallFameSnapshot[] = {'H', 'A', 'L', 'L'};
+int gVirtualWaitPolls = 0;
+
+bool pollVirtualWait() {
+    gVirtualWaitPolls++;
+    blackbox_noteTick();
+    return gVirtualWaitPolls >= 3;
+}
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(kTestFailureExitCode);
+    }
+}
+
+std::string tempLogPath() {
+    char path[] = "/tmp/f15-blackbox-test-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd >= 0) close(fd);
+    return std::string(path);
+}
+
+} // namespace
+
+int main() {
+    const std::string path = tempLogPath();
+    const std::string badPath = tempLogPath();
+
+    {
+        BlackboxCliOptions options;
+        char program[] = "f15se2-ex";
+        char recordOption[] = "--blackbox-record";
+        char recordPath[] = "/tmp/test.bb";
+        char *recordArgv[] = {program, recordOption, recordPath};
+        int index = 1;
+        blackbox_cliInit(&options);
+        require(options.seed == BLACKBOX_DEFAULT_SEED,
+                "blackbox CLI uses the documented default seed");
+        require(blackbox_cliParseOption(&options, 3, recordArgv, &index) == 1 &&
+                    options.recordPath == recordPath && index == 2,
+                "blackbox CLI parses and consumes a record path");
+
+        char seedOption[] = "--blackbox-seed";
+        char invalidSeed[] = "not-a-number";
+        char *seedArgv[] = {program, seedOption, invalidSeed};
+        index = 1;
+        require(blackbox_cliParseOption(&options, 3, seedArgv, &index) == -1,
+                "blackbox CLI rejects malformed numeric values");
+
+        char negativeSeed[] = "-1";
+        seedArgv[2] = negativeSeed;
+        index = 1;
+        require(blackbox_cliParseOption(&options, 3, seedArgv, &index) == -1,
+                "blackbox CLI rejects negative unsigned values portably");
+
+        char fastForwardOption[] = "--blackbox-fast-forward-tick";
+        char fastForwardTick[] = "20545";
+        char *fastForwardArgv[] = {program, fastForwardOption, fastForwardTick};
+        index = 1;
+        require(blackbox_cliParseOption(&options, 3, fastForwardArgv, &index) == 1 &&
+                    options.fastForwardTick == 12345 && index == 2,
+                "blackbox CLI converts displayed time to its internal tick");
+
+        char dumpOption[] = "--blackbox-dump-tick";
+        char dumpTick[] = "20545";
+        char *dumpArgv[] = {program, dumpOption, dumpTick};
+        index = 1;
+        require(blackbox_cliParseOption(&options, 3, dumpArgv, &index) == 1 &&
+                    options.dumpTick == 12345 && index == 2,
+                "blackbox CLI parses an automatic snapshot time");
+
+        char zeroDumpTick[] = "0";
+        dumpArgv[2] = zeroDumpTick;
+        index = 1;
+        require(blackbox_cliParseOption(&options, 3, dumpArgv, &index) == -1,
+                "blackbox CLI rejects a dump before game state can be captured");
+
+        char invalidDisplayedTick[] = "20575";
+        fastForwardArgv[2] = invalidDisplayedTick;
+        index = 1;
+        require(blackbox_cliParseOption(&options, 3, fastForwardArgv, &index) == -1,
+                "blackbox CLI rejects impossible displayed subticks");
+
+        char captureRenderOption[] = "--blackbox-capture-render";
+        char *captureRenderArgv[] = {program, captureRenderOption};
+        index = 1;
+        require(blackbox_cliParseOption(&options, 2, captureRenderArgv, &index) == 1 &&
+                    options.captureRender != 0,
+                "blackbox CLI enables detailed render-command capture");
+    }
+
+    require(blackbox_startRecord(path.c_str(), kSeed) != 0,
+            "blackbox opens a text record log");
+    blackbox_logPhase("test");
+    blackbox_noteTick();
+    blackbox_noteInputPump();
+    blackbox_recordKey(kBiosWord);
+    blackbox_diagMarker("test_event", 1, 2, 3);
+    blackbox_diagCaptureSimStep();
+    blackbox_diagSetRenderCapture(1);
+    {
+        R3DScene scene = {nullptr, 1, 2, 3, 4, 5, 6, 1};
+        R3DSubmit submit = {nullptr, 7, 8, 9, 10, 11, 12, 0};
+        R3DLine line = {1, 2, 3, 4, 5, 6, 15};
+        blackbox_diagBeginRenderFrame();
+        blackbox_diagRenderBeginScene(&scene);
+        blackbox_diagRenderSubmit(&submit);
+        blackbox_diagRenderLine(&line);
+        blackbox_diagRenderEndScene();
+    }
+    blackbox_recordAxes(kRawX, kRawY, kJoyX, kJoyY);
+    blackbox_captureMutableFile("HallFame", kHallFameSnapshot, sizeof(kHallFameSnapshot));
+    blackbox_seedRandom(kSeed);
+    const int recordedRand = blackbox_rand15();
+    blackbox_shutdown();
+
+    {
+        FILE *recorded = std::fopen(path.c_str(), "r");
+        char line[1024];
+        bool marker = false, state = false, scene = false, object = false, renderLine = false;
+        require(recorded != nullptr, "diagnostic recording can be inspected as text");
+        while (std::fgets(line, sizeof(line), recorded)) {
+            marker |= std::strncmp(line, "marker ", 7) == 0;
+            state |= std::strncmp(line, "state ", 6) == 0;
+            scene |= std::strncmp(line, "render_scene ", 13) == 0;
+            object |= std::strncmp(line, "render_object ", 14) == 0;
+            renderLine |= std::strncmp(line, "render_line ", 12) == 0;
+        }
+        std::fclose(recorded);
+        require(marker && state && scene && object && renderLine,
+                "recording contains markers, subsystem hashes, and detailed render commands");
+    }
+
+    require(blackbox_startDebug(kSeed) != 0,
+            "debug mode enables virtual waits");
+    gVirtualWaitPolls = 0;
+    require(blackbox_virtualWait(10, 1, pollVirtualWait) != 0 &&
+                blackbox_tick() == 3,
+            "virtual wait stops at deterministic input without host-time dependence");
+    blackbox_shutdown();
+
+    require(blackbox_startReplay(path.c_str()) != 0,
+            "blackbox loads the recorded log for replay");
+    require(blackbox_fastForwarding() == 0,
+            "ordinary replay presents normally when no fast-forward target was supplied");
+    blackbox_setFastForwardTick(1);
+    require(blackbox_fastForwarding() != 0,
+            "replay fast-forwards before its target tick");
+    uint16 word = 0;
+    require(blackbox_replayNextKey(&word) == 0,
+            "replay does not emit future input before its recorded input poll");
+    blackbox_noteTick();
+    require(blackbox_fastForwarding() == 0,
+            "replay resumes normal presentation at its target tick");
+    require(blackbox_replayNextKey(&word) == 0,
+            "a matching tick cannot release input before its recorded poll");
+    blackbox_noteInputPump();
+    require(blackbox_replayNextKey(&word) != 0 && word == kBiosWord,
+            "replay emits the recorded BIOS key on the matching input poll");
+    blackbox_diagMarker("test_event", 1, 2, 3);
+    blackbox_diagCaptureSimStep();
+    {
+        R3DScene scene = {nullptr, 1, 2, 3, 4, 5, 6, 1};
+        R3DSubmit submit = {nullptr, 7, 8, 9, 10, 11, 12, 0};
+        R3DLine line = {1, 2, 3, 4, 5, 6, 15};
+        blackbox_diagBeginRenderFrame();
+        blackbox_diagRenderBeginScene(&scene);
+        blackbox_diagRenderSubmit(&submit);
+        blackbox_diagRenderLine(&line);
+        blackbox_diagRenderEndScene();
+    }
+    uint8 rawX = 0x80, rawY = 0x80, joyX = 0x80, joyY = 0x80;
+    blackbox_applyReplayAxes(&rawX, &rawY, &joyX, &joyY);
+    require(rawX == kRawX && rawY == kRawY && joyX == kJoyX && joyY == kJoyY,
+            "replay restores recorded joystick axes for the tick");
+    blackbox_seedRandom(kSeed);
+    require(blackbox_rand15() == recordedRand,
+            "replay follows the recorded deterministic RNG stream");
+    blackbox_shutdown();
+
+    require(blackbox_startRecord(badPath.c_str(), kSeed) != 0,
+            "test can record stopped-timer menu input");
+    blackbox_captureMutableFile("HallFame", kHallFameSnapshot, sizeof(kHallFameSnapshot));
+    blackbox_noteInputPump();
+    blackbox_recordKey(kBiosWord);
+    blackbox_noteInputPump();
+    blackbox_noteInputPump();
+    blackbox_recordKey(kOtherSeed);
+    blackbox_shutdown();
+    require(blackbox_startReplay(badPath.c_str()) != 0,
+            "test can replay stopped-timer menu input");
+    blackbox_noteInputPump();
+    require(blackbox_replayNextKey(&word) != 0 && word == kBiosWord,
+            "first same-tick key becomes visible at its input poll");
+    blackbox_noteInputPump();
+    require(blackbox_replayNextKey(&word) == 0,
+            "later same-tick key is not prefetched across a buffer clear");
+    blackbox_noteInputPump();
+    require(blackbox_replayNextKey(&word) != 0 && word == kOtherSeed,
+            "later same-tick key becomes visible only at its own input poll");
+    blackbox_shutdown();
+
+    require(blackbox_startRecord(badPath.c_str(), kSeed) != 0,
+            "test can record an external RNG seed");
+    blackbox_captureMutableFile("HallFame", kHallFameSnapshot, sizeof(kHallFameSnapshot));
+    require(blackbox_seedExternalRandom(1234) == 1234,
+            "recording uses the supplied external seed");
+    blackbox_shutdown();
+    require(blackbox_startReplay(badPath.c_str()) != 0,
+            "test can replay an external RNG seed");
+    require(blackbox_seedExternalRandom(9999) == 1234,
+            "replay restores an external seed without using the current value");
+    blackbox_shutdown();
+
+    {
+        FILE *tickMismatchLog = std::fopen(badPath.c_str(), "w");
+        require(tickMismatchLog != nullptr, "test can create an RNG replay log");
+        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nrng_seed 9 4321\nrng 9 2468\n", tickMismatchLog);
+        std::fclose(tickMismatchLog);
+        require(blackbox_startReplay(badPath.c_str()) != 0,
+                "replay accepts a log with captured RNG events");
+        blackbox_seedRandom(kSeed);
+        require(blackbox_rand15() == 2468,
+                "replay returns recorded RNG values even when local tick/seed differ");
+        blackbox_shutdown();
+    }
+
+    require(blackbox_startDebug(kSeed) != 0, "debug mode enables deterministic RNG");
+    blackbox_setPauseTick(2);
+    blackbox_noteTick();
+    blackbox_noteTick();
+    blackbox_noteTick();
+    require(blackbox_tick() == 2 && blackbox_pauseReached(),
+            "pause tick freezes deterministic time for timeframe inspection");
+    blackbox_shutdown();
+
+    {
+        const char *textPath = "blackbox-dump-1.txt";
+        const char *jsonPath = "blackbox-dump-1.json";
+        std::remove(textPath);
+        std::remove(jsonPath);
+        require(blackbox_startDebug(kSeed) != 0,
+                "debug mode supports automatic state snapshots");
+        blackbox_diagSetDumpTick(1);
+        blackbox_noteTick();
+        blackbox_diagOnTick();
+        FILE *textDump = std::fopen(textPath, "r");
+        FILE *jsonDump = std::fopen(jsonPath, "r");
+        char json[32768] = {};
+        require(textDump != nullptr && jsonDump != nullptr,
+                "automatic dump writes both text and JSON files at its target");
+        require(std::fread(json, 1, sizeof(json) - 1, jsonDump) > 0 &&
+                    json[0] == '{' &&
+                    std::strstr(json, "\"format\":\"f15se2-blackbox-state\"") != nullptr &&
+                    std::strstr(json, "\"sim_objects\"") != nullptr &&
+                    std::strstr(json, "\"projectiles\"") != nullptr &&
+                    std::strstr(json, "\"bullet_tracks\"") != nullptr &&
+                    std::strstr(json, "\"provenance\"") != nullptr &&
+                    std::strstr(json, "\"cursors\"") != nullptr &&
+                    std::strstr(json, "\"timing\"") != nullptr &&
+                    std::strstr(json, "\"waypoints\"") != nullptr &&
+                    std::strstr(json, "\"target_slots\"") != nullptr &&
+                    std::strstr(json, "\"map_targets\"") != nullptr,
+                "automatic JSON snapshot has diagnostic context and object collections");
+        std::fclose(textDump);
+        std::fclose(jsonDump);
+
+        jsonDump = std::fopen(jsonPath, "a");
+        require(jsonDump != nullptr, "automatic snapshot fixture can mark its output");
+        std::fputs("snapshot-not-overwritten\n", jsonDump);
+        std::fclose(jsonDump);
+        blackbox_noteTick();
+        blackbox_diagOnTick();
+        jsonDump = std::fopen(jsonPath, "r");
+        std::memset(json, 0, sizeof(json));
+        require(jsonDump != nullptr && std::fread(json, 1, sizeof(json) - 1, jsonDump) > 0 &&
+                    std::strstr(json, "snapshot-not-overwritten") != nullptr,
+                "automatic dump fires only once");
+        std::fclose(jsonDump);
+        blackbox_shutdown();
+        std::remove(textPath);
+        std::remove(jsonPath);
+    }
+
+    require(blackbox_startDebug(kSeed) != 0, "debug mode can be restarted after pause");
+    const int firstA = blackbox_rand15();
+    const int secondA = blackbox_rand15();
+    blackbox_seedRandom(kSeed);
+    require(firstA == blackbox_rand15() && secondA == blackbox_rand15(),
+            "deterministic RNG repeats for the same seed");
+    blackbox_seedRandom(kOtherSeed);
+    require(firstA != blackbox_rand15(),
+            "deterministic RNG changes when the seed changes");
+    require(blackbox_diagWriteDump(badPath.c_str()) != 0,
+            "manual diagnostics write a readable state/render dump");
+    {
+        FILE *dump = std::fopen(badPath.c_str(), "r");
+        char dumpText[4096] = {};
+        require(dump != nullptr && std::fread(dumpText, 1, sizeof(dumpText) - 1, dump) > 0,
+                "manual diagnostic dump can be read back");
+        std::fclose(dump);
+        require(std::strstr(dumpText, "subsystem flight=") != nullptr &&
+                    std::strstr(dumpText, "object[00]") != nullptr,
+                "manual dump contains subsystem hashes and object state");
+    }
+
+    SDL_Surface *surface = SDL_CreateSurface(64, 16, SDL_PIXELFORMAT_INDEX8);
+    require(surface != nullptr, "SDL creates an indexed debug overlay surface");
+    std::memset(surface->pixels, 7, static_cast<size_t>(surface->pitch) * surface->h);
+    blackbox_recordFrame(surface);
+    blackbox_drawDebugOverlay(surface);
+    require(static_cast<unsigned char *>(surface->pixels)[0] == 0,
+            "debug overlay clears its top-left background");
+    blackbox_restoreDebugOverlay(surface);
+    require(static_cast<unsigned char *>(surface->pixels)[0] == 7,
+            "debug overlay restores the game page after presentation");
+
+    require(blackbox_startRecord(badPath.c_str(), kSeed) != 0,
+            "test can record logical frames while excluding passive redraws");
+    blackbox_captureMutableFile("HallFame", kHallFameSnapshot, sizeof(kHallFameSnapshot));
+    blackbox_beginPassivePresent();
+    blackbox_recordFrame(surface);
+    blackbox_endPassivePresent();
+    for (int tick = 0; tick < 5; tick++) blackbox_noteTick();
+    blackbox_recordFrame(surface);
+    blackbox_shutdown();
+    require(blackbox_startReplay(badPath.c_str()) != 0,
+            "test can replay a logical-frame log");
+    blackbox_recordFrame(surface);
+    require(blackbox_tick() == 0,
+            "frame verification never changes deterministic time");
+    blackbox_shutdown();
+
+    SDL_DestroySurface(surface);
+    blackbox_shutdown();
+
+    {
+        FILE *badLog = std::fopen(badPath.c_str(), "w");
+        require(badLog != nullptr, "test can create a malformed replay log");
+        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nkey 1 1 10000\n", badLog);
+        std::fclose(badLog);
+        require(blackbox_startReplay(badPath.c_str()) == 0,
+                "replay rejects out-of-range BIOS key words instead of truncating them");
+    }
+
+    {
+        FILE *badLog = std::fopen(badPath.c_str(), "w");
+        require(badLog != nullptr, "test can create a malformed snapshot log");
+        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 1 00ff\n", badLog);
+        std::fclose(badLog);
+        require(blackbox_startReplay(badPath.c_str()) == 0,
+                "replay rejects mutable snapshots with trailing data");
+    }
+
+    {
+        FILE *largeLog = std::fopen(badPath.c_str(), "w");
+        require(largeLog != nullptr, "test can create a multi-capacity replay log");
+        std::fputs("F15SE2_BLACKBOX 5\nseed 7\nbuild_version unknown\nmutable_file HallFame 0 -\n", largeLog);
+        for (int i = 0; i < 130; i++)
+            std::fprintf(largeLog, "key 0 0 %04x\n", i + 1);
+        std::fclose(largeLog);
+        require(blackbox_startReplay(badPath.c_str()) != 0,
+                "replay grows event storage geometrically");
+        uint16 replayWord = 0;
+        int replayedKeys = 0;
+        while (blackbox_replayNextKey(&replayWord)) replayedKeys++;
+        require(replayedKeys == 130 && replayWord == 130,
+                "grown replay storage preserves every event in order");
+        blackbox_shutdown();
+    }
+
+    std::remove(path.c_str());
+    std::remove(badPath.c_str());
+    std::cout << "blackbox_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/blackbox_behavior_tests.cpp
+++ b/tests/blackbox_behavior_tests.cpp
@@ -68,9 +68,38 @@ int main() {
         blackbox_cliInit(&options);
         require(options.seed == BLACKBOX_DEFAULT_SEED,
                 "blackbox CLI uses the documented default seed");
+        blackbox_cliApplyDebugDefaults(&options);
+        require(options.recordPath != nullptr &&
+                    std::strcmp(options.recordPath, BLACKBOX_DEFAULT_RECORD_PATH) == 0,
+                "debug defaults record to the local blackbox file");
+
+        blackbox_cliInit(&options);
         require(blackbox_cliParseOption(&options, 3, recordArgv, &index) == 1 &&
                     options.recordPath == recordPath && index == 2,
                 "blackbox CLI parses and consumes a record path");
+        blackbox_cliApplyDebugDefaults(&options);
+        require(options.recordPath == recordPath,
+                "an explicit recording path overrides the debug default");
+
+        BlackboxCliOptions replayOptions;
+        char replayOption[] = "--blackbox-replay";
+        char replayPath[] = "/tmp/replay.bb";
+        char *replayArgv[] = {program, replayOption, replayPath};
+        index = 1;
+        blackbox_cliInit(&replayOptions);
+        require(blackbox_cliParseOption(&replayOptions, 3, replayArgv, &index) == 1,
+                "blackbox CLI parses an explicit replay path");
+        blackbox_cliApplyDebugDefaults(&replayOptions);
+        require(replayOptions.recordPath == nullptr &&
+                    replayOptions.replayPath == replayPath,
+                "an explicit replay disables automatic debug recording");
+
+        BlackboxCliOptions debugOptions;
+        blackbox_cliInit(&debugOptions);
+        debugOptions.debug = 1;
+        blackbox_cliApplyDebugDefaults(&debugOptions);
+        require(debugOptions.recordPath == nullptr,
+                "explicit deterministic debug mode disables automatic recording");
 
         char seedOption[] = "--blackbox-seed";
         char invalidSeed[] = "not-a-number";

--- a/tests/blackbox_behavior_tests.cpp
+++ b/tests/blackbox_behavior_tests.cpp
@@ -248,7 +248,9 @@ int main() {
     blackbox_noteInputPump();
     blackbox_recordKey(kBiosWord);
     blackbox_noteInputPump();
+    blackbox_recordAxes(kRawX, kRawY, kJoyX, kJoyY);
     blackbox_noteInputPump();
+    blackbox_recordAxes(kJoyX, kJoyY, kRawX, kRawY);
     blackbox_recordKey(kOtherSeed);
     blackbox_shutdown();
     require(blackbox_startReplay(badPath.c_str()) != 0,
@@ -259,7 +261,13 @@ int main() {
     blackbox_noteInputPump();
     require(blackbox_replayNextKey(&word) == 0,
             "later same-tick key is not prefetched across a buffer clear");
+    blackbox_applyReplayAxes(&rawX, &rawY, &joyX, &joyY);
+    require(rawX == kRawX && rawY == kRawY && joyX == kJoyX && joyY == kJoyY,
+            "same-tick axes are not prefetched from a later input poll");
     blackbox_noteInputPump();
+    blackbox_applyReplayAxes(&rawX, &rawY, &joyX, &joyY);
+    require(rawX == kJoyX && rawY == kJoyY && joyX == kRawX && joyY == kRawY,
+            "later axes become visible at their own input poll");
     require(blackbox_replayNextKey(&word) != 0 && word == kOtherSeed,
             "later same-tick key becomes visible only at its own input poll");
     blackbox_shutdown();
@@ -279,7 +287,7 @@ int main() {
     {
         FILE *tickMismatchLog = std::fopen(badPath.c_str(), "w");
         require(tickMismatchLog != nullptr, "test can create an RNG replay log");
-        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nrng_seed 9 4321\nrng 9 2468\n", tickMismatchLog);
+        std::fputs("F15SE2_BLACKBOX 8\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nrng_seed 9 4321\nrng 9 2468\n", tickMismatchLog);
         std::fclose(tickMismatchLog);
         require(blackbox_startReplay(badPath.c_str()) != 0,
                 "replay accepts a log with captured RNG events");
@@ -401,7 +409,7 @@ int main() {
     {
         FILE *badLog = std::fopen(badPath.c_str(), "w");
         require(badLog != nullptr, "test can create a malformed replay log");
-        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nkey 1 1 10000\n", badLog);
+        std::fputs("F15SE2_BLACKBOX 8\nseed 7\nbuild_version unknown\nmutable_file HallFame 4 48414c4c\nkey 1 1 10000\n", badLog);
         std::fclose(badLog);
         require(blackbox_startReplay(badPath.c_str()) == 0,
                 "replay rejects out-of-range BIOS key words instead of truncating them");
@@ -410,7 +418,7 @@ int main() {
     {
         FILE *badLog = std::fopen(badPath.c_str(), "w");
         require(badLog != nullptr, "test can create a malformed snapshot log");
-        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 1 00ff\n", badLog);
+        std::fputs("F15SE2_BLACKBOX 8\nseed 7\nbuild_version unknown\nmutable_file HallFame 1 00ff\n", badLog);
         std::fclose(badLog);
         require(blackbox_startReplay(badPath.c_str()) == 0,
                 "replay rejects mutable snapshots with trailing data");
@@ -419,7 +427,7 @@ int main() {
     {
         FILE *largeLog = std::fopen(badPath.c_str(), "w");
         require(largeLog != nullptr, "test can create a multi-capacity replay log");
-        std::fputs("F15SE2_BLACKBOX 7\nseed 7\nbuild_version unknown\nmutable_file HallFame 0 -\n", largeLog);
+        std::fputs("F15SE2_BLACKBOX 8\nseed 7\nbuild_version unknown\nmutable_file HallFame 0 -\n", largeLog);
         for (int i = 0; i < 130; i++)
             std::fprintf(largeLog, "key 0 0 %04x\n", i + 1);
         std::fclose(largeLog);

--- a/tests/blackbox_gl_behavior_tests.cpp
+++ b/tests/blackbox_gl_behavior_tests.cpp
@@ -1,0 +1,73 @@
+#include "shared/blackbox.h"
+#include "shared/blackbox_gl.h"
+#include "headless.h"
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_opengl.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+bool gEnabled = false;
+uint32 gTick = 123;
+int gSetupCalls = 0;
+int gBeginCalls = 0;
+int gEndCalls = 0;
+int gVertexCalls = 0;
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setupOverlayState() { ++gSetupCalls; }
+
+} // namespace
+
+/* The overlay is immediate-mode geometry. Test-owned GL entry points let the
+ * behavior run headlessly while preserving the production vertex generation. */
+extern "C" void APIENTRY glVertex2f(GLfloat, GLfloat) { ++gVertexCalls; }
+extern "C" void APIENTRY glDisable(GLenum) {}
+extern "C" void APIENTRY glColor3ub(GLubyte, GLubyte, GLubyte) {}
+extern "C" void APIENTRY glBegin(GLenum) { ++gBeginCalls; }
+extern "C" void APIENTRY glEnd(void) { ++gEndCalls; }
+
+extern "C" int blackbox_enabled(void) { return gEnabled; }
+extern "C" uint32 blackbox_tick(void) { return gTick; }
+
+int main() {
+    test_headless_init();
+    require(SDL_Init(SDL_INIT_VIDEO), "SDL initializes its headless video driver");
+    SDL_Window *window = SDL_CreateWindow("blackbox overlay", 640, 400, SDL_WINDOW_HIDDEN);
+    SDL_Surface *page = SDL_CreateSurface(320, 200, SDL_PIXELFORMAT_INDEX8);
+    SDL_Palette *palette = SDL_CreatePalette(256);
+    require(window && page && palette, "overlay fixtures allocate successfully");
+    SDL_Color white = {255, 255, 255, 255};
+    require(SDL_SetPaletteColors(palette, &white, 15, 1),
+            "overlay foreground palette entry is configured");
+
+    blackbox_drawGlOverlay(page, 0, window, palette, setupOverlayState);
+    require(gSetupCalls == 0, "disabled blackbox does not draw an overlay");
+    gEnabled = true;
+    blackbox_drawGlOverlay(nullptr, 0, window, palette, setupOverlayState);
+    blackbox_drawGlOverlay(page, 0, nullptr, palette, setupOverlayState);
+    blackbox_drawGlOverlay(page, 0, window, nullptr, setupOverlayState);
+    blackbox_drawGlOverlay(page, 0, window, palette, nullptr);
+    require(gSetupCalls == 0, "incomplete overlay inputs are rejected");
+
+    blackbox_drawGlOverlay(page, 2, window, palette, setupOverlayState);
+    require(gSetupCalls == 1 && gBeginCalls == 2 && gEndCalls == 2,
+            "overlay establishes state and emits background and digit batches");
+    require(gVertexCalls > 4, "displayed tick produces background and digit geometry");
+
+    SDL_DestroyPalette(palette);
+    SDL_DestroySurface(page);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    std::cout << "blackbox_gl_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/blackbox_gl_behavior_tests.cpp
+++ b/tests/blackbox_gl_behavior_tests.cpp
@@ -1,6 +1,7 @@
 #include "shared/blackbox.h"
 #include "shared/blackbox_gl.h"
 #include "headless.h"
+#include "r2d.h"
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_opengl.h>
@@ -38,6 +39,14 @@ extern "C" void APIENTRY glEnd(void) { ++gEndCalls; }
 
 extern "C" int blackbox_enabled(void) { return gEnabled; }
 extern "C" uint32 blackbox_tick(void) { return gTick; }
+
+void r2d_computeMapping(int pageW, int pageH, int winW, int winH,
+                        int, R2DMapping *mapping) {
+    mapping->scaleX = static_cast<float>(winW) / pageW;
+    mapping->scaleY = static_cast<float>(winH) / pageH;
+    mapping->offX = 0;
+    mapping->offY = 0;
+}
 
 int main() {
     test_headless_init();

--- a/tests/blackbox_inspect_tool_tests.py
+++ b/tests/blackbox_inspect_tool_tests.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"failed: {message}")
+
+
+def main() -> int:
+    tool = Path(sys.argv[1])
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as f:
+        f.write("F15SE2_BLACKBOX 5\n")
+        f.write("seed 7\n")
+        f.write("build_version test\n")
+        f.write("mutable_file HallFame 0 -\n")
+        f.write("phase 1 start\n")
+        f.write("key 2 17 1f73\n")
+        f.write("axes 3 64 128 128 192\n")
+        f.write("rng_seed 4 7\n")
+        f.write("rng 5 123\n")
+        f.write("frame 6 0 1a2b3c4d\n")
+        f.write("marker 6 view_change 0 132 0\n")
+        f.write("state 6 2 camera abcdef01\n")
+        f.write("render_hash 6 3 1 7 2 12345678\n")
+        log_path = Path(f.name)
+    try:
+        text = subprocess.check_output(
+            [sys.executable, str(tool), str(log_path), "--around-tick", "3", "--before", "1", "--after", "1"],
+            text=True,
+        )
+        event_lines = [line for line in text.splitlines() if line.lstrip()[:1].isdigit()]
+        require(any(" key " in line for line in event_lines) and
+                any(" axes " in line for line in event_lines) and
+                not any(" phase " in line for line in event_lines),
+                "text window includes only events around the requested tick")
+
+        raw = subprocess.check_output(
+            [sys.executable, str(tool), str(log_path), "--from-tick", "4", "--to-tick", "5", "--json"],
+            text=True,
+        )
+        data = json.loads(raw)
+        require(data["seed"] == 7, "JSON output reports the log seed")
+        require([event["kind"] for event in data["events"]] == ["rng_seed", "rng"],
+                "JSON output preserves ordered events in the requested window")
+        frame_text = subprocess.check_output(
+            [sys.executable, str(tool), str(log_path), "--from-tick", "6", "--to-tick", "6"],
+            text=True,
+        )
+        require("frame=0 hash=0x1a2b3c4d" in frame_text,
+                "text output formats recorded frame hashes for divergence investigation")
+        require("view_change(0,132,0)" in frame_text and
+                "subsystem=camera hash=0xabcdef01" in frame_text and
+                "objects=7 lines=2 hash=0x12345678" in frame_text,
+                "text output formats diagnostic markers, subsystem hashes, and render hashes")
+    finally:
+        log_path.unlink(missing_ok=True)
+    print("blackbox_inspect_tool_tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/blackbox_inspect_tool_tests.py
+++ b/tests/blackbox_inspect_tool_tests.py
@@ -21,6 +21,7 @@ def main() -> int:
         f.write("build_version test\n")
         f.write("mutable_file HallFame 0 -\n")
         f.write("phase 1 start\n")
+        f.write("timer_pump 2 0\n")
         f.write("key 2 17 1f73\n")
         f.write("axes 3 64 128 128 192\n")
         f.write("rng_seed 4 7\n")
@@ -36,7 +37,8 @@ def main() -> int:
             text=True,
         )
         event_lines = [line for line in text.splitlines() if line.lstrip()[:1].isdigit()]
-        require(any(" key " in line for line in event_lines) and
+        require(any("timer_pump" in line and "ticks=0" in line for line in event_lines) and
+                any(" key " in line for line in event_lines) and
                 any(" axes " in line for line in event_lines) and
                 not any(" phase " in line for line in event_lines),
                 "text window includes only events around the requested tick")

--- a/tests/blackbox_inspect_tool_tests.py
+++ b/tests/blackbox_inspect_tool_tests.py
@@ -16,7 +16,7 @@ def require(condition: bool, message: str) -> None:
 def main() -> int:
     tool = Path(sys.argv[1])
     with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as f:
-        f.write("F15SE2_BLACKBOX 5\n")
+        f.write("F15SE2_BLACKBOX 7\n")
         f.write("seed 7\n")
         f.write("build_version test\n")
         f.write("mutable_file HallFame 0 -\n")

--- a/tests/blackbox_inspect_tool_tests.py
+++ b/tests/blackbox_inspect_tool_tests.py
@@ -16,14 +16,14 @@ def require(condition: bool, message: str) -> None:
 def main() -> int:
     tool = Path(sys.argv[1])
     with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as f:
-        f.write("F15SE2_BLACKBOX 7\n")
+        f.write("F15SE2_BLACKBOX 8\n")
         f.write("seed 7\n")
         f.write("build_version test\n")
         f.write("mutable_file HallFame 0 -\n")
         f.write("phase 1 start\n")
         f.write("timer_pump 2 0\n")
         f.write("key 2 17 1f73\n")
-        f.write("axes 3 64 128 128 192\n")
+        f.write("axes 3 4 64 128 128 192\n")
         f.write("rng_seed 4 7\n")
         f.write("rng 5 123\n")
         f.write("frame 6 0 1a2b3c4d\n")

--- a/tests/blackbox_validation_tests.cpp
+++ b/tests/blackbox_validation_tests.cpp
@@ -37,7 +37,7 @@ void writeFile(const std::filesystem::path &path, const std::string &contents) {
 }
 
 std::string validLog(const std::string &events = {}) {
-    return "F15SE2_BLACKBOX 5\nseed 7\nbuild_version test-build\n"
+    return "F15SE2_BLACKBOX 7\nseed 7\nbuild_version test-build\n"
            "mutable_file HallFame 0 -\n" + events;
 }
 
@@ -225,10 +225,10 @@ void testCoreFailures(const std::filesystem::path &path) {
     writeFile(path, validLog("unknown 1 2 3\n"));
     require(!blackbox_startReplay(path.string().c_str()),
             "replay rejects unknown event lines");
-    writeFile(path, "F15SE2_BLACKBOX 5\nseed 7\nmutable_file HallFame 0 -\n");
+    writeFile(path, "F15SE2_BLACKBOX 7\nseed 7\nmutable_file HallFame 0 -\n");
     require(!blackbox_startReplay(path.string().c_str()),
             "replay requires build metadata");
-    writeFile(path, "F15SE2_BLACKBOX 5\nseed 7\nbuild_version test-build\n");
+    writeFile(path, "F15SE2_BLACKBOX 7\nseed 7\nbuild_version test-build\n");
     require(!blackbox_startReplay(path.string().c_str()),
             "replay requires captured mutable state");
 

--- a/tests/blackbox_validation_tests.cpp
+++ b/tests/blackbox_validation_tests.cpp
@@ -1,0 +1,320 @@
+#include "shared/blackbox.h"
+#include "shared/blackbox_cli.h"
+#include "shared/blackbox_diag.h"
+#include "shared/blackbox_gl.h"
+#include "shared/blackbox_state.h"
+#include "egdata.h"
+#include "strand.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+enum : int {
+    kFailure = 1,
+    kSeed = 7,
+};
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(kFailure);
+    }
+}
+
+void writeFile(const std::filesystem::path &path, const std::string &contents) {
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
+    require(file.good(), "test fixture file can be created");
+    file << contents;
+}
+
+std::string validLog(const std::string &events = {}) {
+    return "F15SE2_BLACKBOX 5\nseed 7\nbuild_version test-build\n"
+           "mutable_file HallFame 0 -\n" + events;
+}
+
+void testCli(const std::filesystem::path &recordPath) {
+    BlackboxCliOptions options;
+    char program[] = "f15se2-ex";
+    char debugOption[] = "--blackbox-debug";
+    char ignoreOption[] = "--blackbox-replay-ignore-build";
+    char replayOption[] = "--blackbox-replay";
+    char pauseOption[] = "--blackbox-pause-tick";
+    char unknownOption[] = "--not-blackbox";
+    char overflow[] = "4294967296";
+    char validTime[] = "10001";
+    char *singleArgv[] = {program, debugOption};
+    int index = 1;
+
+    blackbox_cliInit(&options);
+    require(blackbox_cliParseOption(&options, 2, singleArgv, &index) == 1 && options.debug,
+            "CLI parses debug mode");
+    singleArgv[1] = ignoreOption;
+    index = 1;
+    require(blackbox_cliParseOption(&options, 2, singleArgv, &index) == 1 &&
+                options.ignoreBuild,
+            "CLI parses build-mismatch override");
+    singleArgv[1] = unknownOption;
+    index = 1;
+    require(blackbox_cliParseOption(&options, 2, singleArgv, &index) == 0,
+            "CLI leaves unrelated options to the main parser");
+
+    char *missingArgv[] = {program, replayOption};
+    index = 1;
+    require(blackbox_cliParseOption(&options, 2, missingArgv, &index) == -1,
+            "CLI rejects a missing path argument");
+    char *overflowArgv[] = {program, pauseOption, overflow};
+    index = 1;
+    require(blackbox_cliParseOption(&options, 3, overflowArgv, &index) == -1,
+            "CLI rejects values outside uint32 range");
+    char *pauseArgv[] = {program, pauseOption, validTime};
+    index = 1;
+    require(blackbox_cliParseOption(&options, 3, pauseArgv, &index) == 1 &&
+                options.pauseTick == 6001,
+            "CLI parses pause time");
+    blackbox_cliPrintUsage();
+
+    blackbox_cliInit(&options);
+    options.recordPath = "record.bb";
+    options.replayPath = "replay.bb";
+    require(!blackbox_cliStart(&options), "CLI rejects simultaneous record and replay");
+
+    blackbox_cliInit(&options);
+    options.fastForwardTick = 10;
+    require(!blackbox_cliStart(&options), "CLI requires replay for fast-forward");
+
+    blackbox_cliInit(&options);
+    options.captureRender = 1;
+    require(!blackbox_cliStart(&options), "CLI requires recording for render capture");
+
+    blackbox_cliInit(&options);
+    options.dumpTick = 10;
+    require(!blackbox_cliStart(&options), "CLI requires a blackbox mode for dumps");
+
+    blackbox_cliInit(&options);
+    options.replayPath = "missing.bb";
+    options.fastForwardTick = 20;
+    options.pauseTick = 10;
+    require(!blackbox_cliStart(&options), "CLI rejects pause before fast-forward");
+
+    blackbox_cliInit(&options);
+    options.debug = 1;
+    options.dumpTick = 20;
+    options.pauseTick = 10;
+    require(!blackbox_cliStart(&options), "CLI rejects pause before automatic dump");
+
+    blackbox_cliInit(&options);
+    options.debug = 1;
+    options.pauseTick = 12;
+    options.dumpTick = 11;
+    require(blackbox_cliStart(&options), "CLI starts debug mode with valid triggers");
+    require(blackbox_enabled(), "successful CLI start enables blackbox mode");
+    blackbox_shutdown();
+
+    const std::string recordString = recordPath.string();
+    blackbox_cliInit(&options);
+    options.recordPath = recordString.c_str();
+    options.captureRender = 1;
+    require(blackbox_cliStart(&options), "CLI starts record mode with render capture");
+    blackbox_shutdown();
+
+    blackbox_cliInit(&options);
+    require(blackbox_cliStart(&options) && !blackbox_enabled(),
+            "CLI accepts normal mode without enabling blackbox");
+}
+
+void testState(const std::filesystem::path &path) {
+    const uint8 bytes[] = {0xab, 0xcd};
+    const uint8 *replayData = nullptr;
+    uint32 replaySize = 0;
+
+    blackbox_state_reset();
+    blackbox_state_setBuildVersion(nullptr);
+    require(std::string(blackbox_state_currentBuildVersion()) == "unknown" &&
+                std::string(blackbox_state_replayBuildVersion()).empty(),
+            "state metadata has safe defaults");
+    blackbox_state_writeRecordHeader(nullptr);
+    require(!blackbox_state_shouldCaptureMutableFile(nullptr) &&
+                !blackbox_state_shouldCaptureMutableFile("Other") &&
+                blackbox_state_shouldCaptureMutableFile("hallfame"),
+            "only HallFame is mutable blackbox state");
+    require(!blackbox_state_getReplayMutableFile("HallFame", &replayData, &replaySize),
+            "no replay state exists before parsing");
+    require(!blackbox_state_validateReplay(), "state validation requires build metadata");
+
+    FILE *file = std::fopen(path.string().c_str(), "wb");
+    require(file != nullptr, "state record fixture opens");
+    blackbox_state_setBuildVersion("build-a");
+    blackbox_state_writeRecordHeader(file);
+    blackbox_state_recordMutableFile(nullptr, "HallFame", bytes, 2);
+    blackbox_state_recordMutableFile(file, nullptr, bytes, 2);
+    blackbox_state_recordMutableFile(file, "HallFame", nullptr, 2);
+    blackbox_state_recordMutableFile(file, "HallFame", bytes, 2);
+    blackbox_state_recordMutableFile(file, "HallFame", bytes, 2);
+    std::fclose(file);
+    require(!blackbox_state_shouldCaptureMutableFile("HallFame"),
+            "mutable state is recorded only once");
+
+    blackbox_state_reset();
+    require(blackbox_state_parseReplayLine("unrelated line\n") == 0,
+            "state parser ignores non-state lines");
+    require(blackbox_state_parseReplayLine("mutable_file Other 0 -\n") < 0,
+            "state parser rejects unknown mutable files");
+    require(blackbox_state_parseReplayLine("mutable_file HallFame 0 00\n") < 0,
+            "empty snapshots require the explicit marker");
+    require(blackbox_state_parseReplayLine("mutable_file HallFame 2 ab\n") < 0,
+            "state parser rejects truncated hex payloads");
+    require(blackbox_state_parseReplayLine("mutable_file HallFame 1 zz\n") < 0,
+            "state parser rejects non-hex payloads");
+    require(blackbox_state_parseReplayLine("build_version build-b\n") == 1 &&
+                blackbox_state_parseReplayLine("mutable_file hallfame 2 ABCD\n") == 1,
+            "state parser accepts case-insensitive names and uppercase hex");
+    require(blackbox_state_getReplayMutableFile("HALLFAME", &replayData, &replaySize) &&
+                replaySize == 2 && replayData[0] == 0xab && replayData[1] == 0xcd,
+            "parsed mutable bytes are available to replay");
+    blackbox_state_setBuildVersion("build-a");
+    blackbox_state_setAllowBuildMismatch(0);
+    require(!blackbox_state_validateReplay(), "build mismatch is rejected by default");
+    blackbox_state_setAllowBuildMismatch(1);
+    require(blackbox_state_validateReplay(), "explicit override permits build mismatch");
+    blackbox_state_reset();
+    require(blackbox_state_parseReplayLine("build_version build-a\n") == 1 &&
+                !blackbox_state_validateReplay(),
+            "state validation requires a HallFame snapshot");
+    blackbox_state_reset();
+}
+
+void testCoreFailures(const std::filesystem::path &path) {
+    blackbox_setBuildVersion("test-build");
+    blackbox_setAllowBuildMismatch(0);
+    require(!blackbox_startRecord("missing-directory/record.bb", kSeed),
+            "recording reports an unwritable destination");
+    require(!blackbox_startReplay("missing-replay.bb"),
+            "replay reports a missing recording");
+
+    writeFile(path, "not a blackbox\n");
+    require(!blackbox_startReplay(path.string().c_str()),
+            "replay rejects a bad format header");
+    writeFile(path, validLog("axes 0 0 0 0 256\n"));
+    require(!blackbox_startReplay(path.string().c_str()),
+            "replay rejects out-of-range axes");
+    writeFile(path, validLog("unknown 1 2 3\n"));
+    require(!blackbox_startReplay(path.string().c_str()),
+            "replay rejects unknown event lines");
+    writeFile(path, "F15SE2_BLACKBOX 5\nseed 7\nmutable_file HallFame 0 -\n");
+    require(!blackbox_startReplay(path.string().c_str()),
+            "replay requires build metadata");
+    writeFile(path, "F15SE2_BLACKBOX 5\nseed 7\nbuild_version test-build\n");
+    require(!blackbox_startReplay(path.string().c_str()),
+            "replay requires captured mutable state");
+
+    writeFile(path, validLog("phase 0 start\naxes 0 1 2 3 4\n"));
+    require(blackbox_startReplay(path.string().c_str()),
+            "replay accepts navigation markers and valid axes");
+    blackbox_getDebugState(nullptr);
+    blackbox_seedRandom(kSeed);
+    blackbox_seedRandom(kSeed);
+    blackbox_seedExternalRandom(1234);
+    (void)blackbox_rand15();
+    SDL_Surface *surface = SDL_CreateSurface(2, 2, SDL_PIXELFORMAT_INDEX8);
+    require(surface != nullptr, "frame exhaustion fixture creates an indexed surface");
+    blackbox_recordFrame(surface);
+    SDL_DestroySurface(surface);
+    blackbox_shutdown();
+
+    require(blackbox_startDebug(kSeed), "debug mode starts for fallback RNG checks");
+    require(blackbox_seedExternalRandom(9999) == kSeed,
+            "debug mode ignores external wall-clock seeds");
+    blackbox_seedConfiguredRandom();
+    require(blackbox_timerNowNs() == 0 && blackbox_randomActive(),
+            "debug mode exposes deterministic clock and RNG state");
+    blackbox_logPhase(nullptr);
+    blackbox_recordKey(1);
+    blackbox_recordAxes(1, 2, 3, 4);
+    uint8 x = 1, y = 2, joyX = 3, joyY = 4;
+    blackbox_applyReplayAxes(&x, &y, &joyX, &joyY);
+    blackbox_drawGlOverlay(nullptr, 0, nullptr, nullptr, nullptr);
+    blackbox_shutdown();
+
+    gameSrand(kSeed);
+    const int first = gameRand();
+    gameSrand(kSeed);
+    require(first == gameRand() && gameRand15() >= 0,
+            "normal game RNG remains deterministic outside blackbox mode");
+}
+
+void testDiagnosticTransitions(const std::filesystem::path &path) {
+    const ViewMode savedViewMode = g_viewMode;
+    const int16 savedTrackedEnemy = g_trackedEnemyIdx;
+    const int16 savedAirLock = g_airTargetLock;
+    const int16 savedGroundLock = g_groundTargetLock;
+    const int16 savedMissionStatus = g_missionStatus;
+    const uint8 savedMissionEnded = g_missionEndedFlag[0];
+    const Projectile savedProjectile = g_projectiles[0];
+
+    require(blackbox_startRecord(path.string().c_str(), kSeed),
+            "diagnostic transition fixture starts recording");
+    blackbox_diagCaptureSimStep();
+
+    g_viewMode = static_cast<ViewMode>(static_cast<int>(savedViewMode) + 1);
+    g_trackedEnemyIdx = 3;
+    g_airTargetLock = 4;
+    g_groundTargetLock = 5;
+    g_projectiles[0].ttl = 10;
+    g_projectiles[0].weaponIdx = 2;
+    g_projectiles[0].targetLock = 3;
+    blackbox_diagCaptureSimStep();
+
+    g_projectiles[0].ttl = 0;
+    g_missionStatus = 9;
+    g_missionEndedFlag[0] = 1;
+    blackbox_diagCaptureSimStep();
+    blackbox_shutdown();
+
+    std::ifstream recorded(path, std::ios::binary);
+    const std::string text((std::istreambuf_iterator<char>(recorded)),
+                           std::istreambuf_iterator<char>());
+    require(text.find(" view_change ") != std::string::npos &&
+                text.find(" target_change ") != std::string::npos &&
+                text.find(" projectile_launch ") != std::string::npos &&
+                text.find(" projectile_remove ") != std::string::npos &&
+                text.find(" mission_end ") != std::string::npos,
+            "diagnostics record all important gameplay transitions");
+
+    g_viewMode = savedViewMode;
+    g_trackedEnemyIdx = savedTrackedEnemy;
+    g_airTargetLock = savedAirLock;
+    g_groundTargetLock = savedGroundLock;
+    g_missionStatus = savedMissionStatus;
+    g_missionEndedFlag[0] = savedMissionEnded;
+    g_projectiles[0] = savedProjectile;
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path dir =
+        std::filesystem::temp_directory_path() / "f15se2-blackbox-validation";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    const auto recordPath = dir / "record.bb";
+    const auto statePath = dir / "state.txt";
+    const auto replayPath = dir / "replay.bb";
+
+    testCli(recordPath);
+    testState(statePath);
+    testCoreFailures(replayPath);
+    testDiagnosticTransitions(dir / "diagnostics.bb");
+
+    blackbox_shutdown();
+    std::filesystem::remove_all(dir);
+    std::cout << "blackbox_validation_tests passed\n";
+    return 0;
+}

--- a/tests/blackbox_validation_tests.cpp
+++ b/tests/blackbox_validation_tests.cpp
@@ -2,6 +2,7 @@
 #include "shared/blackbox_cli.h"
 #include "shared/blackbox_diag.h"
 #include "shared/blackbox_gl.h"
+#include "shared/blackbox_snapshot.h"
 #include "shared/blackbox_state.h"
 #include "egdata.h"
 #include "strand.h"
@@ -66,6 +67,13 @@ void testCli(const std::filesystem::path &recordPath) {
     require(blackbox_cliParseOption(&options, 2, singleArgv, &index) == 0,
             "CLI leaves unrelated options to the main parser");
 
+    char replayPath[] = "replay.bb";
+    char *replayArgv[] = {program, replayOption, replayPath};
+    index = 1;
+    require(blackbox_cliParseOption(&options, 3, replayArgv, &index) == 1 &&
+                options.replayPath == replayPath,
+            "CLI parses and consumes a replay path");
+
     char *missingArgv[] = {program, replayOption};
     index = 1;
     require(blackbox_cliParseOption(&options, 2, missingArgv, &index) == -1,
@@ -128,6 +136,15 @@ void testCli(const std::filesystem::path &recordPath) {
     blackbox_cliInit(&options);
     require(blackbox_cliStart(&options) && !blackbox_enabled(),
             "CLI accepts normal mode without enabling blackbox");
+
+    writeFile(recordPath, validLog());
+    blackbox_cliInit(&options);
+    options.replayPath = recordString.c_str();
+    options.fastForwardTick = 10;
+    options.ignoreBuild = 1;
+    require(blackbox_cliStart(&options) && blackbox_fastForwarding(),
+            "CLI starts replay and applies its fast-forward target");
+    blackbox_shutdown();
 }
 
 void testState(const std::filesystem::path &path) {
@@ -297,6 +314,87 @@ void testDiagnosticTransitions(const std::filesystem::path &path) {
     g_projectiles[0] = savedProjectile;
 }
 
+void testRngSnapshotsAndDivergence(const std::filesystem::path &dir) {
+    const auto streamsPath = dir / "streams.bb";
+    const auto recordPath = dir / "coverage-record.bb";
+    const auto snapshotPath = dir / "snapshot.json";
+    const auto dumpPath = dir / "render-dump.txt";
+
+    writeFile(streamsPath, validLog(
+        "rng_seed 9 1234\nrng 9 2468\nframe 9 1 deadbeef\nkey 9 9 1234\n"));
+    require(blackbox_startReplay(streamsPath.string().c_str()),
+            "replay accepts complete deterministic event streams");
+    blackbox_shutdown();
+
+    require(blackbox_startReplay(streamsPath.string().c_str()),
+            "external-seed divergence fixture starts replay");
+    require(blackbox_seedExternalRandom(9999) == 1234,
+            "replay restores an external seed despite a tick mismatch");
+    (void)blackbox_seedExternalRandom(9999);
+    blackbox_shutdown();
+
+    require(blackbox_startRecord(recordPath.string().c_str(), kSeed),
+            "recording starts for duplicate-axis suppression");
+    blackbox_recordAxes(1, 2, 3, 4);
+    blackbox_recordAxes(1, 2, 3, 4);
+    blackbox_shutdown();
+
+    seedRandom();
+    int16 clockSeed = 0;
+    gameSrandFromClock(&clockSeed);
+    require(blackbox_startDebug(kSeed), "debug starts for RNG wrapper coverage");
+    seedRandom();
+    gameSrandFromClock(&clockSeed);
+    (void)gameRand();
+    blackbox_setBuildVersion("build-\"\\\n");
+    require(blackbox_snapshotWriteJson(snapshotPath.string().c_str()),
+            "debug snapshot escapes build metadata as valid JSON");
+    blackbox_shutdown();
+
+    require(blackbox_startRecord(recordPath.string().c_str(), kSeed),
+            "record mode starts for snapshot and clock-seed coverage");
+    gameSrandFromClock(&clockSeed);
+    require(blackbox_snapshotWriteJson(snapshotPath.string().c_str()),
+            "record-mode state can be serialized");
+    blackbox_shutdown();
+
+    blackbox_setBuildVersion("test-build");
+    writeFile(streamsPath, validLog());
+    require(blackbox_startReplay(streamsPath.string().c_str()),
+            "replay mode starts for snapshot coverage");
+    require(blackbox_snapshotWriteJson(snapshotPath.string().c_str()),
+            "replay-mode state can be serialized");
+    blackbox_shutdown();
+
+    writeFile(streamsPath, validLog(
+        "marker 9 expected 1 2 3\n"
+        "state 9 9 expected deadbeef\n"
+        "render_hash 9 9 9 9 9 deadbeef\n"));
+    require(blackbox_startReplay(streamsPath.string().c_str()),
+            "diagnostic stream fixture starts replay");
+    blackbox_shutdown();
+    require(blackbox_startReplay(streamsPath.string().c_str()),
+            "diagnostic divergence fixture restarts replay");
+    blackbox_diagMarker("actual", 4, 5, 6);
+    blackbox_diagCaptureSimStep();
+    R3DScene scene = {nullptr, 1, 2, 3, 4, 5, 6, 1};
+    blackbox_diagBeginRenderFrame();
+    blackbox_diagRenderBeginScene(&scene);
+    blackbox_diagRenderEndScene();
+    blackbox_shutdown();
+
+    require(blackbox_startDebug(kSeed), "debug starts for render-command diagnostics");
+    R3DSubmit submit = {g_world3dData, 1, 2, 3, 4, 5, 6, 0};
+    R3DLine line = {1, 2, 3, 4, 5, 6, 15};
+    blackbox_diagBeginRenderFrame();
+    blackbox_diagRenderBeginScene(&scene);
+    for (int i = 0; i < 300; ++i) blackbox_diagRenderSubmit(&submit);
+    blackbox_diagRenderLine(&line);
+    require(blackbox_diagWriteDump(dumpPath.string().c_str()),
+            "diagnostic dump includes retained and dropped render commands");
+    blackbox_shutdown();
+}
+
 } // namespace
 
 int main() {
@@ -312,6 +410,7 @@ int main() {
     testState(statePath);
     testCoreFailures(replayPath);
     testDiagnosticTransitions(dir / "diagnostics.bb");
+    testRngSnapshotsAndDivergence(dir);
 
     blackbox_shutdown();
     std::filesystem::remove_all(dir);

--- a/tests/blackbox_validation_tests.cpp
+++ b/tests/blackbox_validation_tests.cpp
@@ -222,6 +222,9 @@ void testCoreFailures(const std::filesystem::path &path) {
     writeFile(path, validLog("axes 0 0 0 0 256\n"));
     require(!blackbox_startReplay(path.string().c_str()),
             "replay rejects out-of-range axes");
+    writeFile(path, validLog("timer_pump 0 17\n"));
+    require(!blackbox_startReplay(path.string().c_str()),
+            "replay rejects impossible timer-pump counts instead of hanging");
     writeFile(path, validLog("unknown 1 2 3\n"));
     require(!blackbox_startReplay(path.string().c_str()),
             "replay rejects unknown event lines");

--- a/tests/blackbox_validation_tests.cpp
+++ b/tests/blackbox_validation_tests.cpp
@@ -395,6 +395,13 @@ void testRngSnapshotsAndDivergence(const std::filesystem::path &dir) {
     blackbox_diagRenderLine(&line);
     require(blackbox_diagWriteDump(dumpPath.string().c_str()),
             "diagnostic dump includes retained and dropped render commands");
+#if defined(__linux__)
+    // Opening /dev/full succeeds; writes fail, including buffered flushes.
+    require(!blackbox_diagWriteDump("/dev/full"),
+            "text dump reports write failure instead of success");
+    require(!blackbox_snapshotWriteJson("/dev/full"),
+            "JSON snapshot reports write failure instead of success");
+#endif
     blackbox_shutdown();
 }
 

--- a/tests/blackbox_validation_tests.cpp
+++ b/tests/blackbox_validation_tests.cpp
@@ -37,7 +37,7 @@ void writeFile(const std::filesystem::path &path, const std::string &contents) {
 }
 
 std::string validLog(const std::string &events = {}) {
-    return "F15SE2_BLACKBOX 7\nseed 7\nbuild_version test-build\n"
+    return "F15SE2_BLACKBOX 8\nseed 7\nbuild_version test-build\n"
            "mutable_file HallFame 0 -\n" + events;
 }
 
@@ -219,7 +219,7 @@ void testCoreFailures(const std::filesystem::path &path) {
     writeFile(path, "not a blackbox\n");
     require(!blackbox_startReplay(path.string().c_str()),
             "replay rejects a bad format header");
-    writeFile(path, validLog("axes 0 0 0 0 256\n"));
+    writeFile(path, validLog("axes 0 0 0 0 0 256\n"));
     require(!blackbox_startReplay(path.string().c_str()),
             "replay rejects out-of-range axes");
     writeFile(path, validLog("timer_pump 0 17\n"));
@@ -228,14 +228,14 @@ void testCoreFailures(const std::filesystem::path &path) {
     writeFile(path, validLog("unknown 1 2 3\n"));
     require(!blackbox_startReplay(path.string().c_str()),
             "replay rejects unknown event lines");
-    writeFile(path, "F15SE2_BLACKBOX 7\nseed 7\nmutable_file HallFame 0 -\n");
+    writeFile(path, "F15SE2_BLACKBOX 8\nseed 7\nmutable_file HallFame 0 -\n");
     require(!blackbox_startReplay(path.string().c_str()),
             "replay requires build metadata");
-    writeFile(path, "F15SE2_BLACKBOX 7\nseed 7\nbuild_version test-build\n");
+    writeFile(path, "F15SE2_BLACKBOX 8\nseed 7\nbuild_version test-build\n");
     require(!blackbox_startReplay(path.string().c_str()),
             "replay requires captured mutable state");
 
-    writeFile(path, validLog("phase 0 start\naxes 0 1 2 3 4\n"));
+    writeFile(path, validLog("phase 0 start\naxes 0 0 1 2 3 4\n"));
     require(blackbox_startReplay(path.string().c_str()),
             "replay accepts navigation markers and valid axes");
     blackbox_getDebugState(nullptr);

--- a/tests/file_io_behavior_tests.cpp
+++ b/tests/file_io_behavior_tests.cpp
@@ -1,4 +1,5 @@
 #include "shared/common.h"
+#include "shared/blackbox.h"
 
 #include <filesystem>
 #include <fstream>
@@ -36,6 +37,7 @@ enum FileIoOriginalConstant : int {
     kSingleByte = 1,
     kErrorExitStatus = 1,
     kScratchBufferBytes = 8,
+    kReplaySeed = 11,
 };
 
 void require(bool condition, const char *message) {
@@ -93,6 +95,51 @@ int main() {
             "fileWrite writes host buffers");
     fileClose(output);
     require(readWholeFile(testDir / "newfile.bin") == "123", "fileWrite persisted bytes");
+
+    {
+        const auto replayLogPath = testDir / "replay.log";
+        {
+            std::ofstream log(replayLogPath, std::ios::binary);
+            log << "F15SE2_BLACKBOX 5\nseed " << kReplaySeed << "\n"
+                << "build_version unknown\n"
+                << "mutable_file HallFame 4 5245504c\n";
+        }
+        require(blackbox_startReplay(replayLogPath.string().c_str()) != 0,
+                "test can enable blackbox replay mode");
+        input = openFile("HallFame", kDosReadMode);
+        require(input != nullptr,
+                "blackbox replay serves captured mutable files from memory");
+        require(fileReadRaw(input, buf, kReadWholeRemainingStream) == 4,
+                "blackbox replay mutable stream reports captured byte count");
+        require(std::string(buf, 4) == "REPL",
+                "blackbox replay mutable stream returns captured bytes");
+        fileClose(input);
+        output = createFile("HallFame", kDosDefaultCreateAttr);
+        require(output != nullptr && fileWrite("SAVE", 1, 4, output) == 4,
+                "blackbox replay accepts writes through a disposable stream");
+        fileClose(output);
+        require(!std::filesystem::exists(testDir / "HallFame"),
+                "blackbox replay leaves missing persistent files missing");
+        blackbox_shutdown();
+    }
+
+    {
+        const auto recordLogPath = testDir / "record.log";
+        require(blackbox_startRecord(recordLogPath.string().c_str(), kReplaySeed) != 0,
+                "test can enable blackbox record mode");
+        input = openFile("HallFame", kDosReadMode);
+        require(input == nullptr,
+                "missing HallFame still reports as missing during recording");
+        output = createFile("HallFame", kDosDefaultCreateAttr);
+        require(output != nullptr && fileWrite("SAVE", 1, 4, output) == 4,
+                "blackbox recording accepts writes through a disposable stream");
+        fileClose(output);
+        blackbox_shutdown();
+        require(readWholeFile(recordLogPath).find("mutable_file HallFame 0") != std::string::npos,
+                "blackbox recording captures a missing HallFame as explicit empty state");
+        require(!std::filesystem::exists(testDir / "HallFame"),
+                "blackbox recording leaves missing persistent files missing");
+    }
 
     // Null/zero-size guards: the I/O helpers reject bad streams before dereferencing.
     require(fileReadRaw(nullptr, buf, kSingleByte) == kNullStreamError,

--- a/tests/file_io_behavior_tests.cpp
+++ b/tests/file_io_behavior_tests.cpp
@@ -100,7 +100,7 @@ int main() {
         const auto replayLogPath = testDir / "replay.log";
         {
             std::ofstream log(replayLogPath, std::ios::binary);
-            log << "F15SE2_BLACKBOX 5\nseed " << kReplaySeed << "\n"
+            log << "F15SE2_BLACKBOX 7\nseed " << kReplaySeed << "\n"
                 << "build_version unknown\n"
                 << "mutable_file HallFame 4 5245504c\n";
         }

--- a/tests/file_io_behavior_tests.cpp
+++ b/tests/file_io_behavior_tests.cpp
@@ -141,6 +141,26 @@ int main() {
                 "blackbox recording leaves missing persistent files missing");
     }
 
+    {
+        const auto recordLogPath = testDir / "record-existing.log";
+        {
+            std::ofstream hallFame("HallFame", std::ios::binary);
+            hallFame << "LOCAL";
+        }
+        require(blackbox_startRecord(recordLogPath.string().c_str(), kReplaySeed) != 0,
+                "test can record an existing mutable file");
+        input = openFile("HallFame", kDosReadMode);
+        require(input != nullptr && fileReadRaw(input, buf, kReadWholeRemainingStream) == 5 &&
+                    std::string(buf, 5) == "LOCAL",
+                "recording captures an existing HallFame without changing normal reads");
+        fileClose(input);
+        blackbox_shutdown();
+        require(readWholeFile(recordLogPath).find("mutable_file HallFame 5 4c4f43414c") !=
+                    std::string::npos,
+                "existing mutable state is encoded in the recording");
+        std::filesystem::remove("HallFame");
+    }
+
     // Null/zero-size guards: the I/O helpers reject bad streams before dereferencing.
     require(fileReadRaw(nullptr, buf, kSingleByte) == kNullStreamError,
             "fileReadRaw reports null stream");

--- a/tests/file_io_behavior_tests.cpp
+++ b/tests/file_io_behavior_tests.cpp
@@ -100,7 +100,7 @@ int main() {
         const auto replayLogPath = testDir / "replay.log";
         {
             std::ofstream log(replayLogPath, std::ios::binary);
-            log << "F15SE2_BLACKBOX 7\nseed " << kReplaySeed << "\n"
+            log << "F15SE2_BLACKBOX 8\nseed " << kReplaySeed << "\n"
                 << "build_version unknown\n"
                 << "mutable_file HallFame 4 5245504c\n";
         }

--- a/tests/gfx_render_behavior_tests.cpp
+++ b/tests/gfx_render_behavior_tests.cpp
@@ -73,6 +73,20 @@ void fillPageRaw(int page, uint8 color) {
         std::memset(px + (size_t)y * pitch, color, kLogicalWidth);
 }
 
+uint32 pageHash(int page) {
+    uint32 hash = 2166136261u;
+    int pitch = 0;
+    const uint8 *pixels = gfx_pagePixels(page, &pitch);
+    for (int y = 0; y < kLogicalHeight; y++) {
+        const uint8 *row = pixels + (size_t)y * pitch;
+        for (int x = 0; x < kLogicalWidth; x++) {
+            hash ^= row[x];
+            hash *= 16777619u;
+        }
+    }
+    return hash;
+}
+
 // ---- gfx_pagePixels + page-1 aliasing -------------------------------------
 void test_pagePixels_and_alias() {
     int pitch0 = 0, pitch1 = 0, pitch2 = 0;
@@ -285,6 +299,22 @@ void test_setFont() {
     require(w > 0 && w <= 32, "a proportional font returns a positive bounded advance");
 }
 
+// ---- Bitmap glyph rasterization -------------------------------------------
+void test_drawStringBitmapBits() {
+    static const uint32 kFont1AGoldenHash = 0x1f66d074u;
+    int16 params[11] = {};
+    params[0] = 2;
+    params[2] = 7;
+    params[4] = 10;
+    params[5] = 20;
+    params[6] = 1;
+
+    fillPageRaw(2, 0);
+    gfx_drawString(params, "A");
+    require(pageHash(2) == kFont1AGoldenHash,
+            "font rasterization consumes each packed glyph bit exactly once");
+}
+
 // ---- gfx_calcRowAddr / gfx_getRowOffset / blitOffset round-trip -----------
 void test_rowAddrAndBlitOffset() {
     require(gfx_getRowOffset(0) == 0 && gfx_getRowOffset(5) == 5 * kLogicalWidth,
@@ -395,6 +425,7 @@ int main() {
     test_drawLine();
     test_dirtyRect2();
     test_setFont();
+    test_drawStringBitmapBits();
     test_rowAddrAndBlitOffset();
     test_dacPalette();
     test_goldenComposedScene();

--- a/tests/input_behavior_tests.cpp
+++ b/tests/input_behavior_tests.cpp
@@ -2,6 +2,8 @@
 #include "egdata.h"
 #include "eginput.h"
 #include "headless.h"
+#include "input.h"
+#include "shared/blackbox.h"
 
 #include <SDL3/SDL.h>
 
@@ -284,6 +286,23 @@ int main() {
     }
     require(readCount == kRingStoredCapacity,
             "key ring drops overflow after its one-empty-slot capacity");
+
+    resetInputState();
+    std::remove("blackbox-dump-0.txt");
+    std::remove("blackbox-dump-0.json");
+    require(blackbox_startDebug(BLACKBOX_DEFAULT_SEED),
+            "diagnostic shortcut fixture starts deterministic debug mode");
+    pushKey(SDL_SCANCODE_F10, SDL_KMOD_CTRL);
+    input_pumpEvents();
+    FILE *textDump = std::fopen("blackbox-dump-0.txt", "rb");
+    FILE *jsonDump = std::fopen("blackbox-dump-0.json", "rb");
+    require(textDump && jsonDump && kbhit() == 0,
+            "Ctrl+F10 writes diagnostics without entering the game key ring");
+    std::fclose(textDump);
+    std::fclose(jsonDump);
+    blackbox_shutdown();
+    std::remove("blackbox-dump-0.txt");
+    std::remove("blackbox-dump-0.json");
 
     restoreInt9Handler();
     SDL_Quit();

--- a/tests/load_behavior_tests.cpp
+++ b/tests/load_behavior_tests.cpp
@@ -3,6 +3,7 @@
 #include "eg3dload.h"
 #include "egdata.h"
 #include "egtypes.h"
+#include "strand.h"
 
 #include <cstdint>
 #include <cstdlib>
@@ -19,6 +20,14 @@ extern void load15Flt3d3(void);
 char aRegn_xxx[] = "regn.xxx";
 struct Game *gameData = nullptr;
 SDL_IOStream *fileHandle = nullptr;
+
+// egmath.c contains RNG-using functions unrelated to these loader tests. ELF
+// dead-section linking discards them, while MSVC retains their references from
+// the object file, so provide deterministic link-only stubs for this isolated
+// legacy target rather than pulling the complete runtime RNG/blackbox stack in.
+void gameSrand(uint32) {}
+void gameSrandFromClock(int16 *) {}
+int gameRand15(void) { return 0; }
 
 namespace {
 

--- a/tests/r3d_dispatch_behavior_tests.cpp
+++ b/tests/r3d_dispatch_behavior_tests.cpp
@@ -1,0 +1,77 @@
+#include "r3d.h"
+#include "shared/blackbox_diag.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdarg>
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+int gBeginCalls = 0;
+int gSubmitCalls = 0;
+int gLineCalls = 0;
+int gEndCalls = 0;
+int gDiagBeginCalls = 0;
+int gDiagSubmitCalls = 0;
+int gDiagLineCalls = 0;
+int gDiagEndCalls = 0;
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+const char *glName() { return "opengl1"; }
+const char *softwareName() { return "software"; }
+int rejectBackend() { return 0; }
+int acceptBackend() { return 1; }
+void noShutdown() {}
+R3DMesh registerMesh(R3DMesh mesh) { return mesh; }
+void releaseMesh(R3DMesh) {}
+void beginScene(const R3DScene *) { ++gBeginCalls; }
+void submit(const R3DSubmit *) { ++gSubmitCalls; }
+void submitLine(const R3DLine *) { ++gLineCalls; }
+void endScene() { ++gEndCalls; }
+
+} // namespace
+
+const R3DBackend r3d_glBackend = {
+    glName, rejectBackend, noShutdown, registerMesh, releaseMesh,
+    beginScene, submit, submitLine, endScene};
+const R3DBackend r3d_softwareBackend = {
+    softwareName, acceptBackend, noShutdown, registerMesh, releaseMesh,
+    beginScene, submit, submitLine, endScene};
+
+void log_info(const char *, ...) {}
+void log_warn(const char *, ...) {}
+extern "C" void blackbox_diagRenderBeginScene(const R3DScene *) { ++gDiagBeginCalls; }
+extern "C" void blackbox_diagRenderSubmit(const R3DSubmit *) { ++gDiagSubmitCalls; }
+extern "C" void blackbox_diagRenderLine(const R3DLine *) { ++gDiagLineCalls; }
+extern "C" void blackbox_diagRenderEndScene(void) { ++gDiagEndCalls; }
+
+int main() {
+    SDL_setenv_unsafe("F15_RENDER", "software", 1);
+    r3d_init();
+    require(std::string(r3d_backendName()) == "software",
+            "forced software renderer is selected");
+
+    R3DScene scene = {nullptr, 1, 2, 3, 4, 5, 6, 1};
+    R3DSubmit object = {nullptr, 7, 8, 9, 10, 11, 12, 0};
+    R3DLine line = {1, 2, 3, 4, 5, 6, 15};
+    r3d_beginScene(&scene);
+    r3d_submit(&object);
+    r3d_submitLine(&line);
+    r3d_endScene();
+    require(gBeginCalls == 1 && gSubmitCalls == 1 && gLineCalls == 1 && gEndCalls == 1,
+            "renderer dispatch forwards every scene command to the backend");
+    require(gDiagBeginCalls == 1 && gDiagSubmitCalls == 1 && gDiagLineCalls == 1 &&
+                gDiagEndCalls == 1,
+            "renderer dispatch mirrors every scene command to blackbox diagnostics");
+    r3d_shutdown();
+    std::cout << "r3d_dispatch_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/shared_timer_behavior_tests.cpp
+++ b/tests/shared_timer_behavior_tests.cpp
@@ -1,10 +1,12 @@
 #include "egcode.h"
 #include "inttype.h"
 #include "shared/blackbox.h"
+#include "shared/blackbox_wait.h"
 
 #include <SDL3/SDL_timer.h>
 
 #include <cstdlib>
+#include <cstdio>
 #include <iostream>
 
 /* The LINK_CORE test uses the live timer globals defined by stdata.c. Keep
@@ -28,8 +30,11 @@ enum SharedTimerOriginalConstant : int {
     kMaxYieldPolls = 300,
     kNowNondecreasingSleepNs = 1,
     kCatchupResyncSleepMs = 300,
+    kRecordTickSleepMs = 25,
     kTestFailureExitCode = 1,
 };
+
+constexpr const char *kRecordPath = "shared-timer-record-test.bb";
 
 int g_hookCalls = 0;
 
@@ -77,6 +82,8 @@ int main() {
     resetTimerState();
     require(blackbox_startDebug(BLACKBOX_DEFAULT_SEED) != 0,
             "timer test can enable deterministic blackbox time");
+    require(blackbox_usesVirtualTime() != 0,
+            "debug mode owns the deterministic virtual clock");
     setTimerTickHook(testTickHook);
     setTimerIrqHandler();
     timerPump();
@@ -84,6 +91,40 @@ int main() {
                 timerCounter3 == 1 && timerCounter4 == 1 && g_hookCalls == 1,
             "blackbox timer pump advances exactly one deterministic tick and hook");
     blackbox_shutdown();
+
+    resetTimerState();
+    require(blackbox_startRecord(kRecordPath, BLACKBOX_DEFAULT_SEED) != 0,
+            "timer test can enable blackbox recording");
+    {
+        const uint8 hallFameFixture = 0;
+        blackbox_captureMutableFile("HallFame", &hallFameFixture, 1);
+    }
+    require(blackbox_usesVirtualTime() == 0,
+            "recording leaves tick production on the native clock");
+    setTimerTickHook(testTickHook);
+    setTimerIrqHandler();
+    SDL_DelayNS(static_cast<Uint64>(kRecordTickSleepMs) * SDL_NS_PER_MS);
+    timerPump();
+    const uint8 recordedTicks = timerCounter;
+    require(timerCounter > 0 && blackbox_tick() == timerCounter &&
+                g_hookCalls == timerCounter &&
+                timerNowNs() == blackbox_timerNowNs(),
+            "recording timestamps native ticks on the deterministic simulation clock");
+    restoreTimerIrqHandler();
+    blackbox_shutdown();
+
+    resetTimerState();
+    require(blackbox_startReplay(kRecordPath) != 0,
+            "timer test can replay the native timer schedule");
+    setTimerTickHook(testTickHook);
+    setTimerIrqHandler();
+    timerPump();
+    require(timerCounter == recordedTicks && blackbox_tick() == recordedTicks &&
+                g_hookCalls == recordedTicks,
+            "replay consumes the exact recorded ticks for each timer pump");
+    restoreTimerIrqHandler();
+    blackbox_shutdown();
+    std::remove(kRecordPath);
 
     resetTimerState();
     setTimerTickHook(testTickHook);

--- a/tests/shared_timer_behavior_tests.cpp
+++ b/tests/shared_timer_behavior_tests.cpp
@@ -30,13 +30,13 @@ enum SharedTimerOriginalConstant : int {
     kMaxYieldPolls = 300,
     kNowNondecreasingSleepNs = 1,
     kCatchupResyncSleepMs = 300,
-    kRecordTickSleepMs = 25,
     kTestFailureExitCode = 1,
 };
 
 constexpr const char *kRecordPath = "shared-timer-record-test.bb";
 
 int g_hookCalls = 0;
+int g_waitPolls = 0;
 
 void require(bool condition, const char *message) {
     if (!condition) {
@@ -59,6 +59,12 @@ void resetTimerState() {
 
 void far testTickHook(void) {
     ++g_hookCalls;
+}
+
+bool pollTimerWait() {
+    ++g_waitPolls;
+    timerPump();
+    return false;
 }
 
 int main() {
@@ -103,13 +109,16 @@ int main() {
             "recording leaves tick production on the native clock");
     setTimerTickHook(testTickHook);
     setTimerIrqHandler();
-    SDL_DelayNS(static_cast<Uint64>(kRecordTickSleepMs) * SDL_NS_PER_MS);
-    timerPump();
+    g_waitPolls = 0;
+    require(blackbox_virtualWait(kTargetTicks, 0, pollTimerWait) != 0,
+            "recording uses the deterministic polling wait path");
     const uint8 recordedTicks = timerCounter;
+    const int recordedWaitPolls = g_waitPolls;
     require(timerCounter > 0 && blackbox_tick() == timerCounter &&
                 g_hookCalls == timerCounter &&
-                timerNowNs() == blackbox_timerNowNs(),
-            "recording timestamps native ticks on the deterministic simulation clock");
+                timerNowNs() == blackbox_timerNowNs() &&
+                recordedWaitPolls > recordedTicks,
+            "recording preserves zero-tick polls on the deterministic simulation clock");
     restoreTimerIrqHandler();
     blackbox_shutdown();
 
@@ -118,10 +127,12 @@ int main() {
             "timer test can replay the native timer schedule");
     setTimerTickHook(testTickHook);
     setTimerIrqHandler();
-    timerPump();
+    g_waitPolls = 0;
+    require(blackbox_virtualWait(kTargetTicks, 0, pollTimerWait) != 0,
+            "replay follows the recorded polling wait path");
     require(timerCounter == recordedTicks && blackbox_tick() == recordedTicks &&
-                g_hookCalls == recordedTicks,
-            "replay consumes the exact recorded ticks for each timer pump");
+                g_hookCalls == recordedTicks && g_waitPolls == recordedWaitPolls,
+            "replay consumes zero and nonzero timer pumps at the recorded polls");
     restoreTimerIrqHandler();
     blackbox_shutdown();
     std::remove(kRecordPath);

--- a/tests/shared_timer_behavior_tests.cpp
+++ b/tests/shared_timer_behavior_tests.cpp
@@ -1,16 +1,20 @@
 #include "egcode.h"
 #include "inttype.h"
+#include "shared/blackbox.h"
 
 #include <SDL3/SDL_timer.h>
 
 #include <cstdlib>
 #include <iostream>
 
-uint8 timerCounter = 0;
-uint8 timerCounter2 = 0;
-uint8 timerCounter3 = 0;
-uint8 timerCounter4 = 0;
-uint8 timerHandlerInstalled = 0;
+/* The LINK_CORE test uses the live timer globals defined by stdata.c. Keep
+ * declarations here because the translated data headers expose only the subset
+ * used by original modules. */
+extern uint8 timerCounter;
+extern uint8 timerCounter2;
+extern uint8 timerCounter3;
+extern uint8 timerCounter4;
+extern uint8 timerHandlerInstalled;
 
 namespace {
 
@@ -69,6 +73,17 @@ int main() {
             "timerYield/timerPump advance all original timer counters together");
     require(g_hookCalls == timerCounter,
             "timerPump invokes the original per-tick hook once per advanced tick");
+
+    resetTimerState();
+    require(blackbox_startDebug(BLACKBOX_DEFAULT_SEED) != 0,
+            "timer test can enable deterministic blackbox time");
+    setTimerTickHook(testTickHook);
+    setTimerIrqHandler();
+    timerPump();
+    require(blackbox_tick() == 1 && timerCounter == 1 && timerCounter2 == 1 &&
+                timerCounter3 == 1 && timerCounter4 == 1 && g_hookCalls == 1,
+            "blackbox timer pump advances exactly one deterministic tick and hook");
+    blackbox_shutdown();
 
     resetTimerState();
     setTimerTickHook(testTickHook);

--- a/tests/sys_behavior_tests.cpp
+++ b/tests/sys_behavior_tests.cpp
@@ -2,6 +2,8 @@
 #include "egdata.h"
 #include "egtypes.h"
 #include "inttype.h"
+#include "shared/blackbox.h"
+#include "shared/blackbox_diag.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -21,6 +23,9 @@ void renderFrame(void) {}
 void renderHudFrame(int) {}
 void stepFlightModel(void) {}
 void updateFrame(void) {}
+int blackbox_enabled(void) { return 0; }
+void blackbox_diagCaptureSimStep(void) {}
+void blackbox_diagBeginRenderFrame(void) {}
 
 namespace {
 

--- a/tests/sys_behavior_tests.cpp
+++ b/tests/sys_behavior_tests.cpp
@@ -24,6 +24,7 @@ void renderHudFrame(int) {}
 void stepFlightModel(void) {}
 void updateFrame(void) {}
 int blackbox_enabled(void) { return 0; }
+int blackbox_usesVirtualTime(void) { return 0; }
 void blackbox_diagCaptureSimStep(void) {}
 void blackbox_diagBeginRenderFrame(void) {}
 

--- a/tools/blackbox_inspect.py
+++ b/tools/blackbox_inspect.py
@@ -35,7 +35,7 @@ def parse_log(path: Path) -> tuple[int | None, list[Event]]:
     events: list[Event] = []
     with path.open("r", encoding="utf-8") as f:
         header = f.readline().strip()
-        if header != "F15SE2_BLACKBOX 5":
+        if header != "F15SE2_BLACKBOX 7":
             raise SystemExit(f"unsupported blackbox header: {header!r}")
         for lineno, line in enumerate(f, start=2):
             parts = line.strip().split()

--- a/tools/blackbox_inspect.py
+++ b/tools/blackbox_inspect.py
@@ -49,7 +49,7 @@ def parse_log(path: Path) -> tuple[int | None, list[Event]]:
                 continue
             if kind == "mutable_file":
                 continue
-            if kind in {"phase", "rng_seed", "rng", "key", "axes", "frame",
+            if kind in {"phase", "timer_pump", "rng_seed", "rng", "key", "axes", "frame",
                         "marker", "state", "render_scene", "render_object",
                         "render_line", "render_hash"} and len(parts) >= 2:
                 try:
@@ -65,6 +65,8 @@ def parse_log(path: Path) -> tuple[int | None, list[Event]]:
 def format_event(event: Event) -> str:
     if event.kind == "key" and len(event.fields) == 2:
         detail = f"pump={event.fields[0]} word=0x{int(event.fields[1], 16):04x}"
+    elif event.kind == "timer_pump" and len(event.fields) == 1:
+        detail = f"ticks={event.fields[0]}"
     elif event.kind == "axes" and len(event.fields) == 4:
         detail = f"raw=({event.fields[0]},{event.fields[1]}) joy=({event.fields[2]},{event.fields[3]})"
     elif event.kind == "rng" and event.fields:

--- a/tools/blackbox_inspect.py
+++ b/tools/blackbox_inspect.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Inspect an F-15 SE II blackbox log around a deterministic tick/time window."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+TICKS_PER_SECOND = 60
+
+
+@dataclass(frozen=True)
+class Event:
+    tick: int
+    kind: str
+    fields: tuple[str, ...]
+
+
+def parse_tick_or_time(value: str) -> int:
+    displayed = int(value, 0)
+    if displayed < 0 or displayed % 100 >= TICKS_PER_SECOND:
+        raise argparse.ArgumentTypeError("displayed time must end in 00..59")
+    return displayed // 100 * TICKS_PER_SECOND + displayed % 100
+
+
+def tick_time(tick: int) -> str:
+    return str(tick // TICKS_PER_SECOND * 100 + tick % TICKS_PER_SECOND)
+
+
+def parse_log(path: Path) -> tuple[int | None, list[Event]]:
+    seed: int | None = None
+    events: list[Event] = []
+    with path.open("r", encoding="utf-8") as f:
+        header = f.readline().strip()
+        if header != "F15SE2_BLACKBOX 5":
+            raise SystemExit(f"unsupported blackbox header: {header!r}")
+        for lineno, line in enumerate(f, start=2):
+            parts = line.strip().split()
+            if not parts:
+                continue
+            kind = parts[0]
+            if kind == "seed" and len(parts) == 2:
+                seed = int(parts[1], 0)
+                continue
+            if kind == "build_version":
+                continue
+            if kind == "mutable_file":
+                continue
+            if kind in {"phase", "rng_seed", "rng", "key", "axes", "frame",
+                        "marker", "state", "render_scene", "render_object",
+                        "render_line", "render_hash"} and len(parts) >= 2:
+                try:
+                    tick = int(parts[1], 0)
+                except ValueError as exc:
+                    raise SystemExit(f"{path}:{lineno}: bad tick: {parts[1]!r}") from exc
+                events.append(Event(tick=tick, kind=kind, fields=tuple(parts[2:])))
+                continue
+            raise SystemExit(f"{path}:{lineno}: unknown blackbox line: {line.rstrip()!r}")
+    return seed, events
+
+
+def format_event(event: Event) -> str:
+    if event.kind == "key" and len(event.fields) == 2:
+        detail = f"pump={event.fields[0]} word=0x{int(event.fields[1], 16):04x}"
+    elif event.kind == "axes" and len(event.fields) == 4:
+        detail = f"raw=({event.fields[0]},{event.fields[1]}) joy=({event.fields[2]},{event.fields[3]})"
+    elif event.kind == "rng" and event.fields:
+        detail = f"value={event.fields[0]}"
+    elif event.kind == "rng_seed" and event.fields:
+        detail = f"seed={event.fields[0]}"
+    elif event.kind == "phase" and event.fields:
+        detail = event.fields[0]
+    elif event.kind == "frame" and len(event.fields) >= 2:
+        detail = f"frame={event.fields[0]} hash=0x{int(event.fields[1], 16):08x}"
+    elif event.kind == "marker" and len(event.fields) == 4:
+        detail = f"{event.fields[0]}({event.fields[1]},{event.fields[2]},{event.fields[3]})"
+    elif event.kind == "state" and len(event.fields) == 3:
+        detail = f"step={event.fields[0]} subsystem={event.fields[1]} hash=0x{int(event.fields[2], 16):08x}"
+    elif event.kind == "render_hash" and len(event.fields) == 5:
+        detail = (f"frame={event.fields[0]} scene={event.fields[1]} "
+                  f"objects={event.fields[2]} lines={event.fields[3]} "
+                  f"hash=0x{int(event.fields[4], 16):08x}")
+    else:
+        detail = " ".join(event.fields)
+    return f"{event.tick:8d} {tick_time(event.tick)} {event.kind:8s} {detail}"
+
+
+def summarize(events: Iterable[Event]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for event in events:
+        counts[event.kind] = counts.get(event.kind, 0) + 1
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--around-tick", type=parse_tick_or_time, default=None,
+                        help="center at displayed time (seconds*100 + tick), e.g. 20545")
+    parser.add_argument("--from-tick", dest="from_tick", type=parse_tick_or_time, default=None,
+                        help="start at displayed time (seconds*100 + tick)")
+    parser.add_argument("--to-tick", dest="to_tick", type=parse_tick_or_time, default=None,
+                        help="end at displayed time (seconds*100 + tick)")
+    parser.add_argument("--before", type=int, default=180, help="ticks before --around-tick")
+    parser.add_argument("--after", type=int, default=180, help="ticks after --around-tick")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args()
+
+    seed, events = parse_log(args.log)
+    if args.around_tick is not None:
+        start = max(0, args.around_tick - args.before)
+        end = args.around_tick + args.after
+    else:
+        start = 0 if args.from_tick is None else args.from_tick
+        end = (events[-1].tick if events else 0) if args.to_tick is None else args.to_tick
+
+    window = [event for event in events if start <= event.tick <= end]
+    if args.json:
+        print(json.dumps({
+            "file": str(args.log),
+            "seed": seed,
+            "start_tick": start,
+            "end_tick": end,
+            "counts": summarize(events),
+            "events": [
+                {"tick": e.tick, "time": tick_time(e.tick), "kind": e.kind, "fields": list(e.fields)}
+                for e in window
+            ],
+        }, indent=2))
+        return 0
+
+    max_tick = events[-1].tick if events else 0
+    print(f"file: {args.log}")
+    print(f"seed: {seed if seed is not None else 'unknown'}")
+    print(f"recorded ticks: 0..{max_tick} ({tick_time(max_tick)})")
+    print("event counts: " + ", ".join(f"{k}={v}" for k, v in sorted(summarize(events).items())))
+    print(f"window: {start}..{end} ({tick_time(start)}..{tick_time(end)})")
+    for event in window:
+        print(format_event(event))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/blackbox_inspect.py
+++ b/tools/blackbox_inspect.py
@@ -35,7 +35,7 @@ def parse_log(path: Path) -> tuple[int | None, list[Event]]:
     events: list[Event] = []
     with path.open("r", encoding="utf-8") as f:
         header = f.readline().strip()
-        if header != "F15SE2_BLACKBOX 7":
+        if header != "F15SE2_BLACKBOX 8":
             raise SystemExit(f"unsupported blackbox header: {header!r}")
         for lineno, line in enumerate(f, start=2):
             parts = line.strip().split()
@@ -67,8 +67,9 @@ def format_event(event: Event) -> str:
         detail = f"pump={event.fields[0]} word=0x{int(event.fields[1], 16):04x}"
     elif event.kind == "timer_pump" and len(event.fields) == 1:
         detail = f"ticks={event.fields[0]}"
-    elif event.kind == "axes" and len(event.fields) == 4:
-        detail = f"raw=({event.fields[0]},{event.fields[1]}) joy=({event.fields[2]},{event.fields[3]})"
+    elif event.kind == "axes" and len(event.fields) == 5:
+        detail = (f"pump={event.fields[0]} raw=({event.fields[1]},{event.fields[2]}) "
+                  f"joy=({event.fields[3]},{event.fields[4]})")
     elif event.kind == "rng" and event.fields:
         detail = f"value={event.fields[0]}"
     elif event.kind == "rng_seed" and event.fields:


### PR DESCRIPTION
## Summary

Adds deterministic blackbox recording and replay for reproducing intermittent gameplay and rendering problems.

## Changes

- Records deterministic 60 Hz timing, input, joystick axes, RNG values, and program phases.
- Captures frame checksums, gameplay subsystem hashes, and backend-independent 3D submissions.
- Replays recordings while ignoring live gameplay input.
- Captures `HallFame` state and redirects persistent writes during recording/replay.
- Supports replay fast-forward, pause-at-time, and automatic or manual diagnostic dumps.
- Produces human-readable text dumps and structured JSON snapshots.
- Adds an on-screen compact replay clock.
- Adds `tools/blackbox_inspect.py` for inspecting a selected recording timeframe.
- Debug builds automatically record to `_blackbox.rec` in the current working directory when no explicit blackbox mode is selected.
- Builds and tests both Windows Release and Windows Debug configurations; Windows Debug CI uploads `f15se2-ex-windows-debug`.

## Motivation

Several remaining defects are intermittent or require a long sequence of player actions. A recording can be shared with another developer or agent, replayed deterministically, fast-forwarded to the relevant moment, and compared across source versions.

Automatic Debug-build recording lets testers collect a useful report without learning the command-line interface first. Explicit `--blackbox-debug`, `--blackbox-record`, and `--blackbox-replay` behavior remains unchanged. Release builds never record implicitly.

Replay does not require the developer to have the recorder's original pilot roster.

## Design

Most implementation is isolated in `src/shared/blackbox*`. Existing game files contain small integration hooks for timing, input, RNG, frame presentation, persistent-file access, gameplay-state capture, and renderer submissions.

Diagnostic JSON serializes fields explicitly instead of copying raw C structures. Dumps are intended for investigation and comparison, not as loadable save states.

## Usage

A Debug build records automatically:

```bash
./build/f15se2-ex --game /path/to/f15
# Writes ./_blackbox.rec
```

An explicit destination overrides the default:

```bash
./build/f15se2-ex --game /path/to/f15 \
  --blackbox-record /tmp/f15-run.bb
```

Replay:

```bash
./build/f15se2-ex --game /path/to/f15 \
  --blackbox-replay /tmp/f15-run.bb
```

Fast-forward, dump, and pause at a displayed time:

```bash
./build/f15se2-ex --game /path/to/f15 \
  --blackbox-replay /tmp/f15-run.bb \
  --blackbox-fast-forward-tick 20545 \
  --blackbox-dump-tick 20545 \
  --blackbox-pause-tick 20545
```

See `docs/blackbox_debugging.md` for Windows Debug build commands, recording semantics, inspection workflow, and dump formats.

## Validation

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j2
ctest --test-dir build --output-on-failure
```

All 35 local tests passed. GitHub CI additionally validates MSVC Release and Debug builds.
