### PR TITLE
[review: high] 8. [custom] Add external asset conversion and editing tools

### DIFF
--- a/.github/workflows/asset-tools.yml
+++ b/.github/workflows/asset-tools.yml
@@ -1,0 +1,26 @@
+name: Asset tools
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python and Pillow
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python3 python3-pil
+      - name: Test converters and replacement validation
+        env:
+          PYTHONPATH: tools/f15assets:.
+        # Synthetic fixtures run without copyrighted assets. Local developers
+        # can additionally set F15SE2_ORIGINAL_ASSETS for full-asset tests.
+        run: python3 -m unittest discover -s tools/f15assets/tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ coverage.txt
 *.gcda
 *.gcno
 *.actual.bmp
+
+# Python test/tool caches
+__pycache__/
+*.pyc
+
+# Generated replacement asset exports. Keep these out of source commits.
+/converted_assets_all/

--- a/docs/reverse_engineering_asset_formats.md
+++ b/docs/reverse_engineering_asset_formats.md
@@ -62,34 +62,45 @@ The converter prioritizes forward conversion only:
 - The modern baseline used for authoring is:
   - `glTF 2.0` (`.glb` by default, `.gltf` optional) for models.
   - Indexed `PNG` (with embedded palette chunk) for image assets.
-  - `JSON` (with optional `YAML`) for structured world/terrain/table data.
+  - Ordered `JSON` for structured world/terrain/table data.
 - The default developer workflow is stable-then-edit: export to modern formats
   first, then modify only the exported modern format plus metadata sidecars.
+- If a modern media file and JSON sidecar contain overlapping information, the
+  modern media file is authoritative. PNG overrides image JSON for pixels,
+  dimensions, and palette; GLB overrides `.3D3.json` for model geometry and
+  GLB extras; WAV overrides sound JSON for sample data and audio format; BDF
+  overrides font JSON for glyph data and metrics, while PNG overrides font JSON
+  for atlas pixels only.
+- Validation invariant: loading an unmodified converted asset should produce
+  the same in-memory game data as loading the original asset. Float or lossy
+  modern encodings may be numerically equivalent within a documented tolerance
+  instead of byte-identical. This comparison belongs in importer
+  validation/tests or explicit diagnostics, not in normal runtime loading.
 - Modern reliable authoring targets:
   - `glTF 2.0` (`.glb` by default, `.gltf` optional) for geometry and model editing (Blender-first).
   - Indexed `PNG` for image art.
-  - `JSON`/`YAML` for structured world/terrain/table data.
+  - Ordered `JSON` for structured world/terrain/table data.
 - For stable pipelines, the modern editable target for 3D is **glTF 2.0**
   (`.glb`) because it is reproducible, self-contained, widely supported, and easy to
   move into Blender.
 - Lossy/editor formats like PNG and glTF should be accompanied by canonical
   structured metadata for any real edit pipeline.
 
-| Game format | Best editable format | Canonical export source | Export from game | Import back to game | Notes |
+| Game format | Best editable format | Canonical export source | Export from game | Runtime modern load | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `*.PIC` | Indexed PNG | PNG + JSON sidecar + original header/compression metadata | Yes | No | Best for full-screen images and cockpit/title art. JSON keeps palette, image mode, max code width, output layout, and original compression metadata. |
-| `*.SPR` | Indexed PNG sprite sheet + JSON atlas | PNG + JSON sidecar + original header/compression metadata | Yes | No | Same compressed image stream as PIC. The atlas is not embedded in SPR; generate/maintain JSON from code sprite descriptors and hand-assigned names. |
-| `*.3D3` theater models | **glTF (`.glb` default)** + `3D3` JSON sidecar | Parsed `.3D3` JSON plus raw display-list chunks and vertex-pool data | Yes | No | glTF is the stable modern mesh target for Blender, tools, and web pipelines. Keep a canonical `3D3` sidecar for traceable edits. |
-| `15FLT.3D3` aircraft models | **glTF (`.glb` default)** + `3D3` JSON sidecar | Parsed `.3D3` JSON plus raw aircraft display-list chunks | Yes | No | Same model-stream issue as theater `.3D3`; preserve shape ids and aircraft table mapping in JSON metadata. |
-| `PHOTO.3D3` target-photo models | **glTF (`.glb` default)** + `3D3` JSON sidecar | Parsed `.3D3` JSON plus raw chunks and append metadata | Yes | No | Treat like `.3D3`; preserve append/slot metadata because runtime appends selected chunks. |
-| `*.3DT` tile placements | YAML or JSON, optional CSV view | Canonical YAML/JSON with every 16-bit field preserved | Yes | No | Text is better than Blender for placements. It is object placement data: tile level, tile index, x/y/z, and a 16-bit shape word whose low byte is used at runtime. CSV can be a view, not the canonical source. |
-| `*.3DG` terrain grid | JSON/YAML data + PNG previews | Canonical JSON/YAML with all five grid buffers | Yes | No | PNG previews are only for visualization. Exact hierarchical grid data must be kept in JSON/YAML. |
-| `*.WLD` world/campaign | YAML or JSON, optional CSV tables | Canonical YAML/JSON preserving named binary tables, name table bytes, and record order | Yes | No | Best as structured text: world objects, flight units, terrain grid, name table, and proven mission/category tables. CSV helps spreadsheet editing, but JSON/YAML should be canonical. |
-| Palette data | GIMP `.gpl` or JASC `.pal` for editing | JSON with exact DAC tables, mode, and 6-bit/8-bit level metadata | Yes | No | Editor palette files are useful but not enough; JSON must preserve exact game palette/register metadata. |
+| `*.PIC` | Indexed PNG | PNG plus optional decode JSON | Yes | Yes | PNG is authoritative for pixels, dimensions, and palette. `convert-tree --include-image-json` keeps image mode, max code width, layout, and bulky decode metadata for diagnostics only. Backward conversion to `.PIC` is intentionally not required. |
+| `*.SPR` | Indexed PNG sprite sheet + optional JSON atlas | PNG plus optional decode/index JSON | Yes | Yes | PNG is authoritative for pixels, dimensions, and palette. The atlas is not embedded in SPR; generate/maintain JSON from code sprite descriptors and hand-assigned names only when needed. Backward conversion to `.SPR` is intentionally not required. |
+| `*.3D3` theater models | **glTF (`.glb` default)** + optional generated `cache/*.glmesh` runtime cache + lightweight `3D3` JSON index | Combined GLB and per-shape GLB files in the related world directory; `.glmesh` is generated from GLB and stores the source GLB checksum; default JSON keeps lightweight ids/lookup metadata only, while `--include-3d3-model-data` writes full bridge dumps | Yes | Partial: OpenGL geometry replacement, legacy `.3D3` still required for slot tables/fallback unless a full JSON bridge dump is provided | glTF is authoritative for model geometry and extras. Default JSON must not duplicate model bytecode; full bridge dumps are opt-in. A future GLB-only/free-asset runtime still needs a native replacement for the `.3D3` shape-slot table load. |
+| `15FLT.3D3` aircraft models | **glTF (`.glb` default)** + optional generated `cache/*.glmesh` runtime cache + lightweight `3D3` JSON index | Combined GLB and per-shape GLB files in `15FLT/`; cache files live in `15FLT/cache/` when generated; default JSON keeps lightweight ids/lookup metadata only, while `--include-3d3-model-data` writes full bridge dumps | Yes | Partial: OpenGL geometry replacement, legacy `.3D3` still required for aircraft shape slots/fallback unless a full JSON bridge dump is provided | Same model-stream issue as theater `.3D3`; preserve shape ids and aircraft table mapping as lightweight JSON metadata. A future GLB-only/free-asset runtime must load this table from modern metadata. |
+| `PHOTO.3D3` target-photo models | **glTF (`.glb` default)** + optional generated `cache/*.glmesh` runtime cache + lightweight `3D3` JSON index | Combined GLB and per-shape GLB files in `PHOTO/`; cache files live in `PHOTO/cache/` when generated; default JSON keeps lightweight ids/lookup metadata only, while `--include-3d3-model-data` writes full bridge dumps | Yes | Partial: OpenGL geometry replacement, legacy `.3D3` still required for appended target-view slots/fallback unless a full JSON bridge dump is provided | Treat like `.3D3`; preserve append/slot metadata without duplicating geometry by default. A future GLB-only/free-asset runtime must load append/slot metadata from modern metadata. |
+| `*.3DT` tile placements | Ordered JSON in the related world directory, optional CSV view | Canonical JSON with every 16-bit field preserved | Yes | Yes, via rebuild bridge | Text is better than Blender for placements. It is object placement data: tile level, tile index, x/y/z, and a 16-bit shape word whose low byte is used at runtime. CSV can be a view, not the canonical source. |
+| `*.3DG` terrain grid | Ordered JSON in the related world directory + PNG previews | Canonical JSON with all five grid buffers | Yes | Yes, via rebuild bridge | PNG previews are only for visualization. Exact hierarchical grid data must be kept in JSON. |
+| `*.WLD` world/campaign | Ordered JSON, optional CSV tables | Canonical JSON preserving named binary tables, name table bytes, and record order | Yes | Yes, via rebuild bridge | Best as structured text: world objects, flight units, terrain grid, name table, and proven mission/category tables. CSV helps spreadsheet editing, but JSON should be canonical. |
+| Palette data | GIMP `.gpl` or JASC `.pal` for editing | JSON with exact DAC tables, mode, and 6-bit/8-bit level metadata | Yes | Indirect via PNG | Editor palette files are useful but not enough; JSON must preserve exact game palette/register metadata. |
 | Text and strings | `.po` + `.json` text bundles | In-binary text regions extracted from executable/overlay segments | Planned | No | No standalone text resource files were identified. Use string-id and source-offset maps to support translation and custom copy editing. |
-| Fonts | Unicode `BDF` + atlas `PNG` + metadata JSON | Extracted font tables in `src/fontdata.h` + metrics in `src/gfx_impl.c` | Yes | No | `export-fonts` emits one BDF, atlas, and sidecar per known font. BDF is the editable Unicode-capable bitmap font target; JSON preserves legacy CP437 source bytes, Unicode codepoints, atlas rects, advance widths, and raw bitmap rows. |
-| Sounds | `.wav` + metadata JSON, unresolved driver sidecars | `F15DGTL.BIN` and sound-driver executables | Partial | No | `export-sounds` emits `F15DGTL.BIN` as a raw unsigned 8-bit PCM WAV plus ASOUND-recovered cue WAVs and metadata. Driver EXEs are preserved as unresolved JSON until synthesized effect tables are decoded. |
-| Manuals/maps | Markdown notes + georeferenced PNG overlays | Not applicable | Yes | No | These are reference material, not game assets. Use them to validate WLD coordinates, target names, and theater symbols. |
+| Fonts | Unicode `BDF` + atlas `PNG`, optional metadata JSON | Extracted font tables in `src/fontdata.h` + metrics in `src/gfx_impl.c` | Yes | Yes | `export-fonts` emits BDF and atlas PNG by default. BDF is authoritative for glyph data and metrics; PNG is authoritative for atlas pixels only. Optional JSON maps codepoints to atlas/index metadata when `--include-metadata` is used. |
+| Sounds | cue `.wav`, optional metadata JSON, optional unresolved driver sidecars | `F15DGTL.BIN` and sound-driver executables | Partial | Yes | `export-sounds` emits ASOUND-recovered cue WAVs by default. Cue WAV files are authoritative for runtime sample replacement; customizers do not need JSON or a full sound blob. `--include-metadata` adds cue JSON, driver sidecars, and `sounds.json`; `--include-raw-blob` additionally emits `F15DGTL.BIN` as a raw unsigned 8-bit PCM reference WAV for reverse engineering only. Driver sidecars preserve hashes/sizes/status, not executable bytes. |
+| Manuals/maps | Markdown notes + georeferenced PNG overlays | Not applicable | Yes | Not a runtime asset | These are reference material, not game assets. Use them to validate WLD coordinates, target names, and theater symbols. |
 
 ### Modern Forward-Compatible Export Target
 
@@ -97,18 +108,133 @@ The modern stable formats for developer workflows are:
 
 - Indexed `PNG` (with embedded palette chunk) for image assets (`.PIC`, `.SPR`) because it is universally supported and
   easy to edit.
-- `glTF 2.0` (`.glb` by default, `.gltf` optional) for `3D3` model previews/editing.  
+- `glTF 2.0` (`.glb` by default, `.gltf` optional) for `3D3` model previews/editing and runtime replacement.
   Blender users should import/export via glTF (`.blend` is a downstream workspace,
   not the canonical interchange artifact).
-- JSON (and optional YAML) for table/world data (`.3DT`, `.3DG`, `.WLD`), with stable
+- Ordered JSON for table/world data (`.3DT`, `.3DG`, `.WLD`), with stable
   schemas and explicit byte-preservation sidecars.
 - `.po`/`.json` for translatable text bundles and locale work.
 - Unicode `BDF` + font atlas `PNG` + glyph-metrics `JSON` for font extensions and localization.
 - PCM `WAV` (`AIFF/FLAC` as needed) + sidecar JSON for game sounds.
 
+For customizers, the intended authoring surface is the modern media file when it
+can represent the data directly. Edit per-shape GLB in Blender for 3D, indexed
+PNG for images, BDF/PNG for fonts, and WAV for digitized sounds. JSON remains
+the authoritative source for structured tables such as WLD/3DT/3DG, and a small
+manifest/index for media formats. This keeps sidecar editing minimal while still
+preserving ids, offsets, and lookup metadata needed by the loader.
+
+Long-term licensing goal: this pipeline should allow a future install to run
+with freely licensed custom replacement assets only. That is not true for all
+formats today; the current runtime still needs original assets as fallback and
+as the comparison source for unsupported or incomplete replacement paths.
+
 Blender interoperability is achieved via glTF import/export. There is no direct
 `.3D3` editor round-trip in this project. The stable authoritative interchange
-format for model customization is `.glb` (fallback: `.gltf`).
+format for model customization and model replacement is `.glb` (fallback:
+`.gltf`); the matching JSON is only a lightweight index. Per-shape GLBs are
+minimized so a customized model slot carries only the resources referenced by
+that shape. `.glmesh` is a generated runtime cache stored under `cache/`,
+derived from the matching GLB, and not the authoring source. The cache stores
+the MD5 checksum of the source GLB so runtime loading can rebuild stale caches
+automatically.
+
+`PHOTO.3D3` target-view models are a loader special case: the original game
+selectively appends them to the active theater `.3D3` shape table. Modern
+authoring still uses `PHOTO/shape_###.glb`; the OpenGL replacement path maps
+appended target-view slots back to that `PHOTO` directory before looking up the
+per-shape GLB or generated `cache/*.glmesh`.
+
+GLB primitive `extras` are diagnostic/provenance metadata. They let test-time
+validators prove that an unmodified export preserved original `.3D3` primitive
+order and raw color identity, but rendering must still come from GLB
+geometry/materials. A custom GLB exported from Blender may lose those extras and
+still be a valid replacement; old-vs-new proof will simply be weaker for that
+edited shape.
+
+Runtime replacement status:
+
+- The game has a shared converted-asset resolver that searches extensionless
+  export directories (`VN/`, `LIBYA/`, `GULF/`, `15FLT/`, `PHOTO/`, etc.).
+- If `F15_REPLACEMENT_ROOT` is set, the resolver searches that converted/custom
+  asset directory before the usual `converted_assets_all` locations under the
+  game path or current directory. If the variable points at a parent folder, a
+  `converted_assets_all` child is also searched. Missing replacement-root
+  directories are reported once, ignored, and normal fallback locations are
+  still searched. This lets developers test replacement packs without copying
+  them beside the
+  original DOS assets.
+- `F15_ASSET_TOOL` can override the Python bridge command used to rebuild JSON
+  table byte streams and generated GLMESH caches, for example
+  `F15_ASSET_TOOL="python3 /path/to/f15se2-ex/tools/f15assets/cli.py"`. This is
+  useful when `F15_REPLACEMENT_ROOT` points outside the repository layout.
+- Replacement lookup is case-tolerant for modern filenames and grouped model
+  directories, so converted packs do not depend on the source DOS asset casing.
+- Legacy file loads probe for preferred modern replacements before loading old
+  assets and log that the legacy loader remains active until that format has a
+  native modern importer. Current probes cover `.3D3 -> .glb` for OpenGL
+  geometry, full `.3D3.json` for legacy-byte-stream bridge dumps,
+  `.PIC/.SPR -> .png`, and `.WLD/.3DT/.3DG -> .json`.
+- The resolver can locate per-shape model files by stable shape slot, for
+  example `VN/shape_049_SAM_Radar.glb`; those files are the intended runtime
+  source for customized 3D replacements, not the `.3D3.json` sidecar. The
+  OpenGL backend loads matching `cache/*.glmesh` files when their embedded GLB
+  checksum matches and rebuilds missing or stale caches through the
+  `build-glmesh` bridge. The current model loader still reads legacy `.3D3`
+  bytes for shape-slot tables, PHOTO append ranges, comparison, and software
+  fallback; GLB-only/free-asset runtime support requires replacing those table
+  reads with modern metadata before original `.3D3` files can be omitted.
+  Full `.3D3.json` files containing `model_data` can be rebuilt through the
+  legacy-byte-stream bridge; default minimized `.3D3.json` files are treated as
+  metadata-only and leave the old `.3D3` byte stream in place.
+- Digitized sound loading prefers separate `sounds/voice_cue_*.wav` files when
+  present. Each WAV accepts uncompressed mono unsigned 8-bit PCM, and its RIFF
+  sample rate controls replacement playback speed. Missing cue files, empty
+  WAVs, and invalid WAVs fall back to the matching range in `F15DGTL.BIN`.
+  Decoded WAV equivalence is checked by `validate-replacements` and CTest, not
+  during normal gameplay.
+- PIC/SPR loading prefers matching PNG replacements when present. Indexed PNGs
+  are copied as palette indices and their embedded palette is uploaded to the
+  active DAC, so the PNG remains self-contained for pixels and palette.
+  Palette-less indexed PNGs are rejected and fall back to legacy PIC/SPR.
+  `TITLE640.PIC` uses a dedicated 640x350 hi-res PNG path that compares against
+  the original alternating left/right row decode. The replacement path is used
+  by start/end picture wrappers and by flight cockpit picture loads such as
+  `256pit.PIC`. Menu/debrief disk-presence gates for sprite sheets must accept
+  the same PNG replacement path as the later `loadPic()` call, so `.SPR`
+  replacements do not get blocked before loading.
+  `256pit.PIC`, `256Left.Pic`, and `cockpit.PIC`.
+  Truecolor PNGs are accepted as an editing convenience by mapping pixels to the current
+  game palette. Replacement PNGs are sampled into the existing in-game target
+  rectangle, so higher-resolution source PNGs do not enlarge menus, cockpits, or
+  sprite sheets. Pixel and palette equivalence is checked by
+  `validate-replacements` and CTest.
+- WLD/3DT/3DG loading prefers matching JSON replacements when present. Runtime
+  import currently bridges through the converter's `build-binary` command,
+  rebuilding the original byte stream from JSON and feeding that stream to the
+  existing loaders. This preserves runtime memory layout while keeping JSON as
+  the editable source. `F15_ASSET_TOOL` can override the command prefix; by
+  default runtime first looks for `tools/f15assets/cli.py` beside the
+  replacement asset's `converted_assets_all` root, then tries nearby script
+  paths, then falls back to `python3 -m tools.f15assets.cli`. JSON-rebuilt byte
+  equivalence is checked by `validate-replacements` and CTest.
+- Font drawing prefers exported `fonts/font_<id>.bdf`: the runtime parses glyph
+  rows and advance widths, then renders from the BDF data. If BDF is absent or
+  rejected, exported `fonts/font_<id>.png` atlases are tried for glyph pixels;
+  PNG glyph pixels are authoritative, while advance widths currently come from
+  existing font metrics. BDF fonts with incomplete glyphs or zero advance widths
+  are rejected. Built-in font equivalence is checked by `validate-replacements`
+  and CTest.
+- GLB import is implemented for the OpenGL backend through a simple runtime mesh
+  bridge generated from per-shape GLBs. The backend treats `.glb` as the source
+  of truth, loads `cache/*.glmesh` when the embedded source checksum matches,
+  and rebuilds missing or stale cache files from `.glb` through `build-glmesh`.
+  Empty runtime meshes, unsupported primitive modes, bad line/triangle vertex
+  counts, trailing unread bytes, and stale caches are rejected before
+  rebuild/fallback. Replacement runtime mesh equivalence is checked by
+  `validate-replacements` and CTest.
+  Software rendering still uses the original `.3D3` stream. Exported media files
+  are authoritative whenever they overlap JSON.
 
 A practical modernization goal is: export each game format into one of the above
 stable formats plus a machine-readable metadata sidecar (`.json`) before any custom
@@ -129,10 +255,13 @@ executables/overlays rather than as standalone `.txt`, `.fnt`, or `.wav` asset f
 For reliable modding, extend the forward export contract as follows:
 
 1. Text export to `strings.po` + `strings.json`.
-2. Font export to `font_<id>.bdf` + `font_<id>.png` + `font_<id>.json`.
-3. Sound export to `f15dgtl_raw.wav` + `f15dgtl_raw.json`, ASOUND-recovered
-   cue WAVs such as `voice_cue_000_sample0.wav`, plus driver sidecars such as
-   `asound_driver.json` for unresolved synthesis/effect data.
+2. Font export to `font_<id>.bdf` + `font_<id>.png`; optional
+   `font_<id>.json` metadata only with `--include-metadata`.
+3. Sound export to ASOUND-recovered cue WAVs such as
+   `voice_cue_000_sample0.wav`, plus driver sidecars such as
+   `asound_driver.json` for unresolved synthesis/effect data. The full
+   `f15dgtl_raw.wav`/`.json` blob is optional reference output, not the default
+   customizer artifact.
 
 Proposed metadata fields for all three classes:
 
@@ -158,17 +287,17 @@ Translator guidance:
 
 Implement forward export support in this order:
 
-1. `PIC`/`SPR` to indexed PNG + JSON sidecar.
-2. `WLD`, `3DT`, and `3DG` to structured JSON/YAML sidecars.
+1. `PIC`/`SPR` to indexed PNG, with bulky decode JSON only when explicitly requested.
+2. `WLD`, `3DT`, and `3DG` to structured ordered JSON sidecars.
 3. `3D3`/`15FLT.3D3` to glTF export for viewing/editing in modern toolchains.
    Backward conversion/import back to `.3D3` is intentionally unsupported.
 4. Text extraction from executable/overlay data, then export to the formats
    above for localization workflows. Font and sound forward export now have
    initial CLI support.
 
-For editable text, prefer YAML when humans will hand-edit files and JSON when
-tools will generate or validate files. A robust converter can support both, but
-one canonical form should be chosen per format to avoid noisy diffs.
+For editable structured text, use ordered JSON. The converter writes important
+fields first, keeps coordinate-like fields adjacent, and moves large preserved
+base64 fields to the end.
 
 ### Python Converter CLI
 
@@ -181,16 +310,22 @@ model, terrain, world, font, and sound export paths:
 - `.3DG` (`.3dg`)
 - `.WLD` (`.wld`)
 
+The high-level `convert-all` command recurses through the installed game folder
+so campaign/theater subdirectory assets are included.
+
 Usage:
 
 ```text
 python -m tools.f15assets.cli [--pretty] decode <asset> <sidecar.json>
 python -m tools.f15assets.cli [--pretty] decode <input> <output.json> --png <out.png>
-python -m tools.f15assets.cli [--pretty] decode <input> <output.json> --yaml <output.yaml>
 python -m tools.f15assets.cli [--pretty] decode <input.3d3> <output.json> --gltf <out.gltf|out.glb>
-python -m tools.f15assets.cli [--pretty] convert-tree <asset_dir> <out_dir> [--recursive] [--models glb|gltf|none] [--yaml] [--no-png]
+python -m tools.f15assets.cli [--pretty] convert-all <asset_dir> <out_dir> [--include-image-json] [--include-3d3-model-data] [--include-glmesh-cache] [--include-metadata] [--include-raw-blob]
+python -m tools.f15assets.cli [--pretty] convert-tree <asset_dir> <out_dir> [--recursive] [--models glb|gltf|none] [--no-png] [--include-image-json] [--include-3d3-model-data] [--include-glmesh-cache]
 python -m tools.f15assets.cli [--pretty] export-fonts <repo_root> <out_dir> [--no-bdf]
-python -m tools.f15assets.cli [--pretty] export-sounds <asset_dir> <out_dir> [--sample-rate 7850]
+python -m tools.f15assets.cli [--pretty] export-sounds <asset_dir> <out_dir> [--sample-rate 7850] [--include-metadata] [--include-raw-blob]
+python -m tools.f15assets.cli build-binary <asset.json> [--format 3D3|WLD|3DT|3DG]
+python -m tools.f15assets.cli build-glmesh <shape.glb>
+python -m tools.f15assets.cli validate-replacements <asset_dir> <converted_dir> [--repo-root .] [--no-recursive] [--require-all] [--require-generated-cache] [--require-source-proof] [--strict-original-proof] [--allow-custom-glb-differences] [--loadability-only]
 ```
 
 Supported flags:
@@ -198,36 +333,119 @@ Supported flags:
 - `--format`: force a format if the extension is missing or ambiguous.
 - `--png`: extract indexed PNG for PIC/SPR only.
 - `--gltf`: export `*.3D3` to `.gltf` or `.glb` while writing the `3D3` JSON sidecar.
-- `--yaml`: optional YAML sidecar output for table formats (`3DT`, `3DG`, `WLD`) and other parser outputs.
 - `--pretty`: pretty-print JSON output. It is a global option and must appear
   before the subcommand.
 - `convert-tree` command:
   - `--recursive`: recurse input directories.
   - `--models {glb,gltf,none}`: choose 3D model output; defaults to `glb` for self-contained outputs.
   - `--no-png`: skip image exports for PIC/SPR.
-  - `--yaml`: emit YAML sidecars for all supported parsable formats.
+  - `--include-image-json`: also write bulky PIC/SPR decode JSON. Default image
+    conversion writes only PNG because PNG is the runtime source.
+  - `--include-3d3-model-data`: also write bulky `.3D3` `model_data` base64.
+    Default model conversion writes minimized JSON because GLB is the geometry
+    source. Full JSON with `model_data` is required only when `build-binary` or
+    the runtime bridge must rebuild legacy `.3D3` bytes.
+  - `--include-glmesh-cache`: also pre-generate `cache/*.glmesh` runtime caches.
+    Default model conversion writes GLB only and lets the game rebuild caches.
 - `export-fonts` command:
   - Reads `src/fontdata.h` and `src/gfx_impl.c`.
-  - Emits `font_<id>.bdf`, `font_<id>.png`, and `font_<id>.json`.
+  - Emits `font_<id>.bdf` and `font_<id>.png` by default.
+  - `--include-metadata` additionally emits `font_<id>.json` and `fonts.json`.
   - Current known font ids are `0`, `1`, `3`, `4`, and `5`.
   - JSON uses Unicode codepoints while preserving original CP437 source bytes
     (`source_byte`, `source_encoding`) so additional glyphs for other languages
     can be appended without losing the original game mapping.
 - `export-sounds` command:
   - Reads `F15DGTL.BIN` from the installed game directory and emits
-    `f15dgtl_raw.wav` plus `f15dgtl_raw.json`.
-  - Also emits driver-backed cue files (`voice_cue_000_sample0.wav`,
+    driver-backed cue files (`voice_cue_000_sample0.wav`,
     `voice_cue_001_sample4.wav`, `voice_cue_002_sample2_variant0.wav`, ...)
-    with per-cue JSON. ASOUND uses inclusive playback ranges:
+    by default. ASOUND uses inclusive playback ranges:
     `0x0000..0x31F3`, `0x31F4..0x4796`,
     `0x4797..0x5C92`, `0x5C93..0x6A1A`, and `0x6A1B..0x7D9D`.
     The final three ranges are rotating variants for `audio_playSample(2)`.
+  - `--include-metadata` additionally emits per-cue JSON, unresolved driver
+    sidecars, and `sounds.json` for reverse-engineering notes.
+  - `--include-raw-blob` additionally emits `f15dgtl_raw.wav` plus
+    `f15dgtl_raw.json` for reverse-engineering reference.
     `voiceCueThresholds` in `egdata.c` are availability checks before playback,
     not the complete split table.
-  - Preserves sound-driver executables (`ASOUND.EXE`, `ISOUND.EXE`,
-    `NSOUND.EXE`, `RSOUND.EXE`, `TSOUND.EXE`) as unresolved JSON sidecars.
+  - With `--include-metadata`, records sound-driver executables
+    (`ASOUND.EXE`, `ISOUND.EXE`, `NSOUND.EXE`, `RSOUND.EXE`, `TSOUND.EXE`) as
+    unresolved JSON sidecars. Default sound export omits these sidecars.
   - Uses unsigned 8-bit mono PCM at a PIT-derived `7850` Hz by default; override
     with `--sample-rate` if a different recovered driver rate is confirmed.
+- `validate-replacements` command:
+  - Performs explicit old-vs-modern comparison outside runtime loading.
+  - Recurses through the original asset folder by default, matching
+    `convert-all`; use `--no-recursive` for a flat folder check.
+  - `--require-all` requires authoring replacements. Generated
+    `cache/*.glmesh` runtime caches are validated when present and required only
+    with `--require-generated-cache`.
+  - `--require-source-proof` fails validation when GLB/GLMESH source primitive
+    extras are missing or differ from a fresh original export. Without it,
+    metadata loss is a warning because custom Blender exports may strip extras
+    while still providing valid replacement geometry/materials.
+  - `--strict-original-proof` is the converter-regression mode and implies
+    `--require-generated-cache` plus `--require-source-proof`.
+  - `--allow-custom-glb-differences` warns instead of failing when per-shape GLB
+    primitive counts or source proof metadata differ from the original `.3D3`
+    export. It is for customized model packs, not converter regression proof.
+  - `--loadability-only` validates that modern replacements parse and have the
+    required basic structure, but skips old-vs-new equality checks. Use it for
+    edited/custom replacement packs. It is incompatible with
+    `--strict-original-proof`, `--require-source-proof`, and
+    `--allow-custom-glb-differences`. If the original input directory is
+    intentionally absent, `--loadability-only` runs source-free checks directly
+    over the converted output tree; the output argument may be either the
+    `converted_assets_all` folder or a parent folder containing it.
+    `--require-all` is rejected in that case because there is no original asset
+    inventory to require against. If no replacement files are found, the
+    validator prints a warning listing the expected replacement kinds (`PNG`,
+    `WAV`, `BDF`, `WLD/3DT/3DG JSON`, `3D3 JSON`, `GLB`, or `GLMESH`) so a wrong output path is visible. JSON table
+    replacements are still rebuilt and must produce a non-empty legacy byte
+    stream; WAV cue replacements must parse, contain at least one sample, and
+    carry a valid RIFF sample rate; BDF glyphs must have bitmap rows and
+    positive advance widths for all 96 runtime glyphs from U+0020 through
+    U+007F, unless the matching PNG atlas fallback is loadable in
+    `--loadability-only`; source-free PNG font atlases are checked for the
+    current runtime font ids whose cell dimensions are known; indexed PNGs must include an embedded palette, and
+    truecolor PNGs are accepted in loadability-only mode like the runtime
+    loader; per-shape GLBs and generated GLMESH caches must contain renderable
+    geometry or line/point primitives. Source-free minimized `.3D3.json` files
+    are checked for parseable slot metadata, monotonic offsets, and valid
+    `model_data_size`; exact slot-table equivalence still requires original
+    `.3D3` bytes.
+    With `--require-all`, fonts require at least one runtime source per known
+    font: BDF first, or PNG atlas fallback.
+    Extra source-free `sounds/voice_cue_*.wav` files are parsed in loadability
+    mode, but the current runtime playback path uses only the recovered known
+    cue filenames emitted by `export-sounds`.
+    Combined overview GLBs and converter-only proof metadata are ignored in this
+    mode because per-shape GLB geometry is the runtime-editable source of truth.
+  - Currently compares `PIC`/`SPR` legacy decode pixels with indexed PNG
+    replacement pixels byte-for-byte, plus embedded/external PNG palette data
+    when the source palette is known. Byte-for-byte image comparison requires
+    indexed PNG; use `--loadability-only` for edited truecolor PNG replacements.
+  - Also compares `F15DGTL.BIN` ASOUND cue ranges with
+    `sounds/voice_cue_*.wav` sample bytes and compares cue WAV sample rates
+    against the recovered/export default.
+  - Also compares in-repo original font tables with `fonts/font_<id>.bdf`
+    glyph bitmaps/advance widths and `fonts/font_<id>.png` atlas glyph pixels.
+  - Also rebuilds `WLD`, `3DT`, and `3DG` bytes from JSON and compares them with
+    the original files.
+  - Also validates minimized `.3D3.json` slot metadata: shape offset table,
+    `model_data_size`, monotonic offsets, and absence of unnecessary bulky
+    `model_data` in default exports. This proves the compact metadata needed by
+    a future GLB-only/free-asset loader without duplicating geometry bytecode.
+    If bulky `model_data` is present, validation also rebuilds the `.3D3` byte
+    stream and compares it with the original file.
+  - Also validates `.3D3` GLB structure: combined GLB metadata, renderable shape
+    count, per-shape GLB presence, minimized per-shape marker, and stable
+    `source_shape_index` metadata. Present `.glmesh` runtime caches are compared
+    against the source GLB expansion, including triangle/line/point primitive
+    counts.
+  - Future validators should add full GLB rendered-equivalence checks after the
+    OpenGL import path is validated against representative scenes.
 
 Current objective is forward conversion from game assets to modern editable
 formats only. Rebuild/import pathways are intentionally unsupported to keep the
@@ -237,10 +455,12 @@ A required modern compatibility baseline is therefore:
 
 - `.glb` (fallback `.gltf`) for 3D geometry (Blender-first workflows), and it should remain self-contained.
 - Indexed `.png` for image assets.
-- JSON or YAML text for structural tables and world data, with strict,
+- Ordered JSON text for structural tables and world data, with strict,
   versioned sidecar metadata.
 
-PIC/SPR sidecars are lossless for decoded pixel payloads at export time.
+PIC/SPR decode sidecars are optional and lossless for decoded pixel payloads at
+export time. They are useful for reverse engineering, but not needed for normal
+runtime replacement because PNG is authoritative.
 
 - `format`: format tag (`PIC`)
 - `decoded_width`/`decoded_height`: currently expected to be `320`/`200`
@@ -270,9 +490,11 @@ Current text/font/sound extraction state:
 - `PIC`/`SPR`/`3D3`/`3DT`/`3DG`/`WLD` decoding is the current converter focus.
 - Font extraction is implemented from the current recovered font tables and
   metrics.
-- Sound extraction is partial: `F15DGTL.BIN` is exported as a raw WAV plus
-  ASOUND-recovered cue WAVs. Digitized cue ranges are known; synthesized effect
-  driver tables remain unresolved sidecars.
+- Sound extraction is partial: `F15DGTL.BIN` is exported as ASOUND-recovered
+  cue WAVs by default. Cue JSON, driver sidecars, and the full raw WAV blob are
+  optional reverse-engineering output; they are not needed for customization or
+  runtime replacement. Digitized cue ranges are known; synthesized effect driver
+  tables remain unresolved sidecars when metadata export is requested.
 - Text extraction remains a roadmap item and should emit `status: unresolved`
   entries until parsers are implemented.
 
@@ -284,7 +506,7 @@ Reasons:
 
 - Blender scripting is Python, so `.3D3` to Blender import/export can share code
   with the command-line converter.
-- PNG, indexed palettes, YAML, JSON, CSV, and binary struct handling are all
+- PNG, indexed palettes, JSON, CSV, and binary struct handling are all
   well-supported.
 - Reverse-engineering work benefits from quick scripts, readable parsers, and
   fast iteration more than from maximum runtime speed.
@@ -301,15 +523,45 @@ tools/f15assets/
     f15assets/
         pic.py          # PIC/SPR LZW/RLE decode
         fonts.py        # extracted font tables to BDF/PNG/JSON
-        sounds.py       # F15DGTL.BIN WAV/cue export and driver sidecars
+        sounds.py       # F15DGTL.BIN cue WAV export and optional driver sidecars
         model3d.py      # .3D3 container and display-list parser
         terrain.py      # .3DT and .3DG
         world.py        # .WLD
         io.py           # binary/base64 helpers
+        validation_compare.py            # stable facade for validation diff helpers
+        validation_compare_core.py       # shared byte/count/sequence comparisons
+        validation_compare_image.py      # PIC/SPR PNG pixel and palette comparisons
+        validation_compare_font.py       # BDF/PNG font comparisons
+        validation_compare_sound.py      # cue WAV comparisons
+        validation_compare_model3d.py    # GLB/GLMESH primitive comparisons
+        validation_compare_structured.py # WLD/3DT/3DG rebuild comparisons
+        validation_image.py              # PIC/SPR PNG replacement validator
+        validation_font.py               # BDF/PNG font replacement validator
+        validation_sound.py              # cue WAV replacement validator
+        validation_structured.py         # WLD/3DT/3DG JSON replacement validator
+        validation_model3d.py            # .3D3 JSON/GLB/GLMESH replacement validator
     tests/
         test_smoke.py
         test_full_assets.py
 ```
+
+Replacement comparison helpers live under `src/shared/asset_compare*.c` for
+test/developer tooling. Loaders should focus on finding and loading modern
+assets during gameplay; CTest/Python validation owns old-vs-modern equivalence
+proof. Byte-stream checks live in `asset_compare_bytes.c`, indexed image/palette
+checks in `asset_compare_image.c`, bitmap font checks in `asset_compare_font.c`,
+digitized cue checks in `asset_compare_sound.c`, and renderer-independent 3D
+topology/color/source-metadata reporting in `asset_compare_3d.c`. Tool-side
+validation diff helpers live in `tools/f15assets/f15assets/validation_compare.py`;
+that file is a stable facade over per-format `validation_compare_*` modules.
+Per-format replacement validators live in `validation_image.py`,
+`validation_font.py`, `validation_sound.py`, `validation_structured.py`, and
+`validation_model3d.py`; each exposes a `validate_*` entry point, loads/parses
+assets, and delegates reusable diff reporting to `validation_compare.py`.
+`cli.py` should pass repository/output path policy into those validators rather
+than owning format-specific comparison logic. Renderer-specific or
+parser-specific comparisons can remain near their loaders until their
+dependencies are cleanly separable.
 
 Do not start with a mixed-language converter. Add Rust or C++ later only if a
 specific hot path or library boundary needs it. If that happens, keep the file
@@ -643,7 +895,7 @@ mission/runtime fields. A future `.WLD` round-trip converter should preserve the
 original load order above, including the named binary tables.
 
 For editor-facing exports, keep `name_table` bytes as parsed and include any
-suffix bytes beyond the game payload as `trailing_bytes` in the JSON/YAML
+suffix bytes beyond the game payload as `trailing_bytes` in the JSON
 representation so variant or unknown tails are not discarded.
 
 ## Manual and Map Facts Useful for RE

--- a/tools/f15assets/CUSTOMIZATION.md
+++ b/tools/f15assets/CUSTOMIZATION.md
@@ -1,0 +1,387 @@
+# F-15 Asset Customization Guide
+
+This guide describes the practical edit workflow for converted assets. The
+rule is simple: edit the modern media file whenever it can represent the data,
+and touch JSON only for tables, ids, placement, or metadata that the media file
+cannot store.
+
+Converted metadata should be portable. Sidecars should use original asset names
+or paths relative to the converted folder, not absolute developer-machine paths.
+
+## 1. Convert the original game folder
+
+Run from the repository root:
+
+```bash
+python3 -m tools.f15assets.cli convert-all /path/to/F15_GAME converted_assets_all
+```
+
+Use your installed DOS game folder for `/path/to/F15_GAME`. The output folder is
+the folder the game replacement loader and editor tools should use.
+`convert-all` recurses through the game folder so campaign/theater subdirectory
+assets are converted too.
+Default output is minimized for customization. Use `--include-image-json`,
+`--include-3d3-model-data`, `--include-metadata`, or `--include-raw-blob` only
+when you need reverse-engineering diagnostics.
+
+To run the game with replacements stored outside the original game folder, set:
+
+```bash
+F15_REPLACEMENT_ROOT=/path/to/converted_assets_all
+```
+
+The runtime then searches that folder for PNG, JSON, BDF, WAV, GLB, and GLMESH
+replacements before falling back to the usual converted/output locations. If
+you point `F15_REPLACEMENT_ROOT` at the parent folder instead, a
+`converted_assets_all` child is also searched. A missing replacement root is
+reported once, ignored, and the usual fallback locations are still searched.
+If the game is launched from a directory where the repository `tools` folder is
+not discoverable, also set:
+
+```bash
+F15_ASSET_TOOL="python3 /path/to/f15se2-ex/tools/f15assets/cli.py"
+```
+
+That bridge command is used only when the runtime must rebuild JSON tables or
+generated GLMESH caches from editable modern files.
+
+## 2. Check replacement equivalence before editing
+
+Run this once after conversion if you want proof that the unmodified converted
+files still load like the original assets:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --allow-custom-glb-differences
+```
+
+For strict converter regression proof before editing, use:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --require-all --strict-original-proof
+```
+
+After editing PNG, WAV, font, JSON, or GLB assets, use loadability validation:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --loadability-only
+```
+For a source-free custom pack without the original game folder, the first path
+may be a missing placeholder when `--loadability-only` is used. In that mode the
+validator checks modern files directly from `converted_assets_all` and skips
+original-equivalence proof. The output path may be either the `converted_assets_all`
+folder itself or a parent folder containing it; the validator prints the
+normalized directory when it descends to the child folder. Do not combine
+source-free validation with `--require-all`; completeness checks need the
+original asset inventory. If no replacement files are found, the validator
+prints a warning so a wrong output path is visible.
+Do not combine `--loadability-only` with `--strict-original-proof` or
+`--require-source-proof`; those flags are for unmodified converter proof.
+`--loadability-only` already permits custom GLB content differences, so do not
+combine it with `--allow-custom-glb-differences`.
+
+The validator compares original loader output with converted PNG, WAV, BDF/PNG,
+JSON, GLB, and GLMESH replacement data where implemented.
+For sound-only custom packs without `F15DGTL.BIN`, validation still parses and
+checks the separate cue WAVs; it cannot prove byte-equivalence to the original
+blob because there is no original blob to compare.
+For source-free world/table packs, `--loadability-only` also rebuilds
+`*.WLD.json`, `*.3DT.json`, and `*.3DG.json` files found under the converted
+output folder even when the original binary tables are absent.
+For source-free image packs, `--loadability-only` also checks extra PNG files
+under the converted output folder for runtime-loadable dimensions and embedded
+palette requirements for indexed PNGs. Original-equivalence still requires the
+matching original `PIC`/`SPR` file.
+For source-free 3D packs, `--loadability-only` also checks extra `.glb` and
+`.glmesh` files under the converted output folder for parseability and non-empty
+renderable primitives. Exact primitive/order/color proof still requires the
+matching original `.3D3` file.
+It also sanity-checks source-free minimized `.3D3.json` index files for
+parseable slot metadata, monotonic offsets, and valid `model_data_size`.
+For source-free font packs, `--loadability-only` also parses extra
+`fonts/font_*.bdf` files and checks that glyph rows and advance widths are
+usable for all 96 runtime glyphs from U+0020 through U+007F. It also checks
+`fonts/font_*.png` atlases for the current runtime font ids whose cell
+dimensions are known. Built-in font equivalence still requires the in-repo
+captured font tables.
+
+Use equivalence checks before editing. After intentional customization,
+differences from the original asset are expected for the edited file, so
+loadability validation is the useful check for customized packs.
+The normal command treats generated `cache/*.glmesh` and GLB source proof extras
+as optional diagnostics. `--allow-custom-glb-differences` also treats intentional
+per-shape GLB geometry changes as warnings. `--strict-original-proof` requires
+generated caches and source proof metadata.
+
+Comparison is intentionally not done while playing. Use
+`validate-replacements` or CTest before editing when you need old-vs-modern
+proof; use `--loadability-only` after intentional customization.
+
+## 3. 3D models: edit GLB in Blender
+
+Authoritative file:
+
+```text
+converted_assets_all/<group>/shape_###_<name>.glb
+```
+
+Examples:
+
+```text
+converted_assets_all/15FLT/shape_010.glb
+converted_assets_all/VN/shape_049_SAM_Radar.glb
+converted_assets_all/PHOTO/shape_000.glb
+```
+
+Normal Blender workflow:
+
+1. Import the per-shape `.glb` into Blender.
+2. Edit geometry, line objects, point objects, and materials.
+3. Export back to the same `.glb` path.
+4. Keep the `shape_###` number in the filename unchanged.
+5. Start the game with the OpenGL backend; it rebuilds `cache/*.glmesh`
+   automatically if the cache is missing or stale.
+
+The filename label after `shape_###` is only for humans. Runtime lookup is
+case-tolerant and uses the stable slot number prefix.
+
+Current limitation: GLB model replacement is implemented in the OpenGL backend.
+The software 3D backend still renders the original `.3D3` stream, and the
+current loader still reads original `.3D3` bytes for shape-slot tables, PHOTO
+append ranges, comparison, and fallback. The minimized `.3D3.json` index now
+validates those slot fields, but the game does not yet use it as the runtime
+source for GLB-only/free-asset packs.
+
+Do not edit these for normal model customization:
+
+```text
+converted_assets_all/<group>/<group>.3D3.json
+converted_assets_all/<group>/cache/*.glmesh
+```
+
+`.3D3.json` is a lightweight index/manifest. It preserves shape slots and source
+container metadata, but GLB geometry and GLB primitive extras override it. Bulk
+conversion omits bulky `.3D3` `model_data` base64 by default; validation still
+compares the minimized shape offset table and `model_data_size` against the
+original `.3D3`. Request bulky `model_data` only with
+`convert-tree --include-3d3-model-data` for reverse-engineering dumps or for
+the legacy-byte-stream bridge. Those full dumps duplicate original model data
+and are not the normal customization surface.
+`cache/*.glmesh` is generated runtime data derived from GLB and can be deleted.
+Default conversion does not pre-generate it; use `--include-glmesh-cache` only
+when you want caches ahead of first runtime load. The runtime and validator
+parse these caches strictly, so malformed or stale caches are rejected instead
+of being treated as an alternate editable model source.
+
+Keep these constraints:
+
+- Preserve the shape slot number. World objects reference shape ids.
+- `PHOTO/shape_###.glb` files replace target-view photo models. The legacy
+  loader appends those models to the theater shape table, but the OpenGL
+  replacement lookup maps the appended slots back to `PHOTO/shape_###`.
+- Preserve line-only details such as antennas, masts, deck lines, runway lines, and ship rails unless you intentionally remove them.
+- Preserve coplanar faces and draw-sensitive overlaps when visual fidelity matters. The converter stores source primitive metadata so validation can detect dropped or reordered primitives.
+- Use per-shape GLBs for editing. The combined `<group>.3D3.glb` is mainly for overview and inspection.
+- GLB `extras` are diagnostic metadata, not the drawing source. If Blender or
+	  another editor strips primitive extras, the model can still render from GLB
+	  geometry/materials, but strict `validate-replacements` has less proof that
+	  source order/raw colors still match the original.
+
+When JSON is needed:
+
+- Rename or document shape slots in metadata.
+- Inspect source offsets or original shape order.
+- Debug conversion issues.
+
+When JSON is not needed:
+
+- Changing mesh vertices.
+- Changing face colors/materials.
+- Adding/removing Blender geometry inside the same shape file.
+- Re-exporting the same shape from Blender.
+
+## 4. World and mission data: edit WLD JSON
+
+Authoritative file:
+
+```text
+converted_assets_all/<world>/<world>.WLD.json
+```
+
+Use the map editor for placement edits:
+
+```text
+tools/f15assets/map_editor.html
+```
+
+World JSON is the source of truth for:
+
+- object coordinates;
+- object shape ids;
+- target flags;
+- takeoff/landing/base-like records;
+- flight-unit templates;
+- terrain and mission classification tables;
+- name strings.
+
+GLB files do not store world placement. If you move a SAM site, runway, carrier,
+or target on the theater map, edit the WLD JSON through the editor.
+
+Runtime note: the current loader rebuilds a legacy `.WLD` byte stream from this
+JSON and feeds it to the existing game loader. JSON is still the editable source
+because world data is structured table data, not a media file.
+
+## 5. Terrain tables: edit 3DT and 3DG JSON carefully
+
+Authoritative files:
+
+```text
+converted_assets_all/<group>/<file>.3DT.json
+converted_assets_all/<group>/<file>.3DG.json
+```
+
+Use these for terrain/tile placement and lookup data. These formats are numeric
+tables, not artwork. Keep record order stable unless you understand the runtime
+lookup path.
+
+Runtime note: as with WLD, the current loader rebuilds legacy bytes from JSON
+before calling the existing table loaders.
+
+## 6. Pictures and sprites: edit indexed PNG
+
+Authoritative files:
+
+```text
+converted_assets_all/<asset>.png
+```
+
+PNG is authoritative for:
+
+- pixels;
+- dimensions;
+- embedded palette.
+
+PIC/SPR JSON is only decode/index metadata and is not emitted by default by
+`convert-tree`/`convert-all`. For normal art changes, edit the PNG and keep it
+indexed/paletted when possible. Truecolor PNG can be accepted by the runtime as
+an editing convenience, but indexed PNG with an embedded palette is the safest
+self-contained replacement.
+
+Use `ctest -R asset_replacement_full_validation` or
+`python3 -m tools.f15assets.cli validate-replacements` to compare indexed PNG
+replacements against the original PIC/SPR pixel indices and active legacy DAC
+palette. This proof is intentionally a test-time check, not a runtime game mode.
+
+`TITLE640.PIC` is exported as a 640x350 PNG. It is also loaded as PNG at runtime
+when present, using the hi-res title surface rather than the normal 320x200 page
+surface.
+
+## 7. Fonts: edit TTF/OTF or BDF
+
+Authoritative files:
+
+```text
+converted_assets_all/fonts/font_<id>.ttf
+converted_assets_all/fonts/font_<id>.otf
+converted_assets_all/fonts/font_<id>.bdf
+```
+
+Preferred workflow:
+
+1. Use `font_<id>.ttf` or `font_<id>.otf` for normal scalable-font replacement.
+2. Use `font_<id>.bdf` only when you need hand-edited pixel glyphs and metrics.
+3. Ignore JSON for normal customization; `font_<id>.json` is optional metadata
+   emitted only with `--include-metadata`.
+
+TTF/OTF is preferred for Unicode/localization because customizers can use normal
+font editors and do not need sidecar files. Runtime loads TTF/OTF first when the
+build has FreeType, then BDF, then legacy `font_<id>.png` atlases. Leave
+`font_0.*` absent to keep the original tiny HUD font. JSON cannot override font
+glyph data.
+
+## 8. Sounds: edit separate WAV cues
+
+Authoritative files:
+
+```text
+converted_assets_all/sounds/voice_cue_*.wav
+```
+
+`sounds/f15dgtl_raw.wav` is not exported by default. It is only a full-blob
+reference export when `export-sounds --include-raw-blob` is used. Customizers
+do not need it. The current runtime replacement path uses the separate
+`voice_cue_*.wav` files for playback.
+
+WAV files are authoritative for:
+
+- sample bytes;
+- sample rate;
+- channel count;
+- bit depth.
+
+Use mono unsigned 8-bit PCM for maximum compatibility with the current loader.
+The current runtime cue loader accepts mono unsigned 8-bit PCM cue WAVs and uses
+their sample bytes and RIFF sample rate as replacements for the matching ASOUND
+cue ranges. The default exported sample rate is `7850` Hz; changing a cue WAV's
+sample rate intentionally changes playback speed. JSON keeps cue ranges and
+driver metadata; do not edit JSON for normal sample replacement. Cue JSON,
+driver sidecars, and `sounds.json` are not exported by default; use
+`export-sounds --include-metadata` only when you need reverse-engineering notes.
+Rerunning the exporter without metadata/raw flags removes stale optional sound
+sidecars, leaving the cue WAVs as the normal customization files.
+`--loadability-only` also parses extra `sounds/voice_cue_*.wav` files in a
+source-free pack, but the current runtime playback path uses only the recovered
+known cue filenames exported by `export-sounds`.
+
+## 9. What the game loads first
+
+When a modern replacement exists, the runtime should prefer it:
+
+| Asset class | Preferred replacement |
+| --- | --- |
+| 3D shape | per-shape `.glb`; `cache/*.glmesh` is generated from it |
+| PIC/SPR image | `.png` |
+| WLD/3DT/3DG table | `.json` rebuilt through `build-binary` |
+| Font | `.bdf` for glyphs and metrics; `.png` atlas fallback for glyph pixels only |
+| Digitized sound cue | separate `.wav` |
+
+If a replacement is missing or invalid, the loader should fall back to the
+original game asset.
+
+## 10. Files you can usually ignore
+
+```text
+cache/*.glmesh
+default *.3D3.json for geometry-only edits; full model_data dumps only for bridge/reverse-engineering work
+*.PIC.json / *.SPR.json for pixel-only edits; request them only with --include-image-json for decoder diagnostics
+fonts/font_<id>.json for normal glyph edits; request it only with --include-metadata for glyph/index diagnostics
+optional sounds/sounds.json for sample-only edits
+```
+
+These files are useful for validation, indexing, or loader bridges, but they are
+not the normal authoring surface when the modern media file already represents
+the data.
+
+## 11. Future free custom asset packs
+
+The long-term target is a replacement pack that can contain only freely licensed
+custom assets, for example Creative Commons models, images, fonts, and sounds.
+That is a packaging goal, not the current guarantee.
+
+Current state:
+
+- Original game assets are still required as fallback data.
+- Default minimized `.3D3.json` plus per-shape GLB still need an original
+  `.3D3` byte stream for shape-slot tables and software renderer fallback. A
+  full `.3D3.json` bridge dump can replace those bytes, but it duplicates
+  original model data and is not the desired free/minimized asset path.
+- Some replacement paths still bridge through original-compatible binary layouts.
+- Runtime comparison uses original assets as the reference for equivalence.
+
+Future pack requirements:
+
+- Every loaded asset class must have a modern replacement loader.
+- Missing original assets must not be needed for supported replacement packs.
+- The pack should include license metadata for every media file.
+- Sidecars should stay portable and should not contain local absolute paths.
+- Generated caches such as `cache/*.glmesh` should be reproducible from the
+  editable source files and should not be the legal/source artifact.

--- a/tools/f15assets/CUSTOMIZATION.md
+++ b/tools/f15assets/CUSTOMIZATION.md
@@ -153,6 +153,16 @@ Normal Blender workflow:
 The filename label after `shape_###` is only for humans. Runtime lookup is
 case-tolerant and uses the stable slot number prefix.
 
+The importer bakes the selected static GLB scene's node translations, rotations,
+scales, and matrices into the model geometry. Multiple nodes using one mesh remain
+separate instances; meshes outside that scene are ignored. Export a static mesh
+for animated, skinned, or morph-target models: those features are rejected rather
+than silently dropped.
+
+After upgrading the converter, delete the affected group's generated `cache/`
+directory once. Cache freshness currently tracks the GLB file, not the converter
+version, so an unchanged GLB otherwise retains a cache produced by an older tool.
+
 Current limitation: GLB model replacement is implemented in the OpenGL backend.
 The software 3D backend still renders the original `.3D3` stream, and the
 current loader still reads original `.3D3` bytes for shape-slot tables, PHOTO

--- a/tools/f15assets/CUSTOMIZATION.md
+++ b/tools/f15assets/CUSTOMIZATION.md
@@ -158,6 +158,10 @@ scales, and matrices into the model geometry. Multiple nodes using one mesh rema
 separate instances; meshes outside that scene are ignored. Export a static mesh
 for animated, skinned, or morph-target models: those features are rejected rather
 than silently dropped.
+Use flat material colors and independent triangles, lines, or points. Vertex
+colors, base-color textures, and other primitive modes are rejected by the
+current importer; they previously could produce incomplete or incorrectly
+colored models without a diagnostic.
 
 After upgrading the converter, delete the affected group's generated `cache/`
 directory once. Cache freshness currently tracks the GLB file, not the converter

--- a/tools/f15assets/CUSTOMIZATION.md
+++ b/tools/f15assets/CUSTOMIZATION.md
@@ -8,6 +8,11 @@ cannot store.
 Converted metadata should be portable. Sidecars should use original asset names
 or paths relative to the converted folder, not absolute developer-machine paths.
 
+The converter and editors are independent of the runtime replacement loaders.
+The runtime workflows below require a game build containing the corresponding
+replacement loader; installing these Python tools alone does not add replacement
+support to the game.
+
 ## 1. Convert the original game folder
 
 Run from the repository root:
@@ -47,8 +52,8 @@ generated GLMESH caches from editable modern files.
 
 ## 2. Check replacement equivalence before editing
 
-Run this once after conversion if you want proof that the unmodified converted
-files still load like the original assets:
+Run this after conversion to compare unmodified converted files with the Python
+decoders' interpretation of the original assets:
 
 ```bash
 python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --allow-custom-glb-differences
@@ -79,8 +84,12 @@ Do not combine `--loadability-only` with `--strict-original-proof` or
 `--loadability-only` already permits custom GLB content differences, so do not
 combine it with `--allow-custom-glb-differences`.
 
-The validator compares original loader output with converted PNG, WAV, BDF/PNG,
-JSON, GLB, and GLMESH replacement data where implemented.
+This command uses Python decoders and builders to compare PNG, WAV, BDF/PNG,
+JSON, GLB, and GLMESH replacement data where implemented. It does not execute
+the game's C/C++ loaders. Runtime-loader equivalence requires the separate
+CTest asset-comparison tests in the relevant runtime-loader build, configured
+with the original and converted asset folders. Neither check establishes
+visual equivalence for every renderer or proves that an edited pack is complete.
 For sound-only custom packs without `F15DGTL.BIN`, validation still parses and
 checks the separate cue WAVs; it cannot prove byte-equivalence to the original
 blob because there is no original blob to compare.
@@ -341,7 +350,7 @@ When a modern replacement exists, the runtime should prefer it:
 | 3D shape | per-shape `.glb`; `cache/*.glmesh` is generated from it |
 | PIC/SPR image | `.png` |
 | WLD/3DT/3DG table | `.json` rebuilt through `build-binary` |
-| Font | `.bdf` for glyphs and metrics; `.png` atlas fallback for glyph pixels only |
+| Font | `.ttf`/`.otf` with FreeType support; then `.bdf`; then `.png` atlas |
 | Digitized sound cue | separate `.wav` |
 
 If a replacement is missing or invalid, the loader should fall back to the
@@ -375,7 +384,8 @@ Current state:
   full `.3D3.json` bridge dump can replace those bytes, but it duplicates
   original model data and is not the desired free/minimized asset path.
 - Some replacement paths still bridge through original-compatible binary layouts.
-- Runtime comparison uses original assets as the reference for equivalence.
+- Test-time runtime-loader comparison uses original assets as its reference;
+  no equivalence comparison is performed while playing.
 
 Future pack requirements:
 

--- a/tools/f15assets/README.md
+++ b/tools/f15assets/README.md
@@ -4,7 +4,26 @@ Developer and customizer tools for converting original F-15 Strike Eagle II asse
 The overlapping MicroProse formats used by F-117A are partially supported too,
 including external `.PAL` palettes for `PIC` images.
 
+For a step-by-step editing workflow, see `CUSTOMIZATION.md` in this directory.
+
 These tools are forward-conversion first. They are meant to make original game assets inspectable, editable, and eventually loadable by a modernized game runtime when replacement assets are present. They do not currently promise full backward conversion into original binary formats.
+
+Longer-term packaging goal: the replacement pipeline should make it possible to
+run the game with freely licensed custom media assets only, for example CC-licensed
+models, pictures, fonts, and sounds. That is not the current runtime contract:
+today the original assets are still the authoritative fallback and are still
+needed for unsupported or incomplete replacement paths.
+
+When both a modern media file and JSON mention the same property, the media file
+wins. JSON is supplemental index/metadata only. For example, PNG dimensions and
+palette override JSON image metadata, GLB geometry/extras override `.3D3.json`,
+WAV headers/data override sound JSON, and BDF/PNG font data overrides font JSON.
+
+Validation invariant: loading an unmodified converted asset should produce the
+same in-memory game data as loading the original asset. For formats that pass
+through float/modern encodings, the result should be numerically equivalent
+within documented conversion tolerance. This comparison belongs in importer
+validation/tests or explicit diagnostics, not in normal runtime loading.
 
 ## Source and output layout
 
@@ -21,6 +40,17 @@ converted_assets_all
 ```
 
 Run commands from the repository root that contains this `tools` directory.
+At runtime, the game searches `converted_assets_all` below the game asset path
+and current directory. Set `F15_REPLACEMENT_ROOT=/path/to/converted_assets_all`
+to point the loader at an explicit converted/custom asset directory without
+copying files beside the original game assets. If `F15_REPLACEMENT_ROOT` points
+at a parent folder that contains `converted_assets_all`, that child folder is
+also searched. If it points to a missing directory, the loader ignores it and
+continues with the normal fallback locations after logging one warning. If the
+game is launched from a
+directory where `tools/f15assets/cli.py` is not discoverable, also set
+`F15_ASSET_TOOL="python3 /path/to/f15se2-ex/tools/f15assets/cli.py"` so JSON and
+GLB bridge loaders can rebuild legacy byte streams and GLMESH caches.
 
 ## Commands
 
@@ -35,10 +65,17 @@ python3 -m tools.f15assets.cli convert-all /home/xor/games/f15 converted_assets_
 This produces:
 
 - `*.png` for all supported `PIC`/`SPR` image assets.
-- `*.json` sidecars for decoded assets.
-- `*.3D3.glb` model files for Blender and other glTF tools.
-- `fonts/font_<id>.bdf`, `fonts/font_<id>.png`, and `fonts/font_<id>.json`.
-- `sounds/f15dgtl_raw.wav`, driver-backed `sounds/voice_cue_*.wav`, and sound metadata JSON.
+- `*.json` sidecars for structured/table/model metadata. Bulky PIC/SPR decode
+  JSON and font metadata JSON are skipped by default because PNG/BDF are the
+  runtime media sources.
+- extensionless asset directories for world/model groups, for example `VN/`,
+  `LIBYA/`, `15FLT/`, or `WORLD/`.
+- combined `.3D3.glb` and per-shape `shape_###*.glb` for supported 3D assets.
+  Generated `cache/shape_###*.glmesh` runtime caches are optional and can be
+  rebuilt by the game from GLB.
+- `fonts/font_<id>.bdf`.
+- driver-backed `sounds/voice_cue_*.wav` files. Sound metadata JSON and the
+  full digitized sound blob are not exported by default.
 
 Use a different source path if your original DOS game files are not in
 `/home/xor/games/f15`.
@@ -52,19 +89,27 @@ python3 -m tools.f15assets.cli convert-tree /home/xor/games/F117A/F117.CD conver
 Optional flags:
 
 - Add global `--pretty` before `convert-all` for pretty-printed JSON.
-- Use `convert-tree` directly if you need YAML sidecars, recursive input, or non-default model output.
+- `convert-all` recurses through the game asset folder. Its default output is
+  minimized; add `--include-image-json`, `--include-3d3-model-data`,
+  `--include-glmesh-cache`, `--include-metadata`, or `--include-raw-blob` only
+  for reverse-engineering diagnostics or prebuilt runtime caches.
+  `--include-metadata` adds optional font JSON and sound metadata.
+- Use `convert-tree` directly if you need non-default model output.
 - Use `export-sounds` directly if you need a non-default sample rate.
 
 Convert a whole asset tree:
 
 ```bash
-python3 -m tools.f15assets.cli convert-tree /home/xor/games/f15 converted_assets_all --yaml
+python3 -m tools.f15assets.cli convert-tree /home/xor/games/f15 converted_assets_all
 ```
+
+Use `convert-tree --include-image-json` only when you need lossless PIC/SPR
+decoder diagnostics such as compressed payloads and decoded pixel base64.
 
 Decode one asset:
 
 ```bash
-python3 -m tools.f15assets.cli decode /home/xor/games/f15/VN.WLD converted_assets_all/VN.WLD.json --format WLD --yaml converted_assets_all/VN.WLD.yaml
+python3 -m tools.f15assets.cli decode /home/xor/games/f15/VN.WLD converted_assets_all/VN/VN.WLD.json --format WLD
 ```
 
 Export fonts:
@@ -73,39 +118,231 @@ Export fonts:
 python3 -m tools.f15assets.cli export-fonts . converted_assets_all/fonts
 ```
 
-Export digitized sounds and driver sidecars:
+Add `--include-metadata` only when you need optional `font_<id>.json` sidecars
+and `fonts.json`; runtime loading uses TTF/OTF first, then BDF, then PNG.
+
+Use TrueType/OpenType fonts directly by placing `font_<id>.ttf` or
+`font_<id>.otf` in `converted_assets_all/fonts`. To replace all non-small fonts
+with a single face, copy it as `font_1.ttf`, `font_3.ttf`, `font_4.ttf`, and
+`font_5.ttf`; leave `font_0.*` absent to keep the tiny HUD font.
+
+Export digitized cue WAVs:
 
 ```bash
 python3 -m tools.f15assets.cli --pretty export-sounds /home/xor/games/f15 converted_assets_all/sounds --sample-rate 7850
 ```
 
+Add `--include-raw-blob` only when you also want the full `f15dgtl_raw.wav`
+reference export for reverse engineering. Runtime replacement uses the separate
+`voice_cue_*.wav` files.
+
+Add `--include-metadata` only when you also want per-cue JSON, unresolved
+driver sidecars, and `sounds.json` for reverse-engineering notes.
+Rerunning without these flags removes stale optional sound metadata/reference
+files from the output folder, so the default sound folder contains only the cue
+WAV authoring files.
+
+Validate modern replacements against original loader output outside normal runtime:
+
+```bash
+python3 -m tools.f15assets.cli validate-replacements /home/xor/games/f15 converted_assets_all
+```
+
+Rebuild full structured JSON to the original runtime binary byte stream:
+
+```bash
+python3 -m tools.f15assets.cli build-binary converted_assets_all/VN/VN.WLD.json --format WLD > /tmp/VN.WLD
+```
+
+Full `.3D3.json` files with `model_data` can also be rebuilt for the old loader
+bridge. Default minimized `.3D3.json` omits `model_data`, so it is validation
+and index metadata only.
+
+Expand a per-shape GLB to the simple runtime mesh stream used by the OpenGL backend:
+
+```bash
+python3 -m tools.f15assets.cli build-glmesh converted_assets_all/VN/shape_049_SAM_Radar.glb > converted_assets_all/VN/cache/shape_049_SAM_Radar.glmesh
+```
+
+`*.glmesh` files are strict generated caches, not hand-editing sources. The
+runtime and validator reject unsupported primitive modes, bad line/triangle
+vertex counts, stale source checksums, empty meshes, and trailing unread bytes.
+Delete a cache after editing the matching `.glb`; the game can rebuild it.
+
+The validator currently compares original `PIC`/`SPR` decode output with indexed
+PNG replacements byte-for-byte at the palette-index level, compares embedded or
+externally attached image palettes when the source palette is known, compares
+`F15DGTL.BIN` cue ranges with `sounds/voice_cue_*.wav` sample bytes, compares
+cue WAV sample rates against the recovered/export default, compares in-repo font
+tables with `fonts/font_<id>.bdf` and `fonts/font_<id>.png`, rebuilds `WLD`,
+`3DT`, and `3DG` bytes from JSON, compares minimized `.3D3.json` shape-slot
+metadata against the original `.3D3`, rebuilds and byte-compares full
+`.3D3.json` when bulky `model_data` is present, compares unmodified per-shape
+GLBs against the original `.3D3` export for primitive/source-metadata coverage,
+and checks `.glmesh` caches against their source GLBs when caches are present. Use
+`--require-all` when missing supported authoring replacements should fail the
+check; for `.3D3`, this means the minimized JSON index and per-shape GLBs, not
+the combined overview GLB. Use `--require-generated-cache` only when generated
+runtime caches must also exist.
+Use `--strict-original-proof` for converter regression checks; it implies
+generated cache and GLB source-proof requirements.
+
+Recommended validation modes:
+
+- Edited/custom asset pack loadability:
+  `python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --loadability-only`
+  For source-free packs, `/path/to/F15_GAME` may be a missing placeholder path
+  in `--loadability-only`; the command then checks modern files directly from
+  `converted_assets_all` and skips original-equivalence proof. The output path
+  may also be a parent folder containing `converted_assets_all`; the validator
+  will use that child folder automatically and print the normalized directory.
+  Do not use
+  `--require-all` in that source-free mode because there is no original asset
+  inventory to require against. If no replacement files are found, the validator
+  prints a warning so a wrong output path is visible.
+- Custom GLB check:
+  `python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --allow-custom-glb-differences`
+- Converter regression proof:
+  `python3 -m tools.f15assets.cli validate-replacements /path/to/F15_GAME converted_assets_all --require-all --strict-original-proof`
+
+For PNG, WAV, font, and JSON table replacements, normal `validate-replacements`
+still checks original equivalence. After intentionally editing those assets, use
+`--loadability-only` to check modern file parseability and structure without
+treating expected content differences as failures. For JSON table replacements,
+loadability mode still rebuilds the replacement and requires a non-empty byte
+stream for the legacy loader bridge. In loadability mode, source-free
+`*.WLD.json`, `*.3DT.json`, and `*.3DG.json` files under the converted output
+tree are also rebuilt even when the original binary asset is absent; byte
+equivalence still requires the original files. Source-free PNG files under the
+converted output tree are also checked for runtime-loadable dimensions and
+indexed-palette requirements, except font atlases which are handled by font
+validation. Source-free `.glb` and `.glmesh` files under the converted output
+tree are also checked for parseability and non-empty renderable primitives;
+primitive/order/color equivalence still requires the original `.3D3` files and
+converter source metadata. Source-free minimized `.3D3.json` files are checked
+for parseable shape-slot metadata, monotonic offsets, and valid
+`model_data_size`; exact slot-table equivalence still requires the original
+`.3D3`. For sound cues, WAV files must parse as
+mono unsigned 8-bit PCM, contain at least one sample, and carry the playback
+sample rate in the RIFF header. If `F15DGTL.BIN` is absent, sound validation
+still checks cue WAV loadability but skips legacy sample-byte comparison.
+Extra `sounds/voice_cue_*.wav` files are also parsed in loadability mode, but
+only the known cue names are used by the current runtime playback path. For
+BDF fonts, expected glyphs must exist with
+non-empty bitmap rows and positive advance widths; in `--loadability-only`, a
+bad BDF is only a warning when the matching PNG atlas fallback is loadable.
+Extra `fonts/font_*.bdf` files are also parsed in loadability mode so
+source-free/custom font packs can be checked without proving equivalence to the
+built-in font tables; they must include all 96 glyphs from U+0020 through
+U+007F with non-empty rows and positive advance widths. Source-free
+`fonts/font_*.png` atlases are also checked
+for the current runtime font ids whose cell dimensions are known.
+`--require-all` requires at least one runtime font source for each known font:
+BDF first, or PNG atlas fallback.
+Indexed PNG replacements must include an embedded palette. Per-shape GLBs must
+contain at least one triangle, line, or point primitive.
+`--loadability-only` is intentionally incompatible with `--strict-original-proof`
+and `--require-source-proof`; those modes are for proving original equivalence,
+not customized asset loadability. It also supersedes
+`--allow-custom-glb-differences`, so do not combine those two custom modes.
+
 ## Converted formats
 
 | Original | Modern output | Notes |
 | --- | --- | --- |
-| `*.PIC`, `*.SPR` | indexed PNG + JSON/YAML sidecar | PNG keeps palette-based pixels; sidecar keeps original decode metadata and source bytes. |
-| F-117A `*.PIC` + `*.PAL` | indexed PNG + JSON/YAML sidecar | Same-stem `.PAL` is used first; known aliases handle files such as `256LEFT.PIC` using `FLIGHT.PAL` and `CLIMBIN.PIC` using `ADV.PAL`; otherwise `PALETTES.PAL` chunk 0 is used as an F-117A fallback. |
-| `TITLE640.PIC` | `640x350` PNG + sidecar | Stored as alternating left/right rows by the original 640-mode loader. |
-| `1.PIC`..`4.PIC` | VGA-style PNG + sidecar | Demo-only images use a different byte-indexed loader path. |
-| `*.3D3` | `.glb` + JSON/YAML sidecar | Blender-friendly model export. JSON keeps shape ids, offsets, raw chunks, and metadata. |
-| `*.3DT` | JSON/YAML sidecar | Terrain object placement tables. |
-| `*.3DG` | JSON/YAML sidecar | Terrain grid lookup data. |
-| `*.WLD` | JSON/YAML sidecar | Theater/world objects, terrain grid, mission object type table, flight-unit templates, and names. |
-| fonts | BDF + PNG + JSON | Uses Unicode codepoints while preserving original CP437 source bytes. |
-| `F15DGTL.BIN` | raw WAV + cue WAVs + JSON | Unsigned 8-bit mono PCM at 7850 Hz by default. |
-| sound drivers | JSON sidecars | Driver executables are preserved for reverse-engineering metadata. |
+| `*.PIC`, `*.SPR` | indexed PNG, optional decode JSON | PNG is authoritative for pixels, dimensions, and palette. `convert-tree --include-image-json` writes bulky decode/index metadata for diagnostics. |
+| F-117A `*.PIC` + `*.PAL` | indexed PNG, optional decode JSON | PNG is authoritative after palette application. Same-stem `.PAL` is used first; known aliases handle files such as `256LEFT.PIC` using `FLIGHT.PAL` and `CLIMBIN.PIC` using `ADV.PAL`; otherwise `PALETTES.PAL` chunk 0 is used as an F-117A fallback. |
+| `TITLE640.PIC` | `640x350` PNG, optional decode JSON | Stored as alternating left/right rows by the original 640-mode loader; runtime loads the PNG into the hi-res title surface when present. |
+| `1.PIC`..`4.PIC` | VGA-style PNG, optional decode JSON | Demo-only images use a different byte-indexed loader path. |
+| `*.3D3` | asset/world directory with combined `.glb`, per-shape `.glb`, optional `cache/*.glmesh` runtime caches, and lightweight JSON index | GLB is authoritative for OpenGL geometry and model metadata; `.glmesh` is generated from GLB for OpenGL runtime loading and stores the source GLB checksum. Default JSON keeps only lightweight ids and lookup metadata. Full JSON with `model_data` can be rebuilt into legacy `.3D3` bytes for the old loader bridge, but default minimized JSON cannot. Use `convert-tree --include-3d3-model-data` only for full reverse-engineering or bridge dumps, and `--include-glmesh-cache` only if you want prebuilt caches. |
+| `*.3DT` | ordered JSON sidecar in the related world directory | Terrain object placement tables. |
+| `*.3DG` | ordered JSON sidecar in the related world directory | Terrain grid lookup data. |
+| `*.WLD` | world directory with ordered JSON sidecar | Theater/world objects, terrain grid, mission object type table, flight-unit templates, and names. |
+| fonts | BDF, optional JSON | BDF is authoritative for glyph shapes, Unicode codepoints, and metrics. JSON maps codepoints/index metadata only with `--include-metadata`; it does not override BDF glyph data. |
+| `F15DGTL.BIN` | cue WAVs, optional JSON, optional raw WAV | `voice_cue_*.wav` files are authoritative for runtime cue replacement. Current runtime replacement accepts mono unsigned 8-bit PCM cue WAVs and uses their RIFF sample rate for playback speed. JSON keeps cue/index metadata only when `--include-metadata` is requested. The full raw blob is not needed for customization; use `--include-raw-blob` only for reverse-engineering reference. |
+| sound drivers | optional JSON sidecars | Driver executable hashes, sizes, and unresolved status are preserved only when `--include-metadata` is requested; executable bytes are not duplicated into custom asset sidecars. |
 
 ## 3D model customization
 
 `3D3` assets are exported to glTF binary (`.glb`) for Blender and other modern tools.
+Bulk conversion writes related world and shape files into the same extensionless directory.
+For example:
+
+```text
+converted_assets_all/WORLD/
+  WORLD.WLD.json
+  WORLD.3DT.json
+  WORLD.3DG.json
+  WORLD.3D3.glb
+  shape_000.glb
+  shape_001.glb
+
+converted_assets_all/15FLT/
+  15FLT.3D3.json
+  15FLT.3D3.glb
+  shape_000.glb
+  shape_001.glb
+```
+
+The combined GLB is useful for overview and old viewer workflows. The `shape_###`
+per-shape GLBs are the preferred files for editing one model slot without
+opening every shape in the source container. Per-shape GLBs are minimized:
+unused accessors, bufferViews, materials, and binary buffer ranges from the
+combined GLB are not copied into the single-shape file. `.glmesh` files are
+generated runtime caches in `cache/` derived from the matching per-shape GLB.
+Runtime lookup keys off the stable `shape_###` slot prefix and is
+case-tolerant; human-readable labels after the number are optional.
+Default conversion does not pre-generate them; use `--include-glmesh-cache` if
+you want cache files ahead of first runtime load. Each cache stores the MD5
+checksum of the source GLB. Edit the GLB directly; the OpenGL runtime loader
+rebuilds the cache automatically when it is missing or its checksum does not
+match the GLB.
+`PHOTO.3D3` is authored the same way in `converted_assets_all/PHOTO/`, even
+though the legacy loader appends those target-view models to the active theater
+shape table at runtime. The OpenGL replacement lookup maps those appended slots
+back to `PHOTO/shape_###*.glb`.
+Bulk conversion writes minimized `.3D3.json` indexes without `model_data`
+base64. Use `decode` or `convert-tree --include-3d3-model-data` only when you
+need a full reverse-engineering dump that can rebuild the original `.3D3` bytes
+for the old loader bridge. If the runtime finds a minimized `.3D3.json`, the
+bridge rejects it and falls back to the original `.3D3`; OpenGL geometry can
+still come from per-shape GLB.
+Current generated caches use the `F15GLM3` header, which also stores source
+primitive kind/index/raw-color/order flags per runtime primitive. The renderer does not
+need those fields to draw, but validators and diagnostic runs use them to prove
+that cache generation did not merge, reorder, or drop order-sensitive `.3D3`
+geometry or lose palette/color identity.
+Older `F15GLM1`/`F15GLM2` caches can still be read by the runtime, but strict
+test-time validation cannot use them to prove source primitive order.
+
+Theater aliases are grouped with their world file: `LIBYA.WLD` with `LB.3D3`,
+`LB.3DT`, and `LB.3DG` under `LIBYA/`, and `GULF.WLD` with `PG.3D3`,
+`PG.3DT`, and `PG.3DG` under `GULF/`.
 
 Important constraints:
 
 - Shape ids must remain stable. Do not compact or renumber shapes if the game will use the edited asset as a replacement.
 - Some original shapes are intentionally 2D or single-sided. The exporter keeps one-sided planes instead of fabricating backfaces, because duplicated reverse faces can create z-fighting.
+- Source line and point primitives are exported in original order with duplicates
+  preserved; do not deduplicate antennas, masts, deck lines, or other line-only
+  details.
+- Source face triangles are also exported in decoded order with order-sensitive
+  metadata. This deliberately avoids color-batching triangles, because coplanar
+  or overlapping faces can depend on draw order.
 - Some theater model slots are non-renderable placeholders. They are skipped in GLB nodes but preserved in sidecar metadata.
 - Shape names are not embedded in `.3D3`; names are derived from matching `.WLD` object labels where possible.
-- For runtime replacement, use both `.glb` and the `.3D3.json` sidecar. GLB alone is not enough to preserve game-specific ids and flags.
+- For runtime replacement, prefer `.glb` for 3D geometry. The default
+  `.3D3.json` sidecar is an index/manifest only and should not duplicate model
+  bytecode; full bridge dumps may include `model_data` only when explicitly
+  generated with `--include-3d3-model-data`. `cache/*.glmesh` is generated data
+  and can be deleted safely.
+- Non-coplanar triangle order is normally harmless, but coplanar or z-fighting
+  geometry may depend on source draw order; preserve order unless a future
+  validator proves the reordering is render-equivalent.
+- GLB `extras` are diagnostic metadata. Geometry and material colors load from
+  the GLB itself, but if Blender or another editor strips primitive extras then
+  old-vs-new validation can no longer prove original source order/raw-color
+  equivalence for that edited shape.
 
 ## World and mission editing
 
@@ -152,7 +389,11 @@ The `.WLD` format does not expose a simple universal friend/enemy enum. Some run
 
 ## Sound cues
 
-`F15DGTL.BIN` is exported as one raw WAV plus driver-backed cue WAVs recovered from ASOUND.
+`F15DGTL.BIN` is exported as driver-backed cue WAVs recovered from ASOUND.
+Customizers should edit only the individual `voice_cue_*.wav` files. Per-cue
+JSON and driver sidecars are optional via `export-sounds --include-metadata`.
+The full raw blob WAV is optional via `export-sounds --include-raw-blob` and is
+meant only as reverse-engineering reference output.
 
 ASOUND cue ranges are inclusive in the driver:
 
@@ -166,22 +407,144 @@ audio_playSample(2), variant 2: 0x6A1B..0x7D9D
 
 `voiceCueThresholds` in the game code are availability checks before playback, not the full cue split table.
 
-The sample rate defaults to `7850` Hz. This comes from recovered driver timer behavior in the 8 kHz range, not from a WAV header in the original asset.
+The exported sample rate defaults to `7850` Hz, and the runtime uses the same
+recovered rate for legacy `F15DGTL.BIN` cue fallback. This comes from recovered
+driver timer behavior in the 8 kHz range, not from a WAV header in the original
+asset. Replacement WAV headers are authoritative at runtime.
 
 ## Runtime replacement recommendation
 
-For future game loading, prefer a manifest-like approach:
+Runtime loading currently uses path-based lookup, not a required manifest. If a
+future pack manifest is added, it should point to the same grouped files:
 
 ```json
 {
   "VN.WLD": { "world": "VN.WLD.json" },
-  "VN.3D3": { "geometry": "VN.3D3.glb", "metadata": "VN.3D3.json" },
+  "VN.3D3": { "geometry": "VN.3D3.glb", "index": "VN.3D3.json" },
   "TITLE640.PIC": { "image": "TITLE640.png", "metadata": "TITLE640.json" },
-  "F15DGTL.BIN": { "sounds": "sounds/f15dgtl_raw.json" }
+  "F15DGTL.BIN": { "sounds": "sounds/voice_cue_*.wav" }
 }
 ```
 
-Do not rely on PNG, GLB, or WAV alone for game replacement. The sidecar JSON carries ids, flags, palette metadata, original offsets, and unresolved bytes that the runtime may need.
+For replacement loading, always prefer the modern media artifact over JSON when
+both contain overlapping facts. JSON exists to locate assets and preserve
+non-media ids/flags/ranges that the media container does not represent.
+
+Current runtime implementation status:
+
+- A shared resolver searches converted asset directories such as `VN/`,
+  `LIBYA/`, `GULF/`, `15FLT/`, and `PHOTO/`.
+- Replacement lookup is case-tolerant for modern filenames and grouped model
+  directories, so packs converted from lowercase or uppercase DOS asset trees
+  can still be found on case-sensitive filesystems.
+- Legacy file loads detect preferred modern replacements and log that the
+  original loader remains active until that format has a native modern importer.
+  Current probes cover `.3D3 -> .glb` for OpenGL geometry, full `.3D3.json` for
+  legacy-byte-stream bridge dumps, `.PIC/.SPR -> .png`, and
+  `.WLD/.3DT/.3DG -> .json`.
+- PIC/SPR PNG replacement is used by the shared start/end image wrappers and by
+  the flight cockpit/side-view picture path, so converted cockpit art can be
+  edited as PNG without touching the original `.PIC`.
+- The shared resolver can also locate per-shape 3D replacements by stable slot
+  id, such as `VN/shape_049_SAM_Radar.glb`. The OpenGL backend can load these
+  through generated `cache/*.glmesh` files and rebuild missing or stale caches
+  from GLB through the `build-glmesh` bridge. The current loader still reads
+  legacy `.3D3` bytes for shape-slot tables, PHOTO append ranges, comparison,
+  and software fallback; GLB-only/free-asset runtime support requires moving
+  those table reads to modern metadata.
+  Full `.3D3.json` files that include `model_data` can be rebuilt through the
+  same JSON bridge as WLD/3DT/3DG and fed to the old loader. Default minimized
+  `.3D3.json` files are detected as metadata-only and do not trigger that
+  bridge.
+- Digitized sound runtime loading now prefers separate
+  `sounds/voice_cue_*.wav` files when present. Each WAV must be uncompressed
+  mono unsigned 8-bit PCM; its RIFF sample rate controls replacement playback
+  speed. Missing cue files fall back to the matching range in `F15DGTL.BIN`;
+  empty or invalid WAVs are rejected and also fall back to the legacy cue range.
+  Old-vs-new WAV equivalence is checked by `validate-replacements` and CTest,
+  not by normal gameplay.
+- PIC/SPR screen and sprite loads now prefer matching PNG replacements when
+  present. Indexed PNGs are copied as palette indices and their embedded palette
+  is required and applied to the active DAC; truecolor PNGs are accepted by
+  mapping pixels to the current game palette. Palette-less indexed PNGs are
+  rejected and fall back to legacy PIC/SPR. Replacement PNGs are sampled into
+  the existing game target rectangle, so higher-resolution source images do not
+  enlarge menus, cockpits, or sprite sheets. Pixel and palette equivalence is
+  checked by `validate-replacements` and CTest, not by normal gameplay.
+  Menu/debrief disk-presence gates for sprite sheets also accept matching PNG
+  replacements before prompting for original disks.
+- WLD/3DT/3DG loads now prefer matching JSON replacements when present. Runtime
+  import uses the converter's `build-binary` command to rebuild the same byte
+  stream the legacy loaders expect, then feeds those bytes into the existing
+  game loaders. This keeps loaded memory compatible while letting JSON be the
+  editable source. Set `F15_ASSET_TOOL` to override the command prefix; by
+  default runtime first looks for `tools/f15assets/cli.py` beside the
+  replacement asset's `converted_assets_all` root, then tries nearby script
+  paths, then falls back to `python3 -m tools.f15assets.cli`. JSON-rebuilt byte
+  equivalence is checked by `validate-replacements` and CTest.
+- Font drawing now prefers `fonts/font_<id>.ttf` or `.otf` when present and the
+  build has FreeType. The scalable font is fitted into the same in-memory glyph
+  rows and advance-width tables used by the original renderer, so layout and
+  clipping stay compatible. If TTF/OTF is absent or unavailable, the loader
+  falls back to BDF, then PNG atlas, then built-in fonts. Built-in font
+  equivalence is checked by `validate-replacements` and CTest.
+- Runtime GLB import is implemented for the OpenGL backend through a simple
+  runtime mesh bridge generated from per-shape GLBs. The backend treats `.glb`
+  as the source of truth, loads `cache/*.glmesh` only when the embedded source
+  checksum matches, and rebuilds missing or stale caches through `build-glmesh`.
+  Empty generated runtime meshes are rejected and fall back to legacy `.3D3`;
+  stale or empty caches are logged before rebuild/fallback. Replacement runtime
+  mesh equivalence is checked by `validate-replacements` and CTest.
+  Software rendering still uses the original `.3D3` stream. Exported media files
+  are authoritative over JSON metadata where applicable.
+
+## Replacement comparison modes
+
+Comparison is test/developer tooling only:
+
+- `python3 -m tools.f15assets.cli validate-replacements <asset_dir> <converted_dir>`
+  compares exported replacements against original assets outside the game. It
+  recurses by default, matching `convert-all`; use `--no-recursive` for a
+  flat-folder check.
+- CTest `asset_runtime_loader_validation_tests` loads old and modern assets
+  through the real runtime loader paths and compares the resulting data.
+
+`--require-all` applies to authoring replacements such as PNG, BDF, WAV, JSON
+tables, and per-shape GLB. Generated `cache/*.glmesh` files are validated when
+present and required only with `--require-generated-cache`.
+GLB source primitive extras are proof metadata for unmodified conversions; a
+Blender-edited GLB may strip or alter them and still be a valid custom model.
+Use `--require-source-proof` when metadata loss should fail validation.
+`--loadability-only` ignores combined overview GLBs and converter-only proof
+metadata; the runtime-relevant requirement is that each per-shape GLB parses and
+contains renderable triangles, lines, or points.
+
+Runtime comparison helpers are split out of individual loaders under
+`src/shared/asset_compare*.c`. Put byte-stream checks in
+`asset_compare_bytes.c`, indexed image/palette checks in
+`asset_compare_image.c`, bitmap font checks in `asset_compare_font.c`, digitized
+cue checks in `asset_compare_sound.c`, and renderer-independent 3D
+topology/color/source-metadata reporting in `asset_compare_3d.c`. Tool-side
+`validate-replacements` diff helpers live in
+`tools/f15assets/f15assets/validation_compare.py` as a stable facade over
+per-format `validation_compare_*` modules. The heavier per-format validation
+orchestration lives in `validation_image.py`, `validation_font.py`,
+`validation_sound.py`, `validation_structured.py`, and `validation_model3d.py`;
+each module exposes a `validate_*` entry point. `cli.py` should only wire
+commands and repository/output path policy.
+
+Runtime diagnostics currently cover:
+
+- `PIC`/`SPR`: replacement PNG indices against the legacy PIC decoder output.
+- `WLD`/`3DT`/`3DG`: JSON-rebuilt byte stream against the original binary before
+  the existing game loader consumes the replacement stream.
+- Fonts: replacement BDF/PNG glyph rows, metrics, and widths against built-in
+  font tables before installation.
+- Digitized cues: replacement WAV samples against the matching `F15DGTL.BIN`
+  byte range.
+- OpenGL 3D: replacement GLB topology and raw source-color coverage against
+  decoded legacy `.3D3` face/line/point coverage; generated `cache/*.glmesh`
+  files are compared when present.
 
 ## Python package notes
 
@@ -194,5 +557,48 @@ tools/f15assets/tests/*.py
 ```
 
 No install step is required when running from the repository root with `python3 -m tools.f15assets.cli`.
+The game runtime also searches for `tools/f15assets/cli.py` beside the
+replacement asset's `converted_assets_all` root and in nearby relative paths
+before falling back to module execution; use `F15_ASSET_TOOL` if the tool lives
+elsewhere.
 
 The tests are smoke/round-trip helpers for converter development. Run them only when you intentionally want validation work.
+
+`validate-replacements` is the explicit old-vs-modern test/developer comparison path.
+It currently validates `PIC`/`SPR` PNG pixel indices and known embedded/external
+palettes, digitized sound cue WAVs, WLD/3DT/3DG JSON replacements, BDF/PNG font
+replacements, `.3D3` JSON slot metadata, and `.3D3` GLB structure. The `.3D3`
+JSON check verifies the minimized shape offset table and model data size without
+requiring bulky `model_data`; this is the metadata a future GLB-only/free-asset
+runtime needs before original `.3D3` files can be omitted. If bulky `model_data`
+is present, validation also rebuilds the `.3D3` byte stream and compares it with
+the original file. The GLB check verifies combined GLB metadata, renderable
+shape count, per-shape GLB presence, minimized per-shape marker, stable
+`source_shape_index` metadata, primitive/source-metadata coverage against a
+fresh export from the original `.3D3`, and `.glmesh` cache equivalence with the
+source GLB. Full
+runtime mesh primitive counts are also compared against the source GLB so
+geometry drops are reported explicitly. `F15GLM3` source primitive metadata is
+compared against both the original export and the source GLB, so validation
+catches accidental primitive merging, reordering, or raw-color metadata loss
+when `--require-source-proof` is used. Without that flag, missing or changed
+source proof metadata is reported as a warning so custom GLBs remain acceptable.
+Use `--allow-custom-glb-differences` when edited per-shape GLBs intentionally
+change geometry counts or no longer match the original `.3D3` proof metadata.
+Use `--loadability-only` for edited packs when you want structural validation
+without old-vs-new equality checks.
+For image replacements, full equality validation requires indexed PNGs because
+that is the only mode that preserves original palette indices exactly.
+`--loadability-only` accepts truecolor PNGs, matching the runtime convenience
+path that maps truecolor pixels to the active game palette.
+Expanded runtime vertices and RGBA values are compared with a small float
+tolerance so cache validation catches coordinate/color drift without depending
+only on exact byte equality. Stale root-level `shape_*.glmesh` files are
+reported as invalid; generated runtime caches belong under `cache/`.
+Missing generated caches are not failures unless `--require-generated-cache` is
+specified, because the runtime can rebuild them from GLB.
+
+`validate-replacements` is intended for proving an unmodified conversion. After
+intentional customization, differences from the original `.3D3`, PNG, WAV, or
+font source may be expected; runtime fallback and cache checks still apply, but
+old-vs-new equality is no longer the success criterion for that edited asset.

--- a/tools/f15assets/cli.py
+++ b/tools/f15assets/cli.py
@@ -12,33 +12,61 @@ try:
         decode_pic_asset,
         decode_title640_pic_asset,
         parse_3d3,
+        export_3d3_shape_gltfs,
         export_3d3_to_gltf,
         export_3d3_to_glb,
         export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
+        build_3d3,
+        build_3dg,
+        build_3dt,
+        build_wld,
         export_fonts,
         export_sounds,
     )
-    from tools.f15assets.f15assets.pic import to_png_data
+    from tools.f15assets.f15assets.pic import known_runtime_pic_palette, to_png_data
+    from tools.f15assets.f15assets.sounds import DEFAULT_SAMPLE_RATE
     from tools.f15assets.f15assets.io import from_base64, to_base64
+    from tools.f15assets.f15assets.validation_image import validate_pic_png_replacement, validate_png_replacement_loadability
+    from tools.f15assets.f15assets.validation_sound import validate_sound_replacements
+    from tools.f15assets.f15assets.validation_font import validate_font_replacements
+    from tools.f15assets.f15assets.validation_structured import validate_structured_json_replacements
+    from tools.f15assets.f15assets.validation_model3d import (
+        glb_to_glmesh_bytes,
+        validate_3d3_glb_replacements,
+    )
 except ModuleNotFoundError:
     from f15assets import (
         decode_pic_asset,
         decode_title640_pic_asset,
         parse_3d3,
+        export_3d3_shape_gltfs,
         export_3d3_to_gltf,
         export_3d3_to_glb,
         export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
+        build_3d3,
+        build_3dg,
+        build_3dt,
+        build_wld,
         export_fonts,
         export_sounds,
     )
-    from f15assets.pic import to_png_data
+    from f15assets.pic import known_runtime_pic_palette, to_png_data
+    from f15assets.sounds import DEFAULT_SAMPLE_RATE
     from f15assets.io import from_base64, to_base64
+    from f15assets.validation_image import validate_pic_png_replacement, validate_png_replacement_loadability
+    from f15assets.validation_sound import validate_sound_replacements
+    from f15assets.validation_font import validate_font_replacements
+    from f15assets.validation_structured import validate_structured_json_replacements
+    from f15assets.validation_model3d import (
+        glb_to_glmesh_bytes,
+        validate_3d3_glb_replacements,
+    )
 
 ASSET_EXT_FORMATS = {
     ".pic": "PIC",
@@ -61,6 +89,10 @@ F117_PIC_PALETTE_ALIASES = {
     "256RIGHT": "FLIGHT.PAL",
     "CLIMBIN": "ADV.PAL",
 }
+
+# Some tests and external scripts imported this helper from cli.py before the
+# per-format validator split. Keep the alias while new code uses the public name.
+_glb_to_glmesh_bytes = glb_to_glmesh_bytes
 
 
 def _iter_asset_paths(root: Path, recursive: bool):
@@ -85,26 +117,190 @@ def _read_binary(path: Path) -> bytes:
         return f.read()
 
 
-def _read_yaml(path: Path) -> Dict[str, Any]:
-    try:
-        import yaml
-    except Exception as exc:  # pragma: no cover
-        raise RuntimeError("PyYAML is required for YAML support") from exc
-
-    with path.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    if not isinstance(data, dict):
-        raise ValueError("YAML payload must be a mapping")
-    return data
-
-
-def _write_json(path: Path, payload: Dict[str, Any], pretty: bool = True) -> None:
+def _write_json(path: Path, payload: Dict[str, Any], pretty: bool = True, *, media_sidecar: bool = True) -> None:
+    # Default converter sidecars are media-first: for 3D3, GLB files are the
+    # editable source and JSON is minimized. Full bridge dumps deliberately opt
+    # out so runtime can rebuild the legacy byte stream without original .3D3.
+    writable_payload = _sidecar_payload_for_write(payload) if media_sidecar else payload
+    ordered_payload = _human_ordered_payload(writable_payload)
     with path.open("w", encoding="utf-8") as f:
         if pretty:
-            json.dump(payload, f, indent=2, sort_keys=True)
+            json.dump(ordered_payload, f, indent=2)
             f.write("\n")
         else:
-            json.dump(payload, f)
+            json.dump(ordered_payload, f)
+
+
+def _sidecar_payload_for_write(payload: Dict[str, Any]) -> Dict[str, Any]:
+    if payload.get("format") == "PIC":
+        out = {
+            key: payload[key]
+            for key in (
+                "format",
+                "version",
+                "source_name",
+                "decoded_width",
+                "decoded_height",
+                "max_lzw_width",
+                "bitstream_mode",
+                "palette_profile",
+                "original_length",
+                "decoded_length",
+                "stored_height",
+                "layout",
+                "notes",
+            )
+            if key in payload
+        }
+        out["image"] = {
+            "preferred": "png",
+            "authoritative": True,
+            "notes": "Pixel data, dimensions, and palette from the matching indexed PNG override JSON metadata.",
+        }
+        return out
+
+    if payload.get("format") != "3D3":
+        return payload
+
+    # GLB is the preferred model replacement/editing artifact. Keep the JSON
+    # sidecar as a small index/manifest instead of duplicating model bytecode.
+    out = {
+        key: payload[key]
+        for key in (
+            "format",
+            "version",
+            "signature",
+            "shape_offsets",
+            "model_data_size",
+            "shape_names",
+        )
+        if key in payload
+    }
+    shared_pool = payload.get("shared_vertex_pool")
+    if isinstance(shared_pool, dict):
+        out["shared_vertex_pool"] = {
+            "index_count": len(shared_pool.get("x_indices", [])),
+            "x_value_count": len(shared_pool.get("x_values", [])),
+            "y_value_count": len(shared_pool.get("y_values", [])),
+            "z_value_count": len(shared_pool.get("z_values", [])),
+        }
+    else:
+        out["shared_vertex_pool"] = None
+    out["geometry"] = {
+        "preferred": "glb",
+        "authoritative": True,
+        "combined": True,
+        "per_shape_files": True,
+        "notes": "3D geometry and GLB extras override JSON metadata; JSON is only an index.",
+    }
+    return out
+
+
+_LARGE_JSON_KEYS = {
+    "compressed_payload_base64",
+    "model_data",
+    "name_table",
+    "palette_dac6_base64",
+    "palette_rgb8_base64",
+    "pixels_base64",
+    "raw_bytes_base64",
+    "shape_target_category_table",
+    "terrain_grid",
+    "trailing_bytes",
+    "unknown_bytes_base64",
+    "kill_tally_or_unit_flags",
+    "mission_object_type_table",
+}
+
+_JSON_KEY_ORDER = {
+    "WLD": [
+        "format",
+        "version",
+        "terrain_target_ids",
+        "read_item_size",
+        "ground_unit_count",
+        "world_object_count",
+        "world_objects",
+        "flight_unit_count",
+        "flight_units",
+        "name_strings",
+    ],
+    "3D3": [
+        "format",
+        "version",
+        "signature",
+        "shape_offsets",
+        "shape_names",
+        "model_data_size",
+        "shared_vertex_pool",
+    ],
+}
+
+_RECORD_KEY_ORDER = [
+    "name",
+    "label",
+    "unitRef",
+    "unitType",
+    "objectIdx",
+    "x_coord",
+    "y_coord",
+    "z_coord",
+    "startX",
+    "startY",
+    "startZ",
+    "waypointX",
+    "waypointY",
+    "waypointZ",
+    "targetFlags",
+    "occupantType",
+    "patrolCount",
+    "waypointIdx",
+    "flags",
+    "weaponType",
+    "terrainColor",
+    "damage",
+]
+
+
+def _is_large_json_key(key: object) -> bool:
+    text = str(key)
+    return text in _LARGE_JSON_KEYS or text.endswith("_base64")
+
+
+def _ordered_human_mapping(payload: Dict[str, Any], preferred: list[str] | None = None) -> Dict[str, Any]:
+    preferred = preferred or []
+    out: Dict[str, Any] = {}
+    seen = set()
+
+    for key in preferred:
+        if key in payload:
+            out[key] = _human_ordered_payload(payload[key])
+            seen.add(key)
+
+    normal_keys = [
+        key for key in payload.keys()
+        if key not in seen and not _is_large_json_key(key)
+    ]
+    large_keys = [
+        key for key in payload.keys()
+        if key not in seen and _is_large_json_key(key)
+    ]
+    for key in normal_keys + large_keys:
+        out[key] = _human_ordered_payload(payload[key])
+    return out
+
+
+def _human_ordered_payload(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_human_ordered_payload(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    fmt = value.get("format")
+    if isinstance(fmt, str) and fmt in _JSON_KEY_ORDER:
+        return _ordered_human_mapping(value, _JSON_KEY_ORDER[fmt])
+
+    return _ordered_human_mapping(value, _RECORD_KEY_ORDER)
 
 
 def _write_gltf(path: Path, payload: Dict[str, Any], pretty: bool = True) -> None:
@@ -126,18 +322,73 @@ def _write_gltf_binary_doc(path: Path, gltf: Dict[str, Any]) -> None:
     path.write_bytes(glb_data)
 
 
-def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
-    try:
-        import yaml
-    except Exception as exc:  # pragma: no cover
-        raise RuntimeError("PyYAML is required for --yaml output") from exc
-
-    with path.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(payload, f, sort_keys=True)
+def _remove_if_exists(path: Path) -> None:
+    if path.exists():
+        try:
+            path.unlink()
+        except OSError:
+            pass
 
 
 def _detect_format(path: Path) -> str:
     return ASSET_EXT_FORMATS.get(path.suffix.lower(), "")
+
+
+def _safe_output_stem(value: object) -> str:
+    text = str(value or "").strip()
+    safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in text)
+    safe = "_".join(part for part in safe.split("_") if part)
+    return safe[:96] or "model"
+
+
+def _related_world_stem_for_theater_asset(source_path: Path) -> str:
+    stem = source_path.stem
+    upper_stem = stem.upper()
+    wld_stem = THEATER_WLD_STEM_ALIASES.get(upper_stem, upper_stem)
+    if (source_path.with_name(f"{wld_stem}.WLD")).exists() or (
+        source_path.with_name(f"{wld_stem}.wld")
+    ).exists():
+        return wld_stem
+    return stem
+
+
+def _asset_output_dir(src: Path, relative: Path, input_root: Path, output_root: Path, fmt: str) -> Path:
+    parent = output_root / relative.parent
+    if fmt == "WLD":
+        return parent / src.stem
+    if fmt in {"3D3", "3DT", "3DG"}:
+        return parent / _related_world_stem_for_theater_asset(src)
+    return output_root / relative.with_suffix("")
+
+
+def _write_3d3_shape_models(
+    output_dir: Path,
+    payload: Dict[str, Any],
+    model_format: str,
+    pretty: bool,
+    write_cache: bool = False,
+) -> None:
+    if model_format == "none":
+        return
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for stale_glmesh in output_dir.glob("shape_*.glmesh"):
+        _remove_if_exists(stale_glmesh)
+    cache_dir = output_dir / "cache"
+    if model_format == "glb" and cache_dir.exists():
+        for stale_glmesh in cache_dir.glob("shape_*.glmesh"):
+            _remove_if_exists(stale_glmesh)
+    for shape_index, shape_name, shape_gltf in export_3d3_shape_gltfs(payload):
+        label = _safe_output_stem(shape_name)
+        base_shape = f"shape_{shape_index:03d}"
+        base = base_shape if label == base_shape else f"{base_shape}_{label}"
+        if model_format == "glb":
+            glb_path = output_dir / f"{base}.glb"
+            _write_gltf_binary_doc(glb_path, shape_gltf)
+            if write_cache:
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                (cache_dir / f"{base}.glmesh").write_bytes(glb_to_glmesh_bytes(glb_path))
+        elif model_format == "gltf":
+            _write_gltf(output_dir / f"{base}.gltf", shape_gltf, pretty=pretty)
 
 
 def _log_3d3_gltf_diagnostics(gltf: Dict[str, Any], source_path: Path | None) -> None:
@@ -219,6 +470,19 @@ def _attach_external_palette(payload: Dict[str, Any], source_path: Path | None) 
     if isinstance(profile, dict) and profile.get("status") == "embedded":
         return
 
+    index_bit_depth = 8
+    if isinstance(profile, dict):
+        try:
+            index_bit_depth = int(profile.get("index_bit_depth", 8))
+        except (TypeError, ValueError):
+            index_bit_depth = 8
+    known_palette = known_runtime_pic_palette(source_path.name, index_bit_depth)
+    if known_palette is not None:
+        payload["palette_dac6_base64"] = to_base64(bytes(known_palette["palette_dac6"]))
+        payload["palette_rgb8_base64"] = to_base64(bytes(known_palette["palette_rgb8"]))
+        payload["palette_profile"] = known_palette["profile"]
+        return
+
     found = _find_external_palette(source_path)
     if found is None:
         return
@@ -228,7 +492,9 @@ def _attach_external_palette(payload: Dict[str, Any], source_path: Path | None) 
     payload["palette_rgb8_base64"] = to_base64(_dac6_to_rgb8(palette_dac6))
     payload["palette_profile"] = {
         "source": source,
-        "source_file": str(palette_path),
+        # Store the palette filename, not the user's absolute install path, so
+        # converted image sidecars remain shareable across machines.
+        "source_file": palette_path.name,
         "status": "external",
         "index_mode": "indexed",
         "index_bit_depth": payload.get("palette_profile", {}).get("index_bit_depth", 8)
@@ -348,6 +614,36 @@ def _decode_args(png: str | None = None, gltf: str | None = None, pretty: bool =
     return argparse.Namespace(png=png, gltf=gltf, pretty=pretty)
 
 
+def _minimize_3d3_json(payload: Dict[str, Any]) -> Dict[str, Any]:
+    shared_pool = payload.get("shared_vertex_pool")
+    shared_pool_summary = None
+    if isinstance(shared_pool, dict):
+        shared_pool_summary = {
+            "index_count": len(shared_pool.get("x_indices", [])),
+            "x_value_count": len(shared_pool.get("x_values", [])),
+            "y_value_count": len(shared_pool.get("y_values", [])),
+            "z_value_count": len(shared_pool.get("z_values", [])),
+        }
+    minimized = {
+        "format": payload.get("format", "3D3"),
+        "version": payload.get("version", 1),
+        "signature": payload.get("signature"),
+        "shape_offsets": payload.get("shape_offsets", []),
+        "shape_names": payload.get("shape_names", {}),
+        "model_data_size": payload.get("model_data_size"),
+        "shared_vertex_pool_summary": shared_pool_summary,
+        "trailing_byte_count": len(from_base64(payload.get("trailing_bytes", "")))
+        if isinstance(payload.get("trailing_bytes"), str)
+        else 0,
+        "notes": (
+            "Minimized 3D3 index. GLB files are authoritative for geometry; "
+            "use decode or convert-tree --include-3d3-model-data for a full "
+            "reverse-engineering dump with model_data."
+        ),
+    }
+    return minimized
+
+
 def cmd_decode(args: argparse.Namespace) -> int:
     fmt = args.format.upper() if args.format else _detect_format(Path(args.input))
     if not fmt:
@@ -355,9 +651,7 @@ def cmd_decode(args: argparse.Namespace) -> int:
 
     data = _read_binary(Path(args.input))
     payload = _decode_asset(data, fmt, args, source_path=Path(args.input))
-    _write_json(Path(args.json), payload, pretty=args.pretty)
-    if args.yaml:
-        _write_yaml(Path(args.yaml), payload)
+    _write_json(Path(args.json), payload, pretty=args.pretty, media_sidecar=False)
     return 0
 
 
@@ -365,7 +659,14 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
     input_root = Path(args.input)
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
-        raise ValueError(f"input must be an existing directory: {args.input}")
+        if not getattr(args, "loadability_only", False):
+            raise ValueError(f"input must be an existing directory: {args.input}")
+        if getattr(args, "require_all", False):
+            raise ValueError("--require-all needs an existing original input directory; omit it for source-free --loadability-only checks")
+        print(
+            f"warning: original input directory is missing: {args.input}; running source-free loadability checks only",
+            file=sys.stderr,
+        )
 
     output_root.mkdir(parents=True, exist_ok=True)
 
@@ -381,20 +682,19 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
 
         relative = src.relative_to(input_root)
         dst_base = output_root / relative.with_suffix("")
-        dst_base.parent.mkdir(parents=True, exist_ok=True)
         output_base = dst_base
-        if fmt == "3D3":
-            # Keep the original extension in the basename, e.g. 15FLT.3D3.glb,
-            # so similarly named model records from different formats do not
-            # collide in bulk exports.
-            output_base = dst_base.with_name(src.name)
+        if fmt in {"3D3", "WLD", "3DT", "3DG"}:
+            # Keep complex/gameplay-bearing formats isolated so their sidecars,
+            # combined model, and per-shape model files are easy to browse and edit.
+            output_base = _asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
 
-        if fmt == "3D3":
+        output_base.parent.mkdir(parents=True, exist_ok=True)
+
+        if fmt in {"3D3", "WLD", "3DT", "3DG"}:
             json_path = output_base.with_name(output_base.name + ".json")
-            yaml_path = output_base.with_name(output_base.name + ".yaml")
         else:
             json_path = output_base.with_suffix(".json")
-            yaml_path = output_base.with_suffix(".yaml")
+        json_path.parent.mkdir(parents=True, exist_ok=True)
         png_path = None
         if fmt == "PIC" and not args.no_png:
             png_path = str(output_base.with_suffix(".png"))
@@ -421,19 +721,35 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
             print(f"error: {exc} ({src})", file=sys.stderr)
             continue
 
-        _write_json(json_path, payload, pretty=args.pretty)
-        if args.yaml:
-            _write_yaml(yaml_path, payload)
+        write_json_sidecar = fmt != "PIC" or png_path is None or getattr(args, "include_image_json", False)
+        if write_json_sidecar:
+            json_payload = payload
+            if fmt == "3D3" and not getattr(args, "include_3d3_model_data", False):
+                json_payload = _minimize_3d3_json(payload)
+            _write_json(
+                json_path,
+                json_payload,
+                pretty=args.pretty,
+                media_sidecar=not (fmt == "3D3" and getattr(args, "include_3d3_model_data", False)),
+            )
+        else:
+            _remove_if_exists(json_path)
+        _remove_if_exists(json_path.with_suffix(".yaml"))
 
         if fmt == "3D3":
-            legacy_exts = [".json", ".yaml", ".gltf", ".glb"]
+            _write_3d3_shape_models(
+                output_base.parent,
+                payload,
+                args.models,
+                args.pretty,
+                write_cache=getattr(args, "include_glmesh_cache", False),
+            )
+            legacy_exts = [".json", ".yaml", ".gltf", ".glb", ".glmesh"]
             for legacy_ext in legacy_exts:
-                legacy_path = dst_base.with_suffix(legacy_ext)
-                if legacy_path.exists():
-                    try:
-                        legacy_path.unlink()
-                    except OSError:
-                        pass
+                _remove_if_exists(dst_base.with_suffix(legacy_ext))
+        elif fmt in {"WLD", "3DT", "3DG"}:
+            for legacy_ext in [".json", ".yaml"]:
+                _remove_if_exists(dst_base.with_suffix(legacy_ext))
 
     return 0 if failed == 0 else 1
 
@@ -443,8 +759,17 @@ def cmd_export_fonts(args: argparse.Namespace) -> int:
     output_root = Path(args.output)
     if not (repo_root / "src" / "fontdata.h").exists():
         raise ValueError(f"repo root does not contain src/fontdata.h: {repo_root}")
-    index = export_fonts(repo_root, output_root, write_bdf=not args.no_bdf)
-    _write_json(output_root / "fonts.json", index, pretty=args.pretty)
+    index = export_fonts(
+        repo_root,
+        output_root,
+        write_bdf=not args.no_bdf,
+        include_metadata=getattr(args, "include_metadata", False),
+    )
+    index_path = output_root / "fonts.json"
+    if getattr(args, "include_metadata", False):
+        _write_json(index_path, index, pretty=args.pretty)
+    else:
+        _remove_if_exists(index_path)
     return 0
 
 
@@ -453,9 +778,206 @@ def cmd_export_sounds(args: argparse.Namespace) -> int:
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
         raise ValueError(f"input must be an existing directory: {args.input}")
-    index = export_sounds(input_root, output_root, sample_rate=args.sample_rate)
-    _write_json(output_root / "sounds.json", index, pretty=args.pretty)
+    index = export_sounds(
+        input_root,
+        output_root,
+        sample_rate=args.sample_rate,
+        include_raw_blob=getattr(args, "include_raw_blob", False),
+        include_metadata=getattr(args, "include_metadata", False),
+    )
+    if getattr(args, "include_metadata", False):
+        _write_json(output_root / "sounds.json", index, pretty=args.pretty)
     return 0
+
+
+def cmd_build_binary(args: argparse.Namespace) -> int:
+    json_path = Path(args.json)
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    fmt = args.format.upper() if args.format else str(payload.get("format", "")).upper()
+    builders = {
+        "3D3": build_3d3,
+        "WLD": build_wld,
+        "3DT": build_3dt,
+        "3DG": build_3dg,
+    }
+    if fmt not in builders:
+        raise ValueError("build-binary currently supports 3D3, WLD, 3DT, and 3DG JSON")
+    sys.stdout.buffer.write(builders[fmt](payload))
+    return 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def _structured_json_path(src: Path, relative: Path, input_root: Path, output_root: Path, fmt: str) -> Path:
+    if fmt in {"WLD", "3D3", "3DT", "3DG"}:
+        output_base = _asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
+        return output_base.with_name(output_base.name + ".json")
+    return (output_root / relative).with_suffix(".json")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def cmd_build_glmesh(args: argparse.Namespace) -> int:
+    sys.stdout.buffer.write(glb_to_glmesh_bytes(Path(args.glb)))
+    return 0
+
+
+
+
+def cmd_validate_replacements(args: argparse.Namespace) -> int:
+    input_root = Path(args.input)
+    output_root = Path(args.output)
+    if not input_root.exists() or not input_root.is_dir():
+        if not args.loadability_only:
+            raise ValueError(f"input must be an existing directory: {args.input}")
+        if args.require_all:
+            raise ValueError("--require-all needs an existing original input directory; omit it for source-free --loadability-only checks")
+        print(
+            f"warning: original input directory is missing: {args.input}; running source-free loadability checks only",
+            file=sys.stderr,
+        )
+    if output_root.exists() and output_root.is_dir() and output_root.name != "converted_assets_all" and (output_root / "converted_assets_all").is_dir():
+        output_root = output_root / "converted_assets_all"
+        print(f"using converted output directory: {output_root}", file=sys.stderr)
+    if not output_root.exists() or not output_root.is_dir():
+        raise ValueError(f"output must be an existing directory: {args.output}")
+    if args.loadability_only and args.strict_original_proof:
+        raise ValueError("--loadability-only and --strict-original-proof are incompatible validation modes")
+    if args.loadability_only and args.require_source_proof:
+        raise ValueError("--loadability-only and --require-source-proof are incompatible validation modes")
+    if args.loadability_only and args.allow_custom_glb_differences:
+        raise ValueError("--loadability-only already allows custom GLB content differences; do not combine it with --allow-custom-glb-differences")
+
+    checked = 0
+    failed = 0
+    pic_checked = 0
+    checked_png_paths: set[Path] = set()
+    if input_root.exists():
+        for src in _iter_asset_paths(input_root, recursive=args.recursive):
+            fmt = _detect_format(src)
+            if fmt != "PIC":
+                continue
+            relative = src.relative_to(input_root)
+            png_path = output_root / relative.with_suffix(".png")
+            if not png_path.exists():
+                if args.require_all:
+                    print(f"missing replacement PNG: {png_path}", file=sys.stderr)
+                    failed += 1
+                continue
+            checked += 1
+            pic_checked += 1
+            checked_png_paths.add(png_path.resolve())
+            try:
+                errors = validate_pic_png_replacement(src, png_path, _read_binary, args.loadability_only)
+            except Exception as exc:
+                errors = [f"{src}: {exc}"]
+            if errors:
+                failed += 1
+                for error in errors:
+                    print(error, file=sys.stderr)
+    if args.loadability_only:
+        for png_path in sorted(output_root.rglob("*.png")):
+            if png_path.resolve() in checked_png_paths:
+                continue
+            if "fonts" in {part.lower() for part in png_path.relative_to(output_root).parts[:-1]}:
+                continue
+            checked += 1
+            pic_checked += 1
+            errors = validate_png_replacement_loadability(png_path)
+            if errors:
+                failed += 1
+                for error in errors:
+                    print(error, file=sys.stderr)
+
+    sound_checked, sound_failed = validate_sound_replacements(input_root, output_root, args.require_all, args.loadability_only)
+    checked += sound_checked
+    failed += sound_failed
+    font_checked, font_failed = validate_font_replacements(Path(args.repo_root), output_root, args.require_all, args.loadability_only)
+    checked += font_checked
+    failed += font_failed
+    structured_checked, structured_failed = validate_structured_json_replacements(
+        input_root,
+        output_root,
+        args.recursive,
+        args.require_all,
+        _iter_asset_paths,
+        _detect_format,
+        _structured_json_path,
+        args.loadability_only,
+    )
+    checked += structured_checked
+    failed += structured_failed
+    glb_checked, glb_failed = validate_3d3_glb_replacements(
+        input_root,
+        output_root,
+        args.recursive,
+        args.require_all,
+        _iter_asset_paths,
+        _detect_format,
+        _asset_output_dir,
+        _load_shape_names_for_3d3,
+        args.require_generated_cache or args.strict_original_proof,
+        args.require_source_proof or args.strict_original_proof,
+        args.allow_custom_glb_differences and not args.strict_original_proof,
+        args.loadability_only,
+    )
+    checked += glb_checked
+    failed += glb_failed
+
+    if args.loadability_only and checked == 0:
+        print(
+            f"warning: no replacement files were checked under {output_root}; expected PNG, WAV, BDF, WLD/3DT/3DG JSON, 3D3 JSON, GLB, or GLMESH replacements",
+            file=sys.stderr,
+        )
+
+    print(
+        f"validated replacements: PIC/SPR PNG={pic_checked}, "
+        f"sound WAV={sound_checked}, font BDF/PNG={font_checked}, "
+        f"WLD/3DT/3DG JSON={structured_checked}, 3D3 JSON/GLB/GLMESH={glb_checked}; failures={failed}"
+    )
+    return 0 if failed == 0 else 1
 
 
 def _repo_root_from_tool() -> Path:
@@ -473,10 +995,12 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
     convert_args = argparse.Namespace(
         input=str(input_root),
         output=str(output_root),
-        recursive=False,
+        recursive=True,
         models="glb",
         no_png=False,
-        yaml=False,
+        include_image_json=getattr(args, "include_image_json", False),
+        include_3d3_model_data=getattr(args, "include_3d3_model_data", True),
+        include_glmesh_cache=getattr(args, "include_glmesh_cache", False),
         continue_on_error=False,
         pretty=args.pretty,
     )
@@ -489,6 +1013,7 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
         repo_root=str(repo_root),
         output=str(output_root / "fonts"),
         no_bdf=False,
+        include_metadata=getattr(args, "include_metadata", False),
         pretty=args.pretty,
     )
     result = cmd_export_fonts(font_args)
@@ -498,7 +1023,9 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
     sound_args = argparse.Namespace(
         input=str(input_root),
         output=str(output_root / "sounds"),
-        sample_rate=7850,
+        sample_rate=DEFAULT_SAMPLE_RATE,
+        include_raw_blob=getattr(args, "include_raw_blob", False),
+        include_metadata=getattr(args, "include_metadata", False),
         pretty=args.pretty,
     )
     return cmd_export_sounds(sound_args)
@@ -517,11 +1044,43 @@ def build_parser() -> argparse.ArgumentParser:
     )
     convert_all.add_argument("input", help="Installed game folder containing original assets")
     convert_all.add_argument("output", help="Output folder for all converted assets")
+    convert_all.add_argument(
+        "--include-image-json",
+        action="store_true",
+        help="Also write bulky PIC/SPR decode JSON; default output uses PNG as the image source",
+    )
+    convert_all.add_argument(
+        "--include-3d3-model-data",
+        action="store_true",
+        default=True,
+        help="Write .3D3 model_data base64 into JSON so modern-only packs can rebuild shape tables (default)",
+    )
+    convert_all.add_argument(
+        "--minimize-3d3-json",
+        dest="include_3d3_model_data",
+        action="store_false",
+        help="Omit bulky .3D3 model_data; requires original .3D3 files at runtime for shape tables",
+    )
+    convert_all.add_argument(
+        "--include-glmesh-cache",
+        action="store_true",
+        help="Also pre-generate cache/*.glmesh runtime meshes; default output relies on runtime rebuild from GLB",
+    )
+    convert_all.add_argument(
+        "--include-metadata",
+        action="store_true",
+        help="Also export optional font JSON, sound cue JSON, driver sidecars, and index metadata",
+    )
+    convert_all.add_argument(
+        "--include-raw-blob",
+        action="store_true",
+        help="Also export f15dgtl_raw.wav/f15dgtl_raw.json for reverse-engineering reference",
+    )
     convert_all.set_defaults(func=cmd_convert_all)
 
     decode = sub.add_parser(
         "decode",
-        help="decode game asset to modern editable sidecar files",
+        help="decode one game asset to full diagnostic JSON and optional media files",
     )
     decode.add_argument("input", help="Input binary asset")
     decode.add_argument("json", help="Output JSON sidecar")
@@ -534,7 +1093,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--png",
         help="Optional indexed PNG output for PIC/SPR (unsupported for other formats)",
     )
-    decode.add_argument("--yaml", help="Optional YAML output sidecar path")
     decode.add_argument(
         "--gltf",
         help="Optional .gltf or .glb output for 3D3 models",
@@ -543,7 +1101,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     convert = sub.add_parser(
         "convert-tree",
-        help="convert all supported assets in a folder to modern editable targets",
+        help="convert supported assets in one folder; use convert-all for recursive default conversion",
     )
     convert.add_argument("input", help="Input folder containing game assets")
     convert.add_argument("output", help="Output folder for converted assets")
@@ -555,7 +1113,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output format for 3D3 models (`glb` is self-contained by default)",
     )
     convert.add_argument("--no-png", action="store_true", help="Skip PNG output for PIC/SPR")
-    convert.add_argument("--yaml", action="store_true", help="Also write YAML sidecar files")
+    convert.add_argument(
+        "--include-image-json",
+        action="store_true",
+        help="Also write bulky PIC/SPR decode JSON; by default PNG is the image replacement source",
+    )
+    convert.add_argument(
+        "--include-3d3-model-data",
+        action="store_true",
+        help="Also write bulky .3D3 model_data base64 into JSON; by default GLB is the geometry source",
+    )
+    convert.add_argument(
+        "--include-glmesh-cache",
+        action="store_true",
+        help="Also pre-generate cache/*.glmesh runtime meshes; default output relies on runtime rebuild from GLB",
+    )
     convert.add_argument(
         "--continue-on-error",
         action="store_true",
@@ -565,26 +1137,110 @@ def build_parser() -> argparse.ArgumentParser:
 
     fonts = sub.add_parser(
         "export-fonts",
-        help="export extracted in-repo font tables to atlas PNG and JSON metadata",
+        help="export extracted in-repo font tables to BDF; metadata is optional",
     )
     fonts.add_argument("repo_root", help="Repository root containing src/fontdata.h and src/gfx_impl.c")
-    fonts.add_argument("output", help="Output folder for font atlas assets")
+    fonts.add_argument("output", help="Output folder for BDF font assets")
     fonts.add_argument("--no-bdf", action="store_true", help="Skip BDF font files")
+    fonts.add_argument(
+        "--include-metadata",
+        action="store_true",
+        help="Also write font_<id>.json sidecars and fonts.json; default output is BDF only",
+    )
     fonts.set_defaults(func=cmd_export_fonts)
 
     sounds = sub.add_parser(
         "export-sounds",
-        help="export digitized sample blob and sound-driver sidecars",
+        help="export digitized cue WAVs; optional metadata sidecars are opt-in",
     )
     sounds.add_argument("input", help="Installed game folder containing F15DGTL.BIN and sound drivers")
     sounds.add_argument("output", help="Output folder for sound assets")
     sounds.add_argument(
         "--sample-rate",
         type=int,
-        default=7850,
-        help="Sample rate for raw unsigned 8-bit PCM WAV export",
+        default=DEFAULT_SAMPLE_RATE,
+        help="Sample rate for exported unsigned 8-bit PCM cue WAVs",
+    )
+    sounds.add_argument(
+        "--include-raw-blob",
+        action="store_true",
+        help="Also export f15dgtl_raw.wav/f15dgtl_raw.json for reverse-engineering reference",
+    )
+    sounds.add_argument(
+        "--include-metadata",
+        action="store_true",
+        help="Also export cue JSON, driver sidecars, and sounds.json metadata for reverse engineering",
     )
     sounds.set_defaults(func=cmd_export_sounds)
+
+    build_binary = sub.add_parser(
+        "build-binary",
+        help="rebuild runtime binary bytes from structured replacement JSON",
+    )
+    build_binary.add_argument("json", help="Input 3D3/WLD/3DT/3DG JSON replacement")
+    build_binary.add_argument(
+        "--format",
+        choices=["3D3", "3d3", "WLD", "wld", "3DT", "3dt", "3DG", "3dg"],
+        help="Force JSON format instead of reading payload.format",
+    )
+    build_binary.set_defaults(func=cmd_build_binary)
+
+    build_glmesh = sub.add_parser(
+        "build-glmesh",
+        help="expand a replacement GLB into a simple runtime mesh stream for the OpenGL backend",
+    )
+    build_glmesh.add_argument("glb", help="Input per-shape GLB")
+    build_glmesh.set_defaults(func=cmd_build_glmesh)
+
+    validate = sub.add_parser(
+        "validate-replacements",
+        help="compare original asset loads against modern replacements; use flags for strict proof or custom GLB workflows",
+    )
+    validate.add_argument("input", help="Installed game folder containing original assets")
+    validate.add_argument("output", help="Converted asset folder")
+    validate.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root for validating in-repo original font tables",
+    )
+    validate.add_argument(
+        "--no-recursive",
+        dest="recursive",
+        action="store_false",
+        default=True,
+        help="Only validate assets directly under the input folder",
+    )
+    validate.add_argument(
+        "--require-all",
+        action="store_true",
+        help="Fail if a supported original asset has no modern authoring replacement",
+    )
+    validate.add_argument(
+        "--require-generated-cache",
+        action="store_true",
+        help="Also fail if generated 3D cache/*.glmesh runtime caches are missing",
+    )
+    validate.add_argument(
+        "--require-source-proof",
+        action="store_true",
+        help="Fail if GLB/GLMESH source primitive metadata is missing or no longer matches the original export",
+    )
+    validate.add_argument(
+        "--strict-original-proof",
+        action="store_true",
+        help="Strict converter-regression mode: require generated 3D caches and GLB/GLMESH source proof metadata",
+    )
+    validate.add_argument(
+        "--allow-custom-glb-differences",
+        action="store_true",
+        help="Warn instead of failing when per-shape GLB geometry/source proof differs from the original .3D3 export",
+    )
+    validate.add_argument(
+        "--loadability-only",
+        action="store_true",
+        help="Validate modern files parse and have required structure, but skip equality checks against original assets",
+    )
+    validate.set_defaults(func=cmd_validate_replacements)
 
     return parser
 

--- a/tools/f15assets/cli.py
+++ b/tools/f15assets/cli.py
@@ -14,6 +14,7 @@ try:
         parse_3d3,
         export_3d3_to_gltf,
         export_3d3_to_glb,
+        export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
@@ -29,6 +30,7 @@ except ModuleNotFoundError:
         parse_3d3,
         export_3d3_to_gltf,
         export_3d3_to_glb,
+        export_3d3_gltf_to_glb,
         parse_3dg,
         parse_3dt,
         parse_wld,
@@ -119,6 +121,11 @@ def _write_gltf_binary(path: Path, payload: Dict[str, Any]) -> None:
     path.write_bytes(glb_data)
 
 
+def _write_gltf_binary_doc(path: Path, gltf: Dict[str, Any]) -> None:
+    glb_data = export_3d3_gltf_to_glb(gltf)
+    path.write_bytes(glb_data)
+
+
 def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
     try:
         import yaml
@@ -131,6 +138,45 @@ def _write_yaml(path: Path, payload: Dict[str, Any]) -> None:
 
 def _detect_format(path: Path) -> str:
     return ASSET_EXT_FORMATS.get(path.suffix.lower(), "")
+
+
+def _log_3d3_gltf_diagnostics(gltf: Dict[str, Any], source_path: Path | None) -> None:
+    label = str(source_path) if source_path is not None else "3D3"
+    skipped = gltf.get("extras", {}).get("skipped_shapes", [])
+    if isinstance(skipped, list):
+        for item in skipped:
+            if not isinstance(item, dict):
+                continue
+            meta = item.get("shape_payload")
+            if not isinstance(meta, dict):
+                meta = {}
+            reason = (
+                meta.get("render_error")
+                or meta.get("edge_decode_error")
+                or "no_renderable_primitives"
+            )
+            print(
+                "warning: "
+                f"{label}: skipped shape {item.get('shape_index')} "
+                f"{item.get('shape_name')} "
+                f"offset {item.get('shape_offset')}..{item.get('shape_end')} "
+                f"render_mode={item.get('render_mode')} "
+                f"reason={reason} "
+                f"metadata={json.dumps(meta, sort_keys=True)}",
+                file=sys.stderr,
+            )
+
+    raw_color_usage = gltf.get("extras", {}).get("raw_color_usage", {})
+    point_counts = {}
+    if isinstance(raw_color_usage, dict) and isinstance(raw_color_usage.get("points"), dict):
+        point_counts = raw_color_usage["points"]
+    if point_counts:
+        print(
+            "info: "
+            f"{label}: exported degenerate source lines as POINTS "
+            f"colors={json.dumps(point_counts, sort_keys=True)}",
+            file=sys.stderr,
+        )
 
 
 def _dac6_to_rgb8(data: bytes) -> bytes:
@@ -246,10 +292,12 @@ def _decode_asset(
             gltf_path = Path(args.gltf)
             if gltf_path.suffix.lower() not in {".gltf", ".glb"}:
                 raise ValueError("--gltf expects a .gltf or .glb output path")
+            gltf = export_3d3_to_gltf(payload)
+            _log_3d3_gltf_diagnostics(gltf, source_path)
             if gltf_path.suffix.lower() == ".glb":
-                _write_gltf_binary(gltf_path, payload)
+                _write_gltf_binary_doc(gltf_path, gltf)
             else:
-                _write_gltf(gltf_path, export_3d3_to_gltf(payload), pretty=args.pretty)
+                _write_gltf(gltf_path, gltf, pretty=args.pretty)
         return payload
 
     if fmt == "3DT":

--- a/tools/f15assets/cli.py
+++ b/tools/f15assets/cli.py
@@ -96,6 +96,7 @@ _glb_to_glmesh_bytes = glb_to_glmesh_bytes
 
 
 def _iter_asset_paths(root: Path, recursive: bool):
+    """Yield supported game asset files beneath the requested source path."""
     root = root
     if not root.exists():
         return []
@@ -113,6 +114,7 @@ def _iter_asset_paths(root: Path, recursive: bool):
 
 
 def _read_binary(path: Path) -> bytes:
+    """Read binary from the asset representation."""
     with path.open("rb") as f:
         return f.read()
 
@@ -121,6 +123,7 @@ def _write_json(path: Path, payload: Dict[str, Any], pretty: bool = True, *, med
     # Default converter sidecars are media-first: for 3D3, GLB files are the
     # editable source and JSON is minimized. Full bridge dumps deliberately opt
     # out so runtime can rebuild the legacy byte stream without original .3D3.
+    """Write json in the requested modern representation."""
     writable_payload = _sidecar_payload_for_write(payload) if media_sidecar else payload
     ordered_payload = _human_ordered_payload(writable_payload)
     with path.open("w", encoding="utf-8") as f:
@@ -132,6 +135,7 @@ def _write_json(path: Path, payload: Dict[str, Any], pretty: bool = True, *, med
 
 
 def _sidecar_payload_for_write(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Prepare decoded metadata for a deterministic human-readable sidecar."""
     if payload.get("format") == "PIC":
         out = {
             key: payload[key]
@@ -263,11 +267,13 @@ _RECORD_KEY_ORDER = [
 
 
 def _is_large_json_key(key: object) -> bool:
+    """Return whether large json key."""
     text = str(key)
     return text in _LARGE_JSON_KEYS or text.endswith("_base64")
 
 
 def _ordered_human_mapping(payload: Dict[str, Any], preferred: list[str] | None = None) -> Dict[str, Any]:
+    """Order metadata keys so editable fields precede opaque preservation data."""
     preferred = preferred or []
     out: Dict[str, Any] = {}
     seen = set()
@@ -291,6 +297,7 @@ def _ordered_human_mapping(payload: Dict[str, Any], preferred: list[str] | None 
 
 
 def _human_ordered_payload(value: Any) -> Any:
+    """Recursively reorder metadata for stable, readable JSON output."""
     if isinstance(value, list):
         return [_human_ordered_payload(item) for item in value]
     if not isinstance(value, dict):
@@ -304,6 +311,7 @@ def _human_ordered_payload(value: Any) -> Any:
 
 
 def _write_gltf(path: Path, payload: Dict[str, Any], pretty: bool = True) -> None:
+    """Write gltf in the requested modern representation."""
     with path.open("w", encoding="utf-8") as f:
         if pretty:
             json.dump(payload, f, indent=2, sort_keys=True)
@@ -313,16 +321,19 @@ def _write_gltf(path: Path, payload: Dict[str, Any], pretty: bool = True) -> Non
 
 
 def _write_gltf_binary(path: Path, payload: Dict[str, Any]) -> None:
+    """Write gltf binary in the requested modern representation."""
     glb_data = export_3d3_to_glb(payload)
     path.write_bytes(glb_data)
 
 
 def _write_gltf_binary_doc(path: Path, gltf: Dict[str, Any]) -> None:
+    """Serialize a glTF document and binary payload into one GLB container."""
     glb_data = export_3d3_gltf_to_glb(gltf)
     path.write_bytes(glb_data)
 
 
 def _remove_if_exists(path: Path) -> None:
+    """Implement the remove if exists asset-processing operation."""
     if path.exists():
         try:
             path.unlink()
@@ -331,10 +342,12 @@ def _remove_if_exists(path: Path) -> None:
 
 
 def _detect_format(path: Path) -> str:
+    """Identify an asset format from its extension and binary signature."""
     return ASSET_EXT_FORMATS.get(path.suffix.lower(), "")
 
 
 def _safe_output_stem(value: object) -> str:
+    """Return a portable output stem."""
     text = str(value or "").strip()
     safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in text)
     safe = "_".join(part for part in safe.split("_") if part)
@@ -342,6 +355,7 @@ def _safe_output_stem(value: object) -> str:
 
 
 def _related_world_stem_for_theater_asset(source_path: Path) -> str:
+    """Map a theater-specific asset name to its owning world directory."""
     stem = source_path.stem
     upper_stem = stem.upper()
     wld_stem = THEATER_WLD_STEM_ALIASES.get(upper_stem, upper_stem)
@@ -353,6 +367,7 @@ def _related_world_stem_for_theater_asset(source_path: Path) -> str:
 
 
 def _asset_output_dir(src: Path, relative: Path, input_root: Path, output_root: Path, fmt: str) -> Path:
+    """Choose the self-contained output directory for one source asset."""
     parent = output_root / relative.parent
     if fmt == "WLD":
         return parent / src.stem
@@ -368,6 +383,7 @@ def _write_3d3_shape_models(
     pretty: bool,
     write_cache: bool = False,
 ) -> None:
+    """Export each decoded 3D3 shape as an independently editable GLB file."""
     if model_format == "none":
         return
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -392,6 +408,7 @@ def _write_3d3_shape_models(
 
 
 def _log_3d3_gltf_diagnostics(gltf: Dict[str, Any], source_path: Path | None) -> None:
+    """Report suspicious or skipped 3D3 shape slots without aborting conversion."""
     label = str(source_path) if source_path is not None else "3D3"
     skipped = gltf.get("extras", {}).get("skipped_shapes", [])
     if isinstance(skipped, list):
@@ -431,10 +448,12 @@ def _log_3d3_gltf_diagnostics(gltf: Dict[str, Any], source_path: Path | None) ->
 
 
 def _dac6_to_rgb8(data: bytes) -> bytes:
+    """Implement the dac6 to rgb8 asset-processing operation."""
     return bytes(((value & 0x3F) << 2) | ((value & 0x3F) >> 4) for value in data[:768])
 
 
 def _find_external_palette(source_path: Path) -> tuple[Path, bytes, str] | None:
+    """Locate external palette using the converter search rules."""
     same_stem = source_path.with_suffix(".PAL")
     if same_stem.exists() and same_stem.stat().st_size >= 768:
         return same_stem, same_stem.read_bytes()[:768], "same_stem_pal"
@@ -464,6 +483,7 @@ def _find_external_palette(source_path: Path) -> tuple[Path, bytes, str] | None:
 
 
 def _attach_external_palette(payload: Dict[str, Any], source_path: Path | None) -> None:
+    """Attach the best matching external palette to an indexed image asset."""
     if source_path is None:
         return
     profile = payload.get("palette_profile")
@@ -512,6 +532,7 @@ def _decode_asset(
     args: argparse.Namespace,
     source_path: Path | None = None,
 ) -> Dict[str, Any]:
+    """Decode one legacy asset and return normalized metadata plus media outputs."""
     if args.png and fmt != "PIC":
         raise ValueError("--png is only supported for PIC/SPR inputs")
 
@@ -579,6 +600,7 @@ def _decode_asset(
 
 
 def _load_shape_names_for_3d3(source_path: Path) -> Dict[str, str]:
+    """Load stable shape names associated with a 3D3 model table."""
     stem = source_path.stem.upper()
     wld_stem = THEATER_WLD_STEM_ALIASES.get(stem, stem)
     wld_path = source_path.with_name(f"{wld_stem}.WLD")
@@ -611,10 +633,12 @@ def _load_shape_names_for_3d3(source_path: Path) -> Dict[str, str]:
 
 
 def _decode_args(png: str | None = None, gltf: str | None = None, pretty: bool = False) -> argparse.Namespace:
+    """Translate command-line decode options into decoder keyword arguments."""
     return argparse.Namespace(png=png, gltf=gltf, pretty=pretty)
 
 
 def _minimize_3d3_json(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove geometry duplicated by per-shape GLB files from a 3D3 sidecar."""
     shared_pool = payload.get("shared_vertex_pool")
     shared_pool_summary = None
     if isinstance(shared_pool, dict):
@@ -645,6 +669,7 @@ def _minimize_3d3_json(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def cmd_decode(args: argparse.Namespace) -> int:
+    """Implement the single-asset decode command."""
     fmt = args.format.upper() if args.format else _detect_format(Path(args.input))
     if not fmt:
         raise ValueError("cannot detect format from extension; pass --format")
@@ -656,6 +681,7 @@ def cmd_decode(args: argparse.Namespace) -> int:
 
 
 def cmd_convert_tree(args: argparse.Namespace) -> int:
+    """Implement recursive conversion of a game asset tree."""
     input_root = Path(args.input)
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
@@ -755,6 +781,7 @@ def cmd_convert_tree(args: argparse.Namespace) -> int:
 
 
 def cmd_export_fonts(args: argparse.Namespace) -> int:
+    """Implement export of legacy bitmap fonts to editable modern files."""
     repo_root = Path(args.repo_root)
     output_root = Path(args.output)
     if not (repo_root / "src" / "fontdata.h").exists():
@@ -774,6 +801,7 @@ def cmd_export_fonts(args: argparse.Namespace) -> int:
 
 
 def cmd_export_sounds(args: argparse.Namespace) -> int:
+    """Implement export of digitized cues and music streams."""
     input_root = Path(args.input)
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
@@ -791,6 +819,7 @@ def cmd_export_sounds(args: argparse.Namespace) -> int:
 
 
 def cmd_build_binary(args: argparse.Namespace) -> int:
+    """Implement reconstruction of a legacy binary from editable metadata."""
     json_path = Path(args.json)
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     fmt = args.format.upper() if args.format else str(payload.get("format", "")).upper()
@@ -825,6 +854,7 @@ def cmd_build_binary(args: argparse.Namespace) -> int:
 
 
 def _structured_json_path(src: Path, relative: Path, input_root: Path, output_root: Path, fmt: str) -> Path:
+    """Implement the structured json path asset-processing operation."""
     if fmt in {"WLD", "3D3", "3DT", "3DG"}:
         output_base = _asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
         return output_base.with_name(output_base.name + ".json")
@@ -860,6 +890,7 @@ def _structured_json_path(src: Path, relative: Path, input_root: Path, output_ro
 
 
 def cmd_build_glmesh(args: argparse.Namespace) -> int:
+    """Implement generation of the runtime GL mesh cache from a GLB model."""
     sys.stdout.buffer.write(glb_to_glmesh_bytes(Path(args.glb)))
     return 0
 
@@ -867,6 +898,7 @@ def cmd_build_glmesh(args: argparse.Namespace) -> int:
 
 
 def cmd_validate_replacements(args: argparse.Namespace) -> int:
+    """Implement exhaustive legacy-versus-replacement asset validation."""
     input_root = Path(args.input)
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
@@ -981,10 +1013,12 @@ def cmd_validate_replacements(args: argparse.Namespace) -> int:
 
 
 def _repo_root_from_tool() -> Path:
+    """Implement the repo root from tool asset-processing operation."""
     return Path(__file__).resolve().parents[2]
 
 
 def cmd_convert_all(args: argparse.Namespace) -> int:
+    """Convert every supported asset using only source and destination directories."""
     input_root = Path(args.input)
     output_root = Path(args.output)
     if not input_root.exists() or not input_root.is_dir():
@@ -1032,6 +1066,7 @@ def cmd_convert_all(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser and register all asset-tool subcommands."""
     parser = argparse.ArgumentParser(
         description="F-15 asset converter (forward-only: game binary -> modern editable outputs)"
     )
@@ -1246,6 +1281,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the asset-tool command-line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
     try:

--- a/tools/f15assets/f15assets/__init__.py
+++ b/tools/f15assets/f15assets/__init__.py
@@ -2,7 +2,7 @@
 
 from .pic import decode_pic_asset, decode_title640_pic_asset, encode_pic_asset
 from .model3d import build_3d3, export_3d3_to_gltf, parse_3d3
-from .model3d import export_3d3_to_glb
+from .model3d import export_3d3_gltf_to_glb, export_3d3_to_glb
 from .terrain import parse_3dg, build_3dg, parse_3dt, build_3dt
 from .world import parse_wld, build_wld
 from .fonts import export_fonts, load_font_assets
@@ -15,6 +15,7 @@ __all__ = [
     "parse_3d3",
     "build_3d3",
     "export_3d3_to_gltf",
+    "export_3d3_gltf_to_glb",
     "export_3d3_to_glb",
     "parse_3dg",
     "build_3dg",

--- a/tools/f15assets/f15assets/__init__.py
+++ b/tools/f15assets/f15assets/__init__.py
@@ -1,12 +1,17 @@
 """Asset converters for F-15 Strike Eagle II formats."""
 
 from .pic import decode_pic_asset, decode_title640_pic_asset, encode_pic_asset
-from .model3d import build_3d3, export_3d3_to_gltf, parse_3d3
+from .model3d import build_3d3, export_3d3_shape_gltfs, export_3d3_to_gltf, parse_3d3
 from .model3d import export_3d3_gltf_to_glb, export_3d3_to_glb
 from .terrain import parse_3dg, build_3dg, parse_3dt, build_3dt
 from .world import parse_wld, build_wld
 from .fonts import export_fonts, load_font_assets
 from .sounds import export_sounds, decode_digitized_blob
+from .validation_image import validate_pic_png_replacement, validate_png_replacement_loadability
+from .validation_font import validate_font_replacements
+from .validation_sound import validate_sound_replacements
+from .validation_structured import validate_structured_json_replacements
+from .validation_model3d import glb_to_glmesh_bytes, validate_3d3_glb_replacements
 
 __all__ = [
     "decode_pic_asset",
@@ -14,6 +19,7 @@ __all__ = [
     "encode_pic_asset",
     "parse_3d3",
     "build_3d3",
+    "export_3d3_shape_gltfs",
     "export_3d3_to_gltf",
     "export_3d3_gltf_to_glb",
     "export_3d3_to_glb",
@@ -27,4 +33,11 @@ __all__ = [
     "load_font_assets",
     "export_sounds",
     "decode_digitized_blob",
+    "validate_pic_png_replacement",
+    "validate_png_replacement_loadability",
+    "validate_font_replacements",
+    "validate_sound_replacements",
+    "validate_structured_json_replacements",
+    "glb_to_glmesh_bytes",
+    "validate_3d3_glb_replacements",
 ]

--- a/tools/f15assets/f15assets/fonts.py
+++ b/tools/f15assets/f15assets/fonts.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import base64
 import json
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
-
-from .io import to_base64
 
 FONT_CODEPOINT_START = 0x20
 FONT_CODEPOINT_COUNT = 96
@@ -15,6 +12,189 @@ FONT_CODEPOINT_COUNT = 96
 # Unicode without losing the original byte mapping.
 ATLAS_COLUMNS = 16
 ATLAS_PADDING = 1
+
+# The original game has no Cyrillic source glyphs. Export Russian glyphs as
+# explicit 5x7 bitmap templates instead of borrowing Latin letters: letters such
+# as И/Й must have their diagonal in the Cyrillic direction, and shapes such as
+# Д/Л/Я/Ю do not have safe Latin equivalents. The templates are downsampled or
+# centred into each recovered font's cell size, so every font_<id>.bdf receives
+# the same Unicode coverage while preserving its original height/width limits.
+CYRILLIC_5X7 = {
+    0x0401: ["01010", "11111", "10000", "11110", "10000", "10000", "11111"],
+    0x0410: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+    0x0411: ["11111", "10000", "10000", "11110", "10001", "10001", "11110"],
+    0x0412: ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
+    0x0413: ["11111", "10000", "10000", "10000", "10000", "10000", "10000"],
+    0x0414: ["01111", "01001", "01001", "01001", "01001", "11111", "10001"],
+    0x0415: ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+    0x0416: ["10101", "10101", "10101", "01110", "10101", "10101", "10101"],
+    0x0417: ["11110", "00001", "00001", "01110", "00001", "00001", "11110"],
+    0x0418: ["10001", "10011", "10101", "10101", "11001", "10001", "10001"],
+    0x0419: ["01010", "10001", "10011", "10101", "11001", "10001", "10001"],
+    0x041A: ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+    0x041B: ["01111", "01001", "01001", "01001", "01001", "01001", "10001"],
+    0x041C: ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+    0x041D: ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
+    0x041E: ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+    0x041F: ["11111", "10001", "10001", "10001", "10001", "10001", "10001"],
+    0x0420: ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+    0x0421: ["01111", "10000", "10000", "10000", "10000", "10000", "01111"],
+    0x0422: ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+    0x0423: ["10001", "10001", "10001", "01111", "00001", "00001", "11110"],
+    0x0424: ["00100", "01110", "10101", "10101", "01110", "00100", "00100"],
+    0x0425: ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
+    0x0426: ["10001", "10001", "10001", "10001", "10001", "11111", "00001"],
+    0x0427: ["10001", "10001", "10001", "01111", "00001", "00001", "00001"],
+    0x0428: ["10101", "10101", "10101", "10101", "10101", "10101", "11111"],
+    0x0429: ["10101", "10101", "10101", "10101", "10101", "11111", "00001"],
+    0x042A: ["11000", "01000", "01000", "01110", "01001", "01001", "01110"],
+    0x042B: ["10001", "10001", "10001", "11101", "10011", "10011", "11101"],
+    0x042C: ["10000", "10000", "10000", "11110", "10001", "10001", "11110"],
+    0x042D: ["11110", "00001", "00001", "01111", "00001", "00001", "11110"],
+    0x042E: ["10010", "10101", "10101", "11101", "10101", "10101", "10010"],
+    0x042F: ["01111", "10001", "10001", "01111", "00101", "01001", "10001"],
+}
+
+CYRILLIC_LOWER_TO_UPPER = {
+    0x0451: 0x0401,
+    **{codepoint + 0x20: codepoint for codepoint in range(0x0410, 0x0430)},
+}
+
+CYRILLIC_LOWER_5X7 = {
+    0x0451: ["01010", "00000", "01110", "10001", "11111", "10000", "01110"],
+    0x0430: ["00000", "00000", "01110", "00001", "01111", "10001", "01111"],
+    0x0431: ["00111", "01000", "10000", "11110", "10001", "10001", "01110"],
+    0x0432: ["00000", "00000", "11110", "10001", "11110", "10001", "11110"],
+    0x0433: ["00000", "00000", "11111", "10000", "10000", "10000", "10000"],
+    0x0434: ["00000", "00000", "01111", "01001", "01001", "11111", "10001"],
+    0x0435: ["00000", "00000", "01110", "10001", "11111", "10000", "01110"],
+    0x0436: ["00000", "00000", "10101", "10101", "01110", "10101", "10101"],
+    0x0437: ["00000", "00000", "11110", "00001", "01110", "00001", "11110"],
+    0x0438: ["00000", "00000", "10001", "10011", "10101", "11001", "10001"],
+    0x0439: ["01010", "00100", "10001", "10011", "10101", "11001", "10001"],
+    0x043A: ["00000", "00000", "10001", "10010", "11100", "10010", "10001"],
+    0x043B: ["00000", "00000", "01111", "01001", "01001", "01001", "10001"],
+    0x043C: ["00000", "00000", "10001", "11011", "10101", "10001", "10001"],
+    0x043D: ["00000", "00000", "10001", "10001", "11111", "10001", "10001"],
+    0x043E: ["00000", "00000", "01110", "10001", "10001", "10001", "01110"],
+    0x043F: ["00000", "00000", "11111", "10001", "10001", "10001", "10001"],
+    0x0440: ["00000", "00000", "11110", "10001", "11110", "10000", "10000"],
+    0x0441: ["00000", "00000", "01111", "10000", "10000", "10000", "01111"],
+    0x0442: ["00000", "00000", "11111", "00100", "00100", "00100", "00100"],
+    0x0443: ["00000", "00000", "10001", "10001", "01111", "00001", "11110"],
+    0x0444: ["00000", "00100", "01110", "10101", "10101", "01110", "00100"],
+    0x0445: ["00000", "00000", "10001", "01010", "00100", "01010", "10001"],
+    0x0446: ["00000", "00000", "10001", "10001", "10001", "11111", "00001"],
+    0x0447: ["00000", "00000", "10001", "10001", "01111", "00001", "00001"],
+    0x0448: ["00000", "00000", "10101", "10101", "10101", "10101", "11111"],
+    0x0449: ["00000", "00000", "10101", "10101", "10101", "11111", "00001"],
+    0x044A: ["00000", "00000", "11000", "01000", "01110", "01001", "01110"],
+    0x044B: ["00000", "00000", "10001", "10001", "11101", "10011", "11101"],
+    0x044C: ["00000", "00000", "10000", "10000", "11110", "10001", "11110"],
+    0x044D: ["00000", "00000", "11110", "00001", "01111", "00001", "11110"],
+    0x044E: ["00000", "00000", "10010", "10101", "11101", "10101", "10010"],
+    0x044F: ["00000", "00000", "01111", "10001", "01111", "00101", "10001"],
+}
+
+CYRILLIC_4X5 = {
+    0x0414: ["0111", "0101", "0101", "1111", "1001"],
+    0x0416: ["1010", "1010", "0100", "1010", "1010"],
+    0x041B: ["0111", "0101", "0101", "0101", "1001"],
+    0x041E: ["0110", "1001", "1001", "1001", "0110"],
+    0x0421: ["0111", "1000", "1000", "1000", "0111"],
+    0x0426: ["1001", "1001", "1001", "1111", "0001"],
+    0x0428: ["1001", "1001", "1011", "1011", "1111"],
+    0x0429: ["1001", "1001", "1011", "1111", "0001"],
+    0x042D: ["1110", "0001", "0111", "0001", "1110"],
+    0x042E: ["1010", "1011", "1111", "1011", "1010"],
+    0x042F: ["0111", "1001", "0111", "0101", "1001"],
+    0x0436: ["1010", "1010", "0100", "1010", "1010"],
+    0x0448: ["1001", "1001", "1011", "1011", "1111"],
+    0x0449: ["1001", "1001", "1011", "1111", "0001"],
+}
+
+LATIN_EXTENDED_4X5 = {
+    0x00C1: ["0010", "0110", "1001", "1111", "1001"],  # Á
+    0x00E4: ["1010", "0110", "0001", "0111", "0111"],  # ä
+    0x00E1: ["0010", "0110", "0001", "0111", "0111"],  # á
+    0x00C9: ["0010", "1111", "1000", "1110", "1111"],  # É
+    0x00E9: ["0010", "0110", "1111", "1000", "0111"],  # é
+    0x00F6: ["1010", "0110", "1001", "1001", "0110"],  # ö
+    0x00FC: ["1010", "1001", "1001", "1001", "0111"],  # ü
+    0x0104: ["0110", "1001", "1111", "1001", "1011"],  # Ą
+    0x0105: ["0110", "0001", "0111", "1001", "0011"],  # ą
+    0x0106: ["0010", "0111", "1000", "1000", "0111"],  # Ć
+    0x0107: ["0010", "0111", "1000", "1000", "0111"],  # ć
+    0x010C: ["1010", "0111", "1000", "1000", "0111"],  # Č
+    0x010D: ["1010", "0111", "1000", "1000", "0111"],  # č
+    0x0110: ["1110", "1011", "1011", "1011", "1110"],  # Đ
+    0x0111: ["0010", "1110", "1011", "1011", "1110"],  # đ
+    0x0118: ["1111", "1000", "1110", "1000", "1111"],  # Ę
+    0x0119: ["0111", "1000", "1110", "1000", "0111"],  # ę
+    0x0141: ["1000", "1010", "1100", "1000", "1111"],  # Ł
+    0x0142: ["1000", "1010", "1100", "1000", "1000"],  # ł
+    0x0143: ["0010", "1001", "1101", "1011", "1001"],  # Ń
+    0x0144: ["0010", "1110", "1001", "1001", "1001"],  # ń
+    0x00D3: ["0010", "0110", "1001", "1001", "0110"],  # Ó
+    0x00F3: ["0010", "0110", "1001", "1001", "0110"],  # ó
+    0x015A: ["0010", "1111", "1000", "0110", "1110"],  # Ś
+    0x015B: ["0010", "1110", "1100", "0010", "1110"],  # ś
+    0x0160: ["1010", "1111", "1000", "0110", "1110"],  # Š
+    0x0161: ["1010", "1110", "1100", "0010", "1110"],  # š
+    0x0179: ["0010", "1111", "0010", "0100", "1111"],  # Ź
+    0x017A: ["0010", "1111", "0010", "0100", "1111"],  # ź
+    0x017B: ["0010", "1111", "0010", "0100", "1111"],  # Ż
+    0x017C: ["0010", "1111", "0010", "0100", "1111"],  # ż
+    0x017D: ["1010", "1111", "0010", "0100", "1111"],  # Ž
+    0x017E: ["1010", "1111", "0010", "0100", "1111"],  # ž
+}
+
+LATIN_EXTENDED_8X8 = {
+    0x0104: ["00110000", "01001000", "10000100", "11111100", "10000100", "10000100", "10000100", "00001000"],  # Ą
+    0x0105: ["00000000", "00000000", "01111000", "00000100", "01111100", "10000100", "01111100", "00001000"],  # ą
+    0x0118: ["11111100", "10000000", "10000000", "11111000", "10000000", "10000000", "11111100", "00001000"],  # Ę
+    0x0119: ["00000000", "00000000", "01111000", "10000100", "11111100", "10000000", "01111000", "00001000"],  # ę
+    0x0110: ["11110000", "10001000", "10001000", "11111000", "10001000", "10001000", "11110000", "00000000"],  # Đ
+    0x0111: ["00001000", "00111100", "00001000", "01111000", "10001000", "10001000", "01111000", "00000000"],  # đ
+    0x0141: ["10000000", "10000000", "10010000", "10100000", "11000000", "10000000", "11111000", "00000000"],  # Ł
+    0x0142: ["10000000", "10000000", "10010000", "10100000", "11000000", "10000000", "10000000", "00000000"],  # ł
+    0x0179: ["00010000", "11111100", "00001000", "00010000", "00100000", "01000000", "11111100", "00000000"],  # Ź
+    0x017A: ["00010000", "00000000", "11111000", "00010000", "00100000", "01000000", "11111000", "00000000"],  # ź
+    0x017B: ["00010000", "11111100", "00001000", "00010000", "00100000", "01000000", "11111100", "00000000"],  # Ż
+    0x017C: ["00010000", "00000000", "11111000", "00010000", "00100000", "01000000", "11111000", "00000000"],  # ż
+    0x017D: ["00101000", "00010000", "11111100", "00001000", "00010000", "00100000", "11111100", "00000000"],  # Ž
+    0x017E: ["00101000", "00010000", "11111000", "00010000", "00100000", "01000000", "11111000", "00000000"],  # ž
+}
+
+# German and Polish letters are generated from each font's own ASCII Latin
+# glyphs, then accented in-place. This keeps the recovered font style instead
+# of replacing letters with a generic Unicode font. The BDF remains the source
+# of truth for authors who want to hand-tune any generated glyph.
+LATIN_EXTENDED_GLYPHS = {
+    # German
+    0x00C4: ("A", "diaeresis"), 0x00D6: ("O", "diaeresis"),
+    0x00DC: ("U", "diaeresis"), 0x00DF: ("B", "eszett"),
+    0x00E4: ("a", "diaeresis"), 0x00F6: ("o", "diaeresis"),
+    0x00FC: ("u", "diaeresis"), 0x1E9E: ("B", "eszett"),
+    # Acute Latin letters useful for localized custom text.
+    0x00C1: ("A", "acute"), 0x00E1: ("a", "acute"),
+    0x00C9: ("E", "acute"), 0x00E9: ("e", "acute"),
+    # Polish
+    0x0104: ("A", "ogonek"), 0x0105: ("a", "ogonek"),
+    0x0106: ("C", "acute"), 0x0107: ("c", "acute"),
+    # Serbian Latin
+    0x010C: ("C", "caron"), 0x010D: ("c", "caron"),
+    0x0110: ("D", "slash"), 0x0111: ("d", "slash"),
+    0x0118: ("E", "ogonek"), 0x0119: ("e", "ogonek"),
+    0x0141: ("L", "slash"), 0x0142: ("l", "slash"),
+    0x0143: ("N", "acute"), 0x0144: ("n", "acute"),
+    0x00D3: ("O", "acute"), 0x00F3: ("o", "acute"),
+    0x015A: ("S", "acute"), 0x015B: ("s", "acute"),
+    0x0160: ("S", "caron"), 0x0161: ("s", "caron"),
+    0x0179: ("Z", "acute"), 0x017A: ("z", "acute"),
+    0x017B: ("Z", "dot"), 0x017C: ("z", "dot"),
+    0x017D: ("Z", "caron"), 0x017E: ("z", "caron"),
+}
 
 
 def _extract_c_initializer(text: str, decl_pattern: str) -> str | None:
@@ -112,12 +292,12 @@ def load_font_assets(repo_root: Path) -> Dict[int, Dict[str, Any]]:
             "cell_width": cell_width,
             "height": height,
             "source_files": [
-                str(fontdata_path),
-                str(gfx_impl_path),
+                "src/fontdata.h",
+                "src/gfx_impl.c",
             ],
             "source_sha256": {
-                str(fontdata_path): _font_source_hash(fontdata_path),
-                str(gfx_impl_path): _font_source_hash(gfx_impl_path),
+                "src/fontdata.h": _font_source_hash(fontdata_path),
+                "src/gfx_impl.c": _font_source_hash(gfx_impl_path),
             },
         }
     return fonts
@@ -163,7 +343,6 @@ def _build_atlas(font: Dict[str, Any]) -> Tuple["Image.Image", Dict[str, Any]]:
                 "bitmap_width": cell_width,
                 "bitmap_height": height,
                 "advance_width": int(font["advance_widths"][idx]),
-                "bitmap_rows_base64": to_base64(bytes(glyph_rows)),
             }
         )
     metadata = {
@@ -182,9 +361,9 @@ def _build_atlas(font: Dict[str, Any]) -> Tuple["Image.Image", Dict[str, Any]]:
         "atlas_mode": "indexed_1bit_black_white",
         "authoring_formats": ["bdf", "png_atlas_json"],
         "notes": (
-            "Glyphs are exported with Unicode codepoints. Original game bytes "
-            "are preserved as source_byte/source_encoding so additional language "
-            "glyphs can be added without losing legacy mapping."
+            "Glyph shapes are stored in the BDF and PNG atlas. JSON is only "
+            "supplemental atlas/index metadata and must not override BDF/PNG "
+            "glyph data."
         ),
         "source_files": font["source_files"],
         "source_sha256": font["source_sha256"],
@@ -198,20 +377,165 @@ def _glyph_bdf_bitmap(glyph_rows: List[int], width: int) -> List[str]:
     return [f"{row & 0xFF:0{hex_width}X}" for row in glyph_rows]
 
 
+def _cyrillic_template(codepoint: int) -> List[str]:
+    if codepoint in CYRILLIC_LOWER_5X7:
+        return CYRILLIC_LOWER_5X7[codepoint]
+    upper = CYRILLIC_LOWER_TO_UPPER.get(codepoint, codepoint)
+    return CYRILLIC_5X7[upper]
+
+
+def _scale_template_columns(row: str, width: int) -> str:
+    if width == len(row):
+        return row
+    if width <= 0:
+        return ""
+    scaled = []
+    for x in range(width):
+        start = int(x * len(row) / width)
+        end = int((x + 1) * len(row) / width)
+        if end <= start:
+            end = start + 1
+        scaled.append("1" if "1" in row[start:end] else "0")
+    return "".join(scaled)
+
+
+def _template_to_glyph_rows(template: List[str], cell_width: int, height: int) -> List[int]:
+    draw_width = max(1, min(5, cell_width))
+    x_offset = max(0, (cell_width - draw_width) // 2)
+    rows: List[int] = []
+    for y in range(height):
+        if len(template) == 7 and height == 6:
+            # The 6-row menu fonts need the centre row preserved; simple
+            # rounding skips it and damages Э/З/Я-like glyphs.
+            src_y = [0, 1, 2, 3, 5, 6][y]
+        else:
+            src_y = round(y * (len(template) - 1) / max(1, height - 1))
+        scaled = _scale_template_columns(template[src_y], draw_width)
+        bits = 0
+        for x, pixel in enumerate(scaled):
+            if pixel == "1" and x + x_offset < 8:
+                bits |= 0x80 >> (x + x_offset)
+        rows.append(bits)
+    return rows
+
+
+def _cyrillic_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], int]:
+    cell_width = int(font["cell_width"])
+    height = int(font["height"])
+    template = CYRILLIC_4X5.get(codepoint) if cell_width <= 4 and height <= 5 else None
+    if template is None:
+        template = _cyrillic_template(codepoint)
+        if codepoint in CYRILLIC_LOWER_5X7 and height < 7:
+            # Lowercase Russian letters in a 5/6-row font should not spend two
+            # rows on empty ascenders; trim them so small letters remain legible.
+            while len(template) > 1 and template[0].count("1") == 0:
+                template = template[1:]
+    rows = _template_to_glyph_rows(template or _cyrillic_template(codepoint), cell_width, height)
+    # Match the recovered font's normal uppercase advance where possible. This
+    # keeps Russian UI text layout close to existing Latin menu text while BDF
+    # still allows authors to tune individual advances by hand.
+    advance_idx = ord("M") - FONT_CODEPOINT_START
+    advance = int(font["advance_widths"][advance_idx])
+    return rows, max(1, min(255, advance))
+
+
+def _ascii_glyph(font: Dict[str, Any], source_char: str) -> Tuple[List[int], int]:
+    idx = ord(source_char) - FONT_CODEPOINT_START
+    if idx < 0 or idx >= FONT_CODEPOINT_COUNT:
+        idx = ord("?") - FONT_CODEPOINT_START
+    return list(font["glyphs"][idx]), int(font["advance_widths"][idx])
+
+
+def _set_pixel(rows: List[int], x: int, y: int, cell_width: int) -> None:
+    if 0 <= y < len(rows) and 0 <= x < min(cell_width, 8):
+        rows[y] |= 0x80 >> x
+
+
+def _overlay_mark(rows: List[int], cell_width: int, mark: str) -> None:
+    width = min(cell_width, 8)
+    if width <= 0 or not rows:
+        return
+    mid = width // 2
+    right = width - 1
+    if mark == "diaeresis":
+        _set_pixel(rows, max(0, mid - 2), 0, cell_width)
+        _set_pixel(rows, min(right, mid + 1), 0, cell_width)
+    elif mark == "acute":
+        _set_pixel(rows, min(right, mid + 1), 0, cell_width)
+        if len(rows) > 1:
+            _set_pixel(rows, mid, 1, cell_width)
+    elif mark == "caron":
+        lit_columns = [
+            x
+            for row in rows[1:]
+            for x in range(width)
+            if row & (0x80 >> x)
+        ]
+        if lit_columns:
+            mid = (min(lit_columns) + max(lit_columns)) // 2
+        _set_pixel(rows, max(0, mid - 1), 0, cell_width)
+        _set_pixel(rows, mid, min(1, len(rows) - 1), cell_width)
+        _set_pixel(rows, min(right, mid + 1), 0, cell_width)
+    elif mark == "dot":
+        _set_pixel(rows, mid, 0, cell_width)
+    elif mark == "ogonek":
+        _set_pixel(rows, max(0, right - 1), len(rows) - 1, cell_width)
+        if len(rows) > 1:
+            _set_pixel(rows, right, len(rows) - 2, cell_width)
+    elif mark == "slash":
+        # Polish Ł/ł and Serbian Đ/đ use a crossbar/diagonal through the stem.
+        # It should sit around the optical middle, slightly high; placing it
+        # near the bottom reads like a descender instead of a letter mark.
+        y0 = 1 if len(rows) <= 5 else max(1, len(rows) // 2 - 2)
+        _set_pixel(rows, min(right, mid + 1), y0, cell_width)
+        _set_pixel(rows, mid, min(len(rows) - 1, y0 + 1), cell_width)
+        if width > 4:
+            _set_pixel(rows, max(0, mid - 1), min(len(rows) - 1, y0 + 2), cell_width)
+
+
+def _latin_extended_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], int]:
+    source_char, mark = LATIN_EXTENDED_GLYPHS[codepoint]
+    cell_width = int(font["cell_width"])
+    height = int(font["height"])
+    if codepoint in LATIN_EXTENDED_4X5 and cell_width <= 4 and height <= 5:
+        rows = _template_to_glyph_rows(LATIN_EXTENDED_4X5[codepoint], cell_width, height)
+        _, advance = _ascii_glyph(font, source_char)
+        return rows, max(1, min(255, advance))
+    if mark == "eszett":
+        rows = _template_to_glyph_rows(
+            ["01110", "10001", "10000", "11110", "10001", "10001", "11110"],
+            cell_width,
+            height,
+        )
+        _, advance = _ascii_glyph(font, source_char)
+        return rows, max(1, min(255, advance))
+    rows, advance = _ascii_glyph(font, source_char)
+    if mark in {"acute", "caron", "diaeresis", "dot"} and len(rows) > 5:
+        # Reserve the first row for the accent. Without this, the mark is ORed
+        # into an already-lit uppercase row (for example Z/Ž), which makes the
+        # accent look shifted right or glued to the letter.
+        rows = [0] + rows[:-1]
+    _overlay_mark(rows, int(font["cell_width"]), mark)
+    return rows, max(1, min(255, advance))
+
+
 def build_bdf(font: Dict[str, Any]) -> str:
     font_id = int(font["font_id"])
     width = int(font["cell_width"])
     height = int(font["height"])
+    cyrillic_codepoints = sorted(CYRILLIC_5X7) + sorted(CYRILLIC_LOWER_TO_UPPER)
+    latin_codepoints = sorted(LATIN_EXTENDED_GLYPHS)
+    extra_codepoints = cyrillic_codepoints + latin_codepoints
     lines = [
         "STARTFONT 2.1",
-        f"FONT -MicroProse-F15SE2-Font{font_id}-Medium-R-Normal--{height * 10}-100-75-75-C-{width * 10}-CP437",
+        f"FONT -MicroProse-F15SE2-Font{font_id}-Medium-R-Normal--{height * 10}-100-75-75-C-{width * 10}-Unicode",
         f"SIZE {height} 75 75",
         f"FONTBOUNDINGBOX {width} {height} 0 0",
         f"STARTPROPERTIES 2",
         f"FONT_ASCENT {height}",
         "FONT_DESCENT 0",
         "ENDPROPERTIES",
-        f"CHARS {FONT_CODEPOINT_COUNT}",
+        f"CHARS {FONT_CODEPOINT_COUNT + len(extra_codepoints)}",
     ]
     for idx, glyph_rows in enumerate(font["glyphs"]):
         codepoint = FONT_CODEPOINT_START + idx
@@ -228,36 +552,72 @@ def build_bdf(font: Dict[str, Any]) -> str:
                 "ENDCHAR",
             ]
         )
+    for codepoint in extra_codepoints:
+        if codepoint in LATIN_EXTENDED_GLYPHS:
+            glyph_rows, advance = _latin_extended_glyph(font, codepoint)
+        else:
+            glyph_rows, advance = _cyrillic_glyph(font, codepoint)
+        lines.extend(
+            [
+                f"STARTCHAR U+{codepoint:04X}",
+                f"ENCODING {codepoint}",
+                f"SWIDTH {advance * 100} 0",
+                f"DWIDTH {advance} 0",
+                f"BBX {width} {height} 0 0",
+                "BITMAP",
+                *_glyph_bdf_bitmap(glyph_rows, width),
+                "ENDCHAR",
+            ]
+        )
     lines.extend(["ENDFONT", ""])
     return "\n".join(lines)
 
 
-def export_fonts(repo_root: Path, output_root: Path, *, write_bdf: bool = True) -> Dict[str, Any]:
+def export_fonts(
+    repo_root: Path,
+    output_root: Path,
+    *,
+    write_bdf: bool = True,
+    include_metadata: bool = False,
+) -> Dict[str, Any]:
     output_root.mkdir(parents=True, exist_ok=True)
     fonts = load_font_assets(repo_root)
     exported = []
     for font_id, font in sorted(fonts.items()):
-        image, metadata = _build_atlas(font)
         stem = f"font_{font_id}"
         png_path = output_root / f"{stem}.png"
         json_path = output_root / f"{stem}.json"
-        image.save(png_path)
-        json_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if png_path.exists():
+            png_path.unlink()
+        if include_metadata:
+            _image, metadata = _build_atlas(font)
+            json_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        elif json_path.exists():
+            json_path.unlink()
         bdf_path = None
         if write_bdf:
             bdf_path = output_root / f"{stem}.bdf"
             bdf_path.write_text(build_bdf(font), encoding="ascii")
-        exported.append(
-            {
-                "font_id": font_id,
-                "png": str(png_path),
-                "json": str(json_path),
-                "bdf": str(bdf_path) if bdf_path is not None else None,
-            }
-        )
+        record = {
+            "font_id": font_id,
+            "source": "repository_font_tables",
+            # The index is meant to travel with the exported font folder, so
+            # keep paths relative instead of baking in a developer machine's
+            # checkout/output directory.
+            "bdf": bdf_path.name if bdf_path is not None else None,
+        }
+        if include_metadata:
+            record["json"] = json_path.name
+        exported.append(record)
     return {
         "format": "F15_FONT_EXPORT_INDEX",
         "version": 1,
-        "source": str(repo_root),
+        "source": "repository_font_tables",
+        "authoring_source": "font_<id>.bdf",
+        "runtime_authoritative": "font_<id>.bdf",
+        "notes": (
+            "Edit BDF for glyph pixels, Unicode codepoints, and advance widths. "
+            "Per-font JSON is optional metadata and is not used by the runtime loader."
+        ),
         "exported": exported,
     }

--- a/tools/f15assets/f15assets/fonts.py
+++ b/tools/f15assets/f15assets/fonts.py
@@ -198,6 +198,7 @@ LATIN_EXTENDED_GLYPHS = {
 
 
 def _extract_c_initializer(text: str, decl_pattern: str) -> str | None:
+    """Extract c initializer."""
     match = re.search(decl_pattern, text, re.S)
     if not match:
         return None
@@ -216,10 +217,12 @@ def _extract_c_initializer(text: str, decl_pattern: str) -> str | None:
 
 
 def _parse_int_tokens(text: str) -> List[int]:
+    """Parse int tokens."""
     return [int(token, 0) for token in re.findall(r"0x[0-9a-fA-F]+|\b\d+\b", text)]
 
 
 def _parse_font_bitmaps(fontdata_text: str) -> Dict[int, List[List[int]]]:
+    """Parse font bitmaps."""
     fonts: Dict[int, List[List[int]]] = {}
     for match in re.finditer(r"g_font(\d+)_bitmaps\s*\[96\]\[(\d+)\]\s*=\s*\{", fontdata_text):
         font_id = int(match.group(1))
@@ -242,6 +245,7 @@ def _parse_font_bitmaps(fontdata_text: str) -> Dict[int, List[List[int]]]:
 
 
 def _parse_font_widths(gfx_text: str) -> Dict[int, List[int]]:
+    """Parse font widths."""
     widths: Dict[int, List[int]] = {}
     for font_id in (0, 1, 3, 4, 5):
         body = _extract_c_initializer(
@@ -257,6 +261,7 @@ def _parse_font_widths(gfx_text: str) -> Dict[int, List[int]]:
 
 
 def _bitmap_to_pixels(rows: List[int], width: int) -> List[List[int]]:
+    """Perform the bitmap to pixels asset-processing operation."""
     pixels: List[List[int]] = []
     for row in rows:
         # Font rows are stored MSB-first, matching the old blitter's bit order.
@@ -265,12 +270,14 @@ def _bitmap_to_pixels(rows: List[int], width: int) -> List[List[int]]:
 
 
 def _font_source_hash(path: Path) -> str:
+    """Compute a stable digest of source tables used for font export."""
     import hashlib
 
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def load_font_assets(repo_root: Path) -> Dict[int, Dict[str, Any]]:
+    """Load font assets."""
     fontdata_path = repo_root / "src" / "fontdata.h"
     gfx_impl_path = repo_root / "src" / "gfx_impl.c"
     fontdata_text = fontdata_path.read_text(encoding="utf-8")
@@ -304,6 +311,7 @@ def load_font_assets(repo_root: Path) -> Dict[int, Dict[str, Any]]:
 
 
 def _build_atlas(font: Dict[str, Any]) -> Tuple["Image.Image", Dict[str, Any]]:
+    """Build atlas from normalized asset data."""
     try:
         from PIL import Image
     except Exception as exc:
@@ -373,11 +381,13 @@ def _build_atlas(font: Dict[str, Any]) -> Tuple["Image.Image", Dict[str, Any]]:
 
 
 def _glyph_bdf_bitmap(glyph_rows: List[int], width: int) -> List[str]:
+    """Perform the glyph bdf bitmap asset-processing operation."""
     hex_width = max(2, ((width + 7) // 8) * 2)
     return [f"{row & 0xFF:0{hex_width}X}" for row in glyph_rows]
 
 
 def _cyrillic_template(codepoint: int) -> List[str]:
+    """Perform the cyrillic template asset-processing operation."""
     if codepoint in CYRILLIC_LOWER_5X7:
         return CYRILLIC_LOWER_5X7[codepoint]
     upper = CYRILLIC_LOWER_TO_UPPER.get(codepoint, codepoint)
@@ -385,6 +395,7 @@ def _cyrillic_template(codepoint: int) -> List[str]:
 
 
 def _scale_template_columns(row: str, width: int) -> str:
+    """Scale template columns."""
     if width == len(row):
         return row
     if width <= 0:
@@ -400,6 +411,7 @@ def _scale_template_columns(row: str, width: int) -> str:
 
 
 def _template_to_glyph_rows(template: List[str], cell_width: int, height: int) -> List[int]:
+    """Perform the template to glyph rows asset-processing operation."""
     draw_width = max(1, min(5, cell_width))
     x_offset = max(0, (cell_width - draw_width) // 2)
     rows: List[int] = []
@@ -420,6 +432,7 @@ def _template_to_glyph_rows(template: List[str], cell_width: int, height: int) -
 
 
 def _cyrillic_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], int]:
+    """Perform the cyrillic glyph asset-processing operation."""
     cell_width = int(font["cell_width"])
     height = int(font["height"])
     template = CYRILLIC_4X5.get(codepoint) if cell_width <= 4 and height <= 5 else None
@@ -440,6 +453,7 @@ def _cyrillic_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], in
 
 
 def _ascii_glyph(font: Dict[str, Any], source_char: str) -> Tuple[List[int], int]:
+    """Perform the ascii glyph asset-processing operation."""
     idx = ord(source_char) - FONT_CODEPOINT_START
     if idx < 0 or idx >= FONT_CODEPOINT_COUNT:
         idx = ord("?") - FONT_CODEPOINT_START
@@ -447,11 +461,13 @@ def _ascii_glyph(font: Dict[str, Any], source_char: str) -> Tuple[List[int], int
 
 
 def _set_pixel(rows: List[int], x: int, y: int, cell_width: int) -> None:
+    """Set one in-bounds pixel in a mutable glyph."""
     if 0 <= y < len(rows) and 0 <= x < min(cell_width, 8):
         rows[y] |= 0x80 >> x
 
 
 def _overlay_mark(rows: List[int], cell_width: int, mark: str) -> None:
+    """Overlay an accent or distinguishing mark on a synthesized glyph."""
     width = min(cell_width, 8)
     if width <= 0 or not rows:
         return
@@ -494,6 +510,7 @@ def _overlay_mark(rows: List[int], cell_width: int, mark: str) -> None:
 
 
 def _latin_extended_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[int], int]:
+    """Perform the latin extended glyph asset-processing operation."""
     source_char, mark = LATIN_EXTENDED_GLYPHS[codepoint]
     cell_width = int(font["cell_width"])
     height = int(font["height"])
@@ -520,6 +537,7 @@ def _latin_extended_glyph(font: Dict[str, Any], codepoint: int) -> Tuple[List[in
 
 
 def build_bdf(font: Dict[str, Any]) -> str:
+    """Build bdf from normalized asset data."""
     font_id = int(font["font_id"])
     width = int(font["cell_width"])
     height = int(font["height"])
@@ -580,6 +598,7 @@ def export_fonts(
     write_bdf: bool = True,
     include_metadata: bool = False,
 ) -> Dict[str, Any]:
+    """Export fonts to an editable modern format."""
     output_root.mkdir(parents=True, exist_ok=True)
     fonts = load_font_assets(repo_root)
     exported = []

--- a/tools/f15assets/f15assets/gltf_accessor.py
+++ b/tools/f15assets/f15assets/gltf_accessor.py
@@ -5,6 +5,21 @@ from __future__ import annotations
 import math
 import struct
 
+COMPONENT_UNSIGNED_BYTE = 5121
+COMPONENT_UNSIGNED_SHORT = 5123
+COMPONENT_UNSIGNED_INT = 5125
+COMPONENT_FLOAT = 5126
+UNSIGNED_COMPONENT_TYPES = (COMPONENT_UNSIGNED_BYTE, COMPONENT_UNSIGNED_SHORT, COMPONENT_UNSIGNED_INT)
+COMPONENT_FORMATS = {
+    COMPONENT_UNSIGNED_BYTE: "B",
+    COMPONENT_UNSIGNED_SHORT: "H",
+    COMPONENT_UNSIGNED_INT: "I",
+    COMPONENT_FLOAT: "f",
+}
+MIN_VERTEX_STRIDE_BYTES = 4
+MAX_VERTEX_STRIDE_BYTES = 252
+VERTEX_ALIGNMENT_BYTES = 4
+
 
 def _integer(value: object, label: str, minimum: int = 0) -> int:
     """Reject booleans, fractional values, and negative offsets or counts."""
@@ -46,16 +61,19 @@ def accessor_values(doc: dict, blob: bytes, index: int) -> list[int | float | tu
     offset = _integer(accessor.get("byteOffset", 0), "accessor byteOffset")
     count = _integer(accessor.get("count"), "accessor count", 1)
     component = _integer(accessor.get("componentType"), "componentType")
-    formats = {5121: "B", 5123: "H", 5125: "I", 5126: "f"}
     dimensions = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}
     kind = accessor.get("type")
-    if component not in formats or not isinstance(kind, str) or kind not in dimensions:
+    if component not in COMPONENT_FORMATS or not isinstance(kind, str) or kind not in dimensions:
         raise ValueError("unsupported geometry accessor type")
-    decoder = struct.Struct("<" + formats[component] * dimensions[kind])
-    component_size = struct.calcsize("<" + formats[component])
+    decoder = struct.Struct("<" + COMPONENT_FORMATS[component] * dimensions[kind])
+    component_size = struct.calcsize("<" + COMPONENT_FORMATS[component])
     stride = _integer(view.get("byteStride", decoder.size), "byteStride", 1)
-    if (stride < decoder.size or stride % component_size or
-            ("byteStride" in view and (stride < 4 or stride > 252 or stride % 4))):
+    invalid_component_stride = stride < decoder.size or stride % component_size != 0
+    invalid_vertex_stride = "byteStride" in view and (
+        not MIN_VERTEX_STRIDE_BYTES <= stride <= MAX_VERTEX_STRIDE_BYTES
+        or stride % VERTEX_ALIGNMENT_BYTES != 0
+    )
+    if invalid_component_stride or invalid_vertex_stride:
         raise ValueError("invalid geometry accessor stride")
     if offset % component_size or (view_offset + offset) % component_size:
         raise ValueError("unaligned geometry accessor")
@@ -67,7 +85,7 @@ def accessor_values(doc: dict, blob: bytes, index: int) -> list[int | float | tu
         raise ValueError("geometry accessor exceeds its buffer view")
     values = [decoder.unpack_from(blob, view_offset + offset + i * stride)
               for i in range(count)]
-    if component == 5126 and any(not math.isfinite(v) for row in values for v in row):
+    if component == COMPONENT_FLOAT and any(not math.isfinite(v) for row in values for v in row):
         raise ValueError("non-finite geometry coordinate")
     # Index consumers expect numbers; positions retain their vector tuples.
     return [row[0] for row in values] if kind == "SCALAR" else values

--- a/tools/f15assets/f15assets/gltf_accessor.py
+++ b/tools/f15assets/f15assets/gltf_accessor.py
@@ -1,0 +1,73 @@
+"""Bounds-checked access to the embedded geometry buffer of a GLB."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+
+def _integer(value: object, label: str, minimum: int = 0) -> int:
+    """Reject booleans, fractional values, and negative offsets or counts."""
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{label} must be an integer >= {minimum}")
+    return value
+
+
+def _entry(doc: dict, table: str, index: object) -> dict:
+    """Resolve a JSON table index without Python's negative-index semantics."""
+    index = _integer(index, table + " index")
+    entries = doc.get(table, [])
+    if not isinstance(entries, list) or index >= len(entries):
+        raise ValueError(f"{table} index {index} is out of range")
+    entry = entries[index]
+    if not isinstance(entry, dict):
+        raise ValueError(f"{table}[{index}] must be an object")
+    return entry
+
+
+def accessor_values(doc: dict, blob: bytes, index: int) -> list[int | float | tuple]:
+    """Read supported scalar/vector data, bounded by its view and buffer.
+
+    The runtime cache supports plain unsigned indices and float positions.
+    Sparse or normalized accessors must not silently become different geometry.
+    """
+    accessor = _entry(doc, "accessors", index)
+    if "sparse" in accessor or accessor.get("normalized", False):
+        raise ValueError("sparse/normalized geometry accessors are unsupported")
+    view = _entry(doc, "bufferViews", accessor.get("bufferView"))
+    if _integer(view.get("buffer"), "buffer index") != 0:
+        raise ValueError("geometry must use the embedded GLB buffer")
+    buffer = _entry(doc, "buffers", 0)
+    if "uri" in buffer:
+        raise ValueError("external geometry buffers are unsupported")
+    buffer_size = _integer(buffer.get("byteLength"), "buffer byteLength")
+    view_offset = _integer(view.get("byteOffset", 0), "view byteOffset")
+    view_size = _integer(view.get("byteLength"), "view byteLength")
+    offset = _integer(accessor.get("byteOffset", 0), "accessor byteOffset")
+    count = _integer(accessor.get("count"), "accessor count", 1)
+    component = _integer(accessor.get("componentType"), "componentType")
+    formats = {5121: "B", 5123: "H", 5125: "I", 5126: "f"}
+    dimensions = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}
+    kind = accessor.get("type")
+    if component not in formats or not isinstance(kind, str) or kind not in dimensions:
+        raise ValueError("unsupported geometry accessor type")
+    decoder = struct.Struct("<" + formats[component] * dimensions[kind])
+    component_size = struct.calcsize("<" + formats[component])
+    stride = _integer(view.get("byteStride", decoder.size), "byteStride", 1)
+    if (stride < decoder.size or stride % component_size or
+            ("byteStride" in view and (stride < 4 or stride > 252 or stride % 4))):
+        raise ValueError("invalid geometry accessor stride")
+    if offset % component_size or (view_offset + offset) % component_size:
+        raise ValueError("unaligned geometry accessor")
+    # The BIN chunk may have padding, but neither that padding nor the next
+    # buffer view belongs to this accessor. Check before allocating or reading.
+    end = offset + (count - 1) * stride + decoder.size
+    if (buffer_size > len(blob) or view_offset + view_size > buffer_size or
+            end > view_size):
+        raise ValueError("geometry accessor exceeds its buffer view")
+    values = [decoder.unpack_from(blob, view_offset + offset + i * stride)
+              for i in range(count)]
+    if component == 5126 and any(not math.isfinite(v) for row in values for v in row):
+        raise ValueError("non-finite geometry coordinate")
+    # Index consumers expect numbers; positions retain their vector tuples.
+    return [row[0] for row in values] if kind == "SCALAR" else values

--- a/tools/f15assets/f15assets/gltf_primitive.py
+++ b/tools/f15assets/f15assets/gltf_primitive.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import math
 
+from .gltf_accessor import COMPONENT_FLOAT, UNSIGNED_COMPONENT_TYPES
+
+POINTS = 0
+LINES = 1
+TRIANGLES = 4
+VERTICES_PER_PRIMITIVE = {POINTS: 1, LINES: 2, TRIANGLES: 3}
+
 
 def _entry(doc, table, index):
     """Resolve a required accessor or material reference with a useful error."""
@@ -23,8 +30,8 @@ def validate_primitive(doc, primitive):
     """
     if not isinstance(primitive, dict):
         raise ValueError("mesh primitive must be an object")
-    mode = primitive.get("mode", 4)
-    if type(mode) is not int or mode not in (0, 1, 4):
+    mode = primitive.get("mode", TRIANGLES)
+    if type(mode) is not int or mode not in VERTICES_PER_PRIMITIVE:
         raise ValueError(f"unsupported primitive mode {mode!r}; export points, lines or triangles")
     attributes = primitive.get("attributes")
     if not isinstance(attributes, dict) or "POSITION" not in attributes:
@@ -32,17 +39,17 @@ def validate_primitive(doc, primitive):
     if any(key.startswith("COLOR_") for key in attributes):
         raise ValueError("vertex colors are unsupported; use flat material colors")
     position = _entry(doc, "accessors", attributes["POSITION"])
-    if position.get("type") != "VEC3" or position.get("componentType") != 5126:
+    if position.get("type") != "VEC3" or position.get("componentType") != COMPONENT_FLOAT:
         raise ValueError("POSITION must be float VEC3")
     vertices = position.get("count")
     if type(vertices) is not int or vertices <= 0:
         raise ValueError("POSITION must contain vertices")
     if "indices" in primitive:
         indices = _entry(doc, "accessors", primitive["indices"])
-        if indices.get("type") != "SCALAR" or indices.get("componentType") not in (5121, 5123, 5125):
+        if indices.get("type") != "SCALAR" or indices.get("componentType") not in UNSIGNED_COMPONENT_TYPES:
             raise ValueError("indices must be unsigned integer SCALAR values")
         vertices = indices.get("count")
-    if type(vertices) is not int or vertices <= 0 or vertices % {0: 1, 1: 2, 4: 3}[mode]:
+    if type(vertices) is not int or vertices <= 0 or vertices % VERTICES_PER_PRIMITIVE[mode]:
         raise ValueError("primitive has an incomplete point, line or triangle")
     if "material" not in primitive:
         return

--- a/tools/f15assets/f15assets/gltf_primitive.py
+++ b/tools/f15assets/f15assets/gltf_primitive.py
@@ -1,0 +1,59 @@
+"""Validate the geometry/material subset representable by the flat GLMESH cache."""
+
+from __future__ import annotations
+
+import math
+
+
+def _entry(doc, table, index):
+    """Resolve a required accessor or material reference with a useful error."""
+    entries = doc.get(table, [])
+    if (not isinstance(entries, list) or type(index) is not int or
+            index < 0 or index >= len(entries) or not isinstance(entries[index], dict)):
+        raise ValueError(f"invalid {table} reference: {index!r}")
+    return entries[index]
+
+
+def validate_primitive(doc, primitive):
+    """Reject data the current importer would silently drop or reinterpret.
+
+    The game uses flat material colors, independent triangles, lines and points.
+    Unused normal/UV attributes are harmless, but an actual texture or vertex
+    color cannot be represented by a single RGBA value per primitive.
+    """
+    if not isinstance(primitive, dict):
+        raise ValueError("mesh primitive must be an object")
+    mode = primitive.get("mode", 4)
+    if type(mode) is not int or mode not in (0, 1, 4):
+        raise ValueError(f"unsupported primitive mode {mode!r}; export points, lines or triangles")
+    attributes = primitive.get("attributes")
+    if not isinstance(attributes, dict) or "POSITION" not in attributes:
+        raise ValueError("primitive requires POSITION")
+    if any(key.startswith("COLOR_") for key in attributes):
+        raise ValueError("vertex colors are unsupported; use flat material colors")
+    position = _entry(doc, "accessors", attributes["POSITION"])
+    if position.get("type") != "VEC3" or position.get("componentType") != 5126:
+        raise ValueError("POSITION must be float VEC3")
+    vertices = position.get("count")
+    if type(vertices) is not int or vertices <= 0:
+        raise ValueError("POSITION must contain vertices")
+    if "indices" in primitive:
+        indices = _entry(doc, "accessors", primitive["indices"])
+        if indices.get("type") != "SCALAR" or indices.get("componentType") not in (5121, 5123, 5125):
+            raise ValueError("indices must be unsigned integer SCALAR values")
+        vertices = indices.get("count")
+    if type(vertices) is not int or vertices <= 0 or vertices % {0: 1, 1: 2, 4: 3}[mode]:
+        raise ValueError("primitive has an incomplete point, line or triangle")
+    if "material" not in primitive:
+        return
+    material = _entry(doc, "materials", primitive["material"])
+    pbr = material.get("pbrMetallicRoughness", {})
+    if not isinstance(pbr, dict):
+        raise ValueError("invalid material properties")
+    if "baseColorTexture" in pbr:
+        raise ValueError("base-color textures are unsupported; use flat material colors")
+    factor = pbr.get("baseColorFactor", [1, 1, 1, 1])
+    if (not isinstance(factor, list) or len(factor) != 4 or
+            any(type(v) not in (int, float) or not math.isfinite(v) or v < 0 or v > 1
+                for v in factor)):
+        raise ValueError("baseColorFactor must contain four finite values in [0, 1]")

--- a/tools/f15assets/f15assets/gltf_scene.py
+++ b/tools/f15assets/f15assets/gltf_scene.py
@@ -1,0 +1,153 @@
+"""Resolve static GLB scene instances into the runtime's flat mesh space."""
+
+from __future__ import annotations
+
+import math
+import struct
+from copy import deepcopy
+
+IDENTITY = (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+
+
+def _entry(entries, index, label):
+    """Resolve a scene reference without accepting negative Python indices."""
+    if type(index) is not int or index < 0 or index >= len(entries):
+        raise ValueError(f"invalid {label} index: {index!r}")
+    item = entries[index]
+    if not isinstance(item, dict):
+        raise ValueError(f"{label} must be an object")
+    return item
+
+
+def _vector(value, count, label):
+    """Read a finite transform vector of the specified dimension."""
+    if (not isinstance(value, (list, tuple)) or len(value) != count or
+            any(type(v) not in (int, float) or not math.isfinite(v) for v in value)):
+        raise ValueError(f"invalid {label}")
+    return value
+
+
+def _local_matrix(node):
+    """Build glTF's column-major T*R*S transform, or use its explicit matrix."""
+    if "matrix" in node:
+        if any(key in node for key in ("translation", "rotation", "scale")):
+            raise ValueError("node cannot contain both matrix and TRS")
+        matrix = _vector(node["matrix"], 16, "node matrix")
+        if tuple(matrix[i] for i in (3, 7, 11, 15)) != (0, 0, 0, 1):
+            raise ValueError("node matrix must be affine")
+        return matrix
+    tx, ty, tz = _vector(node.get("translation", (0, 0, 0)), 3, "translation")
+    sx, sy, sz = _vector(node.get("scale", (1, 1, 1)), 3, "scale")
+    x, y, z, w = _vector(node.get("rotation", (0, 0, 0, 1)), 4, "rotation")
+    norm = math.sqrt(x*x + y*y + z*z + w*w)
+    if not math.isfinite(norm) or abs(norm - 1) > 0.001:
+        raise ValueError("node rotation must be a unit quaternion")
+    x, y, z, w = x/norm, y/norm, z/norm, w/norm
+    return (
+        (1-2*(y*y+z*z))*sx, 2*(x*y+z*w)*sx, 2*(x*z-y*w)*sx, 0,
+        2*(x*y-z*w)*sy, (1-2*(x*x+z*z))*sy, 2*(y*z+x*w)*sy, 0,
+        2*(x*z+y*w)*sz, 2*(y*z-x*w)*sz, (1-2*(x*x+y*y))*sz, 0,
+        tx, ty, tz, 1,
+    )
+
+
+def _multiply(left, right):
+    """Compose parent and local column-major transforms."""
+    return tuple(sum(left[k*4+r] * right[c*4+k] for k in range(4))
+                 for c in range(4) for r in range(4))
+
+
+def flatten_scene(doc, blob, read_accessor):
+    """Bake the selected static scene into meshes without changing primitives.
+
+    Identity transforms retain the original accessors byte-for-byte. Distinct
+    nodes using one mesh remain distinct instances, while unused meshes do not
+    leak into the selected shape. Animation/skinning cannot be baked silently.
+    """
+    nodes = doc.get("nodes", [])
+    scenes = doc.get("scenes", [])
+    if not isinstance(nodes, list) or not isinstance(scenes, list):
+        raise ValueError("nodes and scenes must be arrays")
+    if doc.get("animations"):
+        raise ValueError("animated GLBs require a static export for this importer")
+    if scenes:
+        roots = _entry(scenes, doc.get("scene", 0), "scene").get("nodes", [])
+    else:
+        # Scene-less assets can still have a node hierarchy. Infer only roots,
+        # not every node (which would duplicate all descendants).
+        children = set()
+        for node in nodes:
+            if not isinstance(node, dict) or not isinstance(node.get("children", []), list):
+                raise ValueError("invalid node children")
+            for child in node.get("children", []):
+                _entry(nodes, child, "child node")
+                children.add(child)
+        roots = [i for i in range(len(nodes)) if i not in children]
+    if not isinstance(roots, list) or not roots:
+        raise ValueError("GLB has no scene roots")
+    result = deepcopy(doc)
+    meshes = []
+    data = bytearray(blob)
+    transformed = {}
+    visited = set()
+    stack = [(index, IDENTITY) for index in reversed(roots)]
+    while stack:
+        index, parent = stack.pop()
+        node = _entry(nodes, index, "node")
+        if index in visited:
+            raise ValueError("scene contains a cycle or repeated node reference")
+        visited.add(index)
+        if "skin" in node or "weights" in node:
+            raise ValueError("skinning and morph weights require a static export")
+        matrix = _multiply(parent, _local_matrix(node))
+        if any(not math.isfinite(v) for v in matrix):
+            raise ValueError("scene transform overflow")
+        if "mesh" in node:
+            mesh = deepcopy(_entry(doc.get("meshes", []), node["mesh"], "mesh"))
+            if "weights" in mesh:
+                raise ValueError("morph weights require a static export")
+            for primitive in mesh.get("primitives", []):
+                if "targets" in primitive:
+                    raise ValueError("morph targets require a static export")
+                if matrix == IDENTITY:
+                    continue
+                attributes = primitive.get("attributes", {})
+                accessor_index = attributes.get("POSITION")
+                accessor = _entry(doc.get("accessors", []), accessor_index, "POSITION")
+                if accessor.get("type") != "VEC3" or accessor.get("componentType") != 5126:
+                    raise ValueError("POSITION must contain float VEC3 values")
+                key = (accessor_index, matrix)
+                if key not in transformed:
+                    positions = read_accessor(doc, blob, accessor_index)
+                    packed = bytearray()
+                    for x, y, z in positions:
+                        values = tuple(matrix[r]*x + matrix[4+r]*y +
+                                       matrix[8+r]*z + matrix[12+r] for r in range(3))
+                        if any(not math.isfinite(v) or abs(v) > 3.4028234663852886e38 for v in values):
+                            raise ValueError("transformed POSITION exceeds float32 range")
+                        packed.extend(struct.pack("<3f", *values))
+                    data.extend(b"\0" * (-len(data) % 4))
+                    view = len(result.setdefault("bufferViews", []))
+                    result["bufferViews"].append({"buffer": 0, "byteOffset": len(data),
+                                                   "byteLength": len(packed)})
+                    transformed[key] = len(result.setdefault("accessors", []))
+                    result["accessors"].append({"bufferView": view, "componentType": 5126,
+                                                 "count": len(positions), "type": "VEC3"})
+                    data.extend(packed)
+                attributes["POSITION"] = transformed[key]
+            meshes.append(mesh)
+        children = node.get("children", [])
+        if not isinstance(children, list):
+            raise ValueError("node children must be an array")
+        stack.extend((child, matrix) for child in reversed(children))
+    if not meshes:
+        raise ValueError("selected scene has no meshes")
+    result["meshes"] = meshes
+    # The caller consumes the flat mesh list; publish a matching scene too so
+    # this intermediate document cannot accidentally retain stale mesh indices.
+    result["nodes"] = [{"mesh": i} for i in range(len(meshes))]
+    result["scenes"] = [{"nodes": list(range(len(meshes)))}]
+    result["scene"] = 0
+    if len(data) != len(blob):
+        _entry(result.get("buffers", []), 0, "buffer")["byteLength"] = len(data)
+    return result, bytes(data)

--- a/tools/f15assets/f15assets/gltf_scene.py
+++ b/tools/f15assets/f15assets/gltf_scene.py
@@ -6,6 +6,8 @@ import math
 import struct
 from copy import deepcopy
 
+from .gltf_primitive import validate_primitive
+
 IDENTITY = (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
 
 
@@ -107,6 +109,7 @@ def flatten_scene(doc, blob, read_accessor):
             if "weights" in mesh:
                 raise ValueError("morph weights require a static export")
             for primitive in mesh.get("primitives", []):
+                validate_primitive(doc, primitive)
                 if "targets" in primitive:
                     raise ValueError("morph targets require a static export")
                 if matrix == IDENTITY:

--- a/tools/f15assets/f15assets/gltf_scene.py
+++ b/tools/f15assets/f15assets/gltf_scene.py
@@ -6,9 +6,12 @@ import math
 import struct
 from copy import deepcopy
 
+from .gltf_accessor import COMPONENT_FLOAT, VERTEX_ALIGNMENT_BYTES
 from .gltf_primitive import validate_primitive
 
 IDENTITY = (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+QUATERNION_NORM_TOLERANCE = 0.001
+FLOAT32_MAX = 3.4028234663852886e38
 
 
 def _entry(entries, index, label):
@@ -42,7 +45,7 @@ def _local_matrix(node):
     sx, sy, sz = _vector(node.get("scale", (1, 1, 1)), 3, "scale")
     x, y, z, w = _vector(node.get("rotation", (0, 0, 0, 1)), 4, "rotation")
     norm = math.sqrt(x*x + y*y + z*z + w*w)
-    if not math.isfinite(norm) or abs(norm - 1) > 0.001:
+    if not math.isfinite(norm) or abs(norm - 1) > QUATERNION_NORM_TOLERANCE:
         raise ValueError("node rotation must be a unit quaternion")
     x, y, z, w = x/norm, y/norm, z/norm, w/norm
     return (
@@ -117,7 +120,7 @@ def flatten_scene(doc, blob, read_accessor):
                 attributes = primitive.get("attributes", {})
                 accessor_index = attributes.get("POSITION")
                 accessor = _entry(doc.get("accessors", []), accessor_index, "POSITION")
-                if accessor.get("type") != "VEC3" or accessor.get("componentType") != 5126:
+                if accessor.get("type") != "VEC3" or accessor.get("componentType") != COMPONENT_FLOAT:
                     raise ValueError("POSITION must contain float VEC3 values")
                 key = (accessor_index, matrix)
                 if key not in transformed:
@@ -126,15 +129,16 @@ def flatten_scene(doc, blob, read_accessor):
                     for x, y, z in positions:
                         values = tuple(matrix[r]*x + matrix[4+r]*y +
                                        matrix[8+r]*z + matrix[12+r] for r in range(3))
-                        if any(not math.isfinite(v) or abs(v) > 3.4028234663852886e38 for v in values):
+                        outside_float32 = any(not math.isfinite(v) or abs(v) > FLOAT32_MAX for v in values)
+                        if outside_float32:
                             raise ValueError("transformed POSITION exceeds float32 range")
                         packed.extend(struct.pack("<3f", *values))
-                    data.extend(b"\0" * (-len(data) % 4))
+                    data.extend(b"\0" * (-len(data) % VERTEX_ALIGNMENT_BYTES))
                     view = len(result.setdefault("bufferViews", []))
                     result["bufferViews"].append({"buffer": 0, "byteOffset": len(data),
                                                    "byteLength": len(packed)})
                     transformed[key] = len(result.setdefault("accessors", []))
-                    result["accessors"].append({"bufferView": view, "componentType": 5126,
+                    result["accessors"].append({"bufferView": view, "componentType": COMPONENT_FLOAT,
                                                  "count": len(positions), "type": "VEC3"})
                     data.extend(packed)
                 attributes["POSITION"] = transformed[key]

--- a/tools/f15assets/f15assets/io.py
+++ b/tools/f15assets/f15assets/io.py
@@ -6,42 +6,52 @@ from typing import Iterable, List, Sequence
 
 
 def read_u8(data: bytes, offset: int) -> int:
+    """Read u8."""
     return data[offset]
 
 
 def read_u16_le(data: bytes, offset: int) -> int:
+    """Read u16 le."""
     return int.from_bytes(data[offset : offset + 2], "little", signed=False)
 
 
 def read_s16_le(data: bytes, offset: int) -> int:
+    """Read s16 le."""
     return int.from_bytes(data[offset : offset + 2], "little", signed=True)
 
 
 def read_u32_le(data: bytes, offset: int) -> int:
+    """Read u32 le."""
     return int.from_bytes(data[offset : offset + 4], "little", signed=False)
 
 
 def read_s32_le(data: bytes, offset: int) -> int:
+    """Read s32 le."""
     return int.from_bytes(data[offset : offset + 4], "little", signed=True)
 
 
 def write_u8(value: int) -> bytes:
+    """Write u8."""
     return int(value & 0xFF).to_bytes(1, "little", signed=False)
 
 
 def write_u16_le(value: int) -> bytes:
+    """Write u16 le."""
     return int(value & 0xFFFF).to_bytes(2, "little", signed=False)
 
 
 def write_s16_le(value: int) -> bytes:
+    """Write s16 le."""
     return int(value).to_bytes(2, "little", signed=True)
 
 
 def write_u32_le(value: int) -> bytes:
+    """Write u32 le."""
     return int(value & 0xFFFFFFFF).to_bytes(4, "little", signed=False)
 
 
 def write_s32_le(value: int) -> bytes:
+    """Write s32 le."""
     return int(value).to_bytes(4, "little", signed=True)
 
 
@@ -59,6 +69,7 @@ def split_c_strings(data: bytes) -> List[str]:
 
 
 def join_c_strings(values: Sequence[str], fixed_size: int) -> bytes:
+    """Perform the join c strings asset-processing operation."""
     chunks = [v.encode("latin1", errors="replace") for v in values]
     out = bytearray()
     for chunk in chunks:
@@ -70,24 +81,29 @@ def join_c_strings(values: Sequence[str], fixed_size: int) -> bytes:
 
 
 def ensure_padding(data: bytes, fixed_size: int) -> bytes:
+    """Perform the ensure padding asset-processing operation."""
     if len(data) > fixed_size:
         raise ValueError(f"payload is too large: {len(data)} > {fixed_size}")
     return data + b"\x00" * (fixed_size - len(data))
 
 
 def to_base64(data: bytes) -> str:
+    """Convert normalized asset data to base64."""
     return base64.b64encode(data).decode("ascii")
 
 
 def from_base64(value: str) -> bytes:
+    """Perform the from base64 asset-processing operation."""
     return base64.b64decode(value.encode("ascii"))
 
 
 def bytes_to_u8_list(data: bytes) -> List[int]:
+    """Perform the bytes to u8 list asset-processing operation."""
     return list(data)
 
 
 def u8_list_to_bytes(values: Iterable[int]) -> bytes:
+    """Perform the u8 list to bytes asset-processing operation."""
     return bytes(int(v) & 0xFF for v in values)
 
 
@@ -96,4 +112,5 @@ class OffsetTracker:
     offset: int = 0
 
     def take(self, count: int) -> "OffsetTracker":
+        """Perform the take asset-processing operation."""
         return OffsetTracker(self.offset + count)

--- a/tools/f15assets/f15assets/model3d.py
+++ b/tools/f15assets/f15assets/model3d.py
@@ -954,6 +954,17 @@ def _shape_label(shape_names: object, shape_index: int) -> str:
     return f"shape_{shape_index:03d}"
 
 
+def _color_key(color: object) -> str:
+    if color is None:
+        return "none"
+    return f"0x{int(color) & 0xFF:02x}"
+
+
+def _bump_color_count(bucket: Dict[str, int], color: object, amount: int = 1) -> None:
+    key = _color_key(color)
+    bucket[key] = bucket.get(key, 0) + int(amount)
+
+
 def parse_3d3(data: bytes) -> Dict[str, Any]:
     if len(data) < 6:
         raise ValueError(".3D3 data too short")
@@ -1098,15 +1109,34 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
             "has_shared_vertex_pool": bool(shared_pool),
             "shared_vertex_pool": shared_pool_summary,
             "skipped_shapes": [],
+            "raw_color_usage": {"faces": {}, "lines": {}, "points": {}},
         },
     }
 
     for shape_index, shape_offset in enumerate(shape_offsets):
         if shape_offset >= model_data_size:
+            gltf["extras"]["skipped_shapes"].append(
+                {
+                    "shape_index": shape_index,
+                    "shape_name": _shape_label(shape_names, shape_index),
+                    "shape_offset": shape_offset,
+                    "shape_end": model_data_size,
+                    "render_mode": None,
+                    "shape_payload": {
+                        "render_error": "shape_offset_outside_model_data",
+                        "model_data_size": model_data_size,
+                    },
+                }
+            )
             continue
         shape_end = model_data_size
         color_materials: Dict[int, int] = {}
         fallback_face_material = 1
+        shape_color_usage: Dict[str, Dict[str, int]] = {
+            "faces": {},
+            "lines": {},
+            "points": {},
+        }
         if shape_index + 1 < len(shape_offsets):
             shape_end = min(model_data_size, shape_offsets[shape_index + 1])
             if shape_end < shape_offset:
@@ -1184,6 +1214,8 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                         if tri_index < len(triangle_colors)
                         else None
                     )
+                    _bump_color_count(shape_color_usage["faces"], color)
+                    _bump_color_count(gltf["extras"]["raw_color_usage"]["faces"], color)
                     triangles_by_color.setdefault(color, []).extend(int(v) for v in tri)
 
                 for color, tri_indices in triangles_by_color.items():
@@ -1230,6 +1262,7 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     )
 
             lines_by_color: Dict[Optional[int], set[Tuple[int, int]]] = {}
+            points_by_color: Dict[Optional[int], set[int]] = {}
             for line in lines:
                 if len(line) == 2:
                     a, b = int(line[0]), int(line[1])
@@ -1239,8 +1272,56 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     color = line[2]
                     color = None if color is None else int(color)
                 if a == b:
+                    if 0 <= a < len(vertices):
+                        points_by_color.setdefault(color, set()).add(a)
+                        _bump_color_count(shape_color_usage["points"], color)
+                        _bump_color_count(gltf["extras"]["raw_color_usage"]["points"], color)
                     continue
                 lines_by_color.setdefault(color, set()).add(tuple(sorted((a, b))))
+                _bump_color_count(shape_color_usage["lines"], color)
+                _bump_color_count(gltf["extras"]["raw_color_usage"]["lines"], color)
+
+            for color, point_set in sorted(points_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
+                uniq_points = sorted(point_set)
+                if not uniq_points:
+                    continue
+                point_bin, point_type = _pack_indices(uniq_points)
+                point_view = _emit_buffer_view(gltf, point_bin, 34963)
+                point_acc = _emit_accessor(
+                    gltf,
+                    point_view,
+                    component_type=point_type,
+                    type_name="SCALAR",
+                    count=len(uniq_points),
+                )
+                gltf["accessors"][point_acc]["min"] = [0]
+                gltf["accessors"][point_acc]["max"] = [max(0, len(vertices) - 1)]
+
+                if color is None:
+                    material_index = 0
+                else:
+                    r, g, b, a = _face_material_color(color)
+                    material_index = len(gltf["materials"])
+                    gltf["materials"].append(
+                        {
+                            "name": f"points_color_0x{color:02x}",
+                            "doubleSided": True,
+                            "pbrMetallicRoughness": {
+                                "baseColorFactor": [r, g, b, a],
+                                "metallicFactor": 0.0,
+                                "roughnessFactor": 1.0,
+                            },
+                        }
+                    )
+
+                primitives.append(
+                    {
+                        "attributes": {"POSITION": pos_acc},
+                        "indices": point_acc,
+                        "mode": 0,
+                        "material": material_index,
+                    }
+                )
 
             for color, line_set in sorted(lines_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
                 uniq_lines = sorted(line_set)
@@ -1314,6 +1395,7 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                 "shape_offset": shape_offset,
                 "shape_end": shape_end,
                 "shape_payload": shape_parse["metadata"],
+                "raw_color_usage": shape_color_usage,
             },
         }
         gltf["meshes"].append(mesh)
@@ -1336,6 +1418,11 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
 def export_3d3_to_glb(payload: Dict[str, Any]) -> bytes:
     """Export a ``3D3`` payload as a binary glTF (`.glb`) blob."""
     gltf = export_3d3_to_gltf(payload)
+    return export_3d3_gltf_to_glb(gltf)
+
+
+def export_3d3_gltf_to_glb(gltf: Dict[str, Any]) -> bytes:
+    """Pack a generated 3D3 glTF document as a binary glTF (`.glb`) blob."""
     buffer_uri = gltf["buffers"][0].get("uri", "")
     if not buffer_uri.startswith("data:application/octet-stream;base64,"):
         raise ValueError("expected embedded binary buffer URI in glTF payload")

--- a/tools/f15assets/f15assets/model3d.py
+++ b/tools/f15assets/f15assets/model3d.py
@@ -38,6 +38,7 @@ _FLIGHT_DAY_COLOR_LUT = [
 
 
 def _face_material_color(color_index: int) -> Tuple[float, float, float, float]:
+    """Resolve the effective game palette color for one polygon."""
     global _FACE_PALETTE_RGB8
     if _FACE_PALETTE_RGB8 is None:
         _FACE_PALETTE_RGB8 = _default_palette(8)
@@ -70,6 +71,7 @@ def _decode_rle_primitive_order(
     # This follows the original renderer's traversal table rather than a normal
     # compression scheme. The stream describes primitive draw order through
     # edge-index links, with 0xFF acting as a return/sentinel marker.
+    """Decode rle primitive order while preserving legacy semantics."""
     if edge_count <= 0:
         return [0xFF]
     if not src:
@@ -159,6 +161,7 @@ def _decode_primitive_command_stream(
     List[Tuple[int, int, Optional[int]]],
     Dict[int, int],
 ]:
+    """Decode primitive command stream while preserving legacy semantics."""
     triangles: List[Tuple[int, int, int]] = []
     triangle_colors: List[int] = []
     lines: List[Tuple[int, int, Optional[int]]] = []
@@ -304,6 +307,7 @@ def _decode_fixed_edge_records(
     edge_count: int,
     wide_mask: bool,
 ) -> Tuple[List[Tuple[int, int]], int, Optional[str]]:
+    """Decode fixed edge records while preserving legacy semantics."""
     edges: List[Tuple[int, int]] = []
     cursor = 0
     for _ in range(edge_count):
@@ -337,6 +341,7 @@ def _decode_primitive_payload(
     Dict[int, int],
     Optional[str],
 ]:
+    """Decode primitive payload while preserving legacy semantics."""
     if cursor >= len(stream):
         return [], [], [], {}, "missing_primitive_payload"
 
@@ -443,10 +448,12 @@ def _decode_primitive_payload(
 
 
 def _skip_visibility_mask(data: bytes, offset: int, wide: bool) -> int:
+    """Perform the skip visibility mask asset-processing operation."""
     return offset + (4 if wide else 2)
 
 
 def _read_visibility_mask(data: bytes, offset: int, wide: bool) -> Tuple[int, int]:
+    """Read visibility mask."""
     end = _skip_visibility_mask(data, offset, wide)
     if end > len(data):
         raise ValueError("truncated visibility mask")
@@ -454,6 +461,7 @@ def _read_visibility_mask(data: bytes, offset: int, wide: bool) -> Tuple[int, in
 
 
 def _edge_loop_from_edges(edge_indices: Sequence[int], edges: Sequence[Tuple[int, int]]) -> List[int]:
+    """Recover a closed polygon loop from unordered edge references."""
     if len(edge_indices) < 3:
         return []
 
@@ -511,6 +519,7 @@ def _edge_loop_from_edges(edge_indices: Sequence[int], edges: Sequence[Tuple[int
 
 
 def _canonical_polygon_signature(vertices: Sequence[int]) -> Tuple[int, ...]:
+    """Build a winding-independent polygon signature for deduplication."""
     if len(vertices) < 3:
         return ()
 
@@ -548,6 +557,7 @@ def _canonical_polygon_signature(vertices: Sequence[int]) -> Tuple[int, ...]:
 def _decode_model_edges_and_primitives(
     stream: bytes, shared_pool: Optional[Dict[str, Any]]
 ) -> Dict[str, Any]:
+    """Decode model edges and primitives while preserving legacy semantics."""
     if not stream:
         return {
             "render_mode": 0,
@@ -938,10 +948,12 @@ def _decode_model_edges_and_primitives(
 
 
 def _align4(value: int) -> int:
+    """Return the next four-byte-aligned offset."""
     return (4 - (value % 4)) % 4
 
 
 def _emit_buffer_view(gltf: Dict[str, Any], raw: bytes, target: int) -> int:
+    """Perform the emit buffer view asset-processing operation."""
     uri = gltf["buffers"][0]["uri"]
     comma_pos = uri.index(",")
     raw_buffer = bytearray(from_base64(uri[comma_pos + 1:]))
@@ -972,6 +984,7 @@ def _emit_accessor(
     count: int,
     byte_offset: int = 0,
 ) -> int:
+    """Perform the emit accessor asset-processing operation."""
     accessor_index = len(gltf["accessors"])
     dims = 3 if type_name == "VEC3" else 1
     gltf["accessors"].append(
@@ -989,6 +1002,7 @@ def _emit_accessor(
 
 
 def _pack_indices(values: Sequence[int]) -> Tuple[bytes, int]:
+    """Pack indices."""
     max_value = max(values) if values else 0
     if max_value > 0xFFFF:
         return struct.pack("<" + "I" * len(values), *values), 5125
@@ -996,10 +1010,12 @@ def _pack_indices(values: Sequence[int]) -> Tuple[bytes, int]:
 
 
 def _pack_floats(values: Sequence[float]) -> bytes:
+    """Pack floats."""
     return struct.pack("<" + "f" * len(values), *values) if values else b""
 
 
 def _safe_shape_name(value: object) -> str:
+    """Return a portable filename component for a source shape name."""
     name = str(value or "").strip()
     name = re.sub(r"[^0-9A-Za-z_. -]+", "_", name)
     name = re.sub(r"\s+", "_", name)
@@ -1007,6 +1023,7 @@ def _safe_shape_name(value: object) -> str:
 
 
 def _shape_label(shape_names: object, shape_index: int) -> str:
+    """Build the stable display label for a shape slot."""
     label = ""
     if isinstance(shape_names, dict):
         label = str(shape_names.get(str(shape_index), "") or shape_names.get(shape_index, "") or "")
@@ -1019,17 +1036,20 @@ def _shape_label(shape_names: object, shape_index: int) -> str:
 
 
 def _color_key(color: object) -> str:
+    """Normalize a color for deterministic material reuse."""
     if color is None:
         return "none"
     return f"0x{int(color) & 0xFF:02x}"
 
 
 def _bump_color_count(bucket: Dict[str, int], color: object, amount: int = 1) -> None:
+    """Increment a color-frequency table used by diagnostics."""
     key = _color_key(color)
     bucket[key] = bucket.get(key, 0) + int(amount)
 
 
 def parse_3d3(data: bytes) -> Dict[str, Any]:
+    """Parse 3d3."""
     if len(data) < 6:
         raise ValueError(".3D3 data too short")
 
@@ -1136,6 +1156,7 @@ def parse_3d3(data: bytes) -> Dict[str, Any]:
 
 
 def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Export 3d3 to gltf to an editable modern format."""
     if payload.get("format") != "3D3":
         raise ValueError("invalid payload format")
 
@@ -1528,6 +1549,7 @@ def _minimized_single_mesh_gltf(gltf: Dict[str, Any], mesh: Dict[str, Any], shap
     out["extras"]["minimized_per_shape_glb"] = True
 
     def remap_buffer_view(old_view_index: int) -> int:
+        """Remap buffer view."""
         if old_view_index in buffer_view_map:
             return buffer_view_map[old_view_index]
         old_view = gltf["bufferViews"][old_view_index]
@@ -1546,6 +1568,7 @@ def _minimized_single_mesh_gltf(gltf: Dict[str, Any], mesh: Dict[str, Any], shap
         return new_index
 
     def remap_accessor(old_accessor_index: int) -> int:
+        """Remap accessor."""
         if old_accessor_index in accessor_map:
             return accessor_map[old_accessor_index]
         old_accessor = gltf["accessors"][old_accessor_index]
@@ -1558,6 +1581,7 @@ def _minimized_single_mesh_gltf(gltf: Dict[str, Any], mesh: Dict[str, Any], shap
         return new_index
 
     def remap_material(old_material_index: int) -> int:
+        """Remap material."""
         if old_material_index in material_map:
             return material_map[old_material_index]
         new_index = len(out["materials"])
@@ -1639,6 +1663,7 @@ def export_3d3_gltf_to_glb(gltf: Dict[str, Any]) -> bytes:
 
 
 def build_3d3(payload: Dict[str, Any]) -> bytes:
+    """Build 3d3 from normalized asset data."""
     if payload.get("format") != "3D3":
         raise ValueError("invalid payload format")
 

--- a/tools/f15assets/f15assets/model3d.py
+++ b/tools/f15assets/f15assets/model3d.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import copy
 import re
 import struct
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -162,10 +163,11 @@ def _decode_primitive_command_stream(
     triangle_colors: List[int] = []
     lines: List[Tuple[int, int, Optional[int]]] = []
     face_edge_colors: Dict[int, int] = {}
-    if seen_faces is None:
-        seen_faces = set()
-    if seen_triangles is None:
-        seen_triangles = set()
+    # Do not suppress duplicate faces/triangles here. The game runtime decoder
+    # intentionally over-collects grouped 0xff/RLE primitive runs, and duplicate
+    # coplanar primitives are part of how the original painter/z-fighting behavior
+    # resolves for some shapes. The validation/runtime loader test compares this
+    # coverage directly, so the editable GLB must preserve it.
 
     cursor = 0
     while cursor < len(stream) and (command_budget is None or command_budget > 0):
@@ -203,14 +205,6 @@ def _decode_primitive_command_stream(
                     command_budget -= 1
                 continue
 
-            signature = _canonical_polygon_signature(polygon_vertices)
-            if signature and signature in seen_faces:
-                if command_budget is not None:
-                    command_budget -= 1
-                continue
-            if signature:
-                seen_faces.add(signature)
-
             a = polygon_vertices[0]
             for i in range(1, len(polygon_vertices) - 1):
                 b = polygon_vertices[i]
@@ -218,12 +212,8 @@ def _decode_primitive_command_stream(
                 if a < len(vertices) and b < len(vertices) and c < len(vertices):
                     if a != b and b != c and a != c:
                         tri = (a, b, c)
-                        tri_signature = tuple(sorted(tri))
-                        tri_key = (tri_signature, color)
-                        if tri_key not in seen_triangles:
-                            seen_triangles.add(tri_key)
-                            triangles.append(tri)
-                            triangle_colors.append(color)
+                        triangles.append(tri)
+                        triangle_colors.append(color)
         else:
             # Non-face commands are kept as line primitives. Some source shapes
             # are intentionally 2D/single-sided, so fabricating reverse faces
@@ -607,6 +597,80 @@ def _decode_model_edges_and_primitives(
             "metadata": {"lod_records": lod_records, "transform_records": transform_records},
         }
 
+    special_form = stream[cursor] & 0x3F
+    if special_form == 0x3F:
+        if cursor + 2 > len(stream):
+            raise ValueError("truncated 3D3 point record")
+        color = int(stream[cursor + 1])
+        return {
+            "render_mode": render_mode,
+            "vertices": [(0, 0, 0)],
+            "edges": [],
+            "triangles": [],
+            "triangle_colors": [],
+            "lines": [(0, 0, color)],
+            "metadata": {
+                "form": "point",
+                "point_color": color,
+                "lod_records": lod_records,
+                "transform_records": transform_records,
+            },
+        }
+
+    if special_form == 0x3E:
+        if cursor + 3 > len(stream):
+            raise ValueError("truncated 3D3 edgerun record")
+        count = int(stream[cursor + 2])
+        refs_start = cursor + 3
+        refs_end = refs_start + count
+        if refs_end > len(stream):
+            raise ValueError("truncated 3D3 edgerun refs")
+        vertices: List[Tuple[int, int, int]] = []
+        lines: List[Tuple[int, int, Optional[int]]] = []
+        unresolved_vertex_count = 0
+        refs = list(stream[refs_start:refs_end])
+        for ref in refs:
+            x = y = z = 0
+            if shared_pool:
+                x_indices = shared_pool.get("x_indices", [])
+                y_indices = shared_pool.get("y_indices", [])
+                z_indices = shared_pool.get("z_indices", [])
+                x_values = shared_pool.get("x_values", [])
+                y_values = shared_pool.get("y_values", [])
+                z_values = shared_pool.get("z_values", [])
+                if ref < len(x_indices) and ref < len(y_indices) and ref < len(z_indices):
+                    xi = x_indices[ref]
+                    yi = y_indices[ref]
+                    zi = z_indices[ref]
+                    x = x_values[xi] if xi < len(x_values) else 0
+                    y = y_values[yi] if yi < len(y_values) else 0
+                    z = z_values[zi] if zi < len(z_values) else 0
+                else:
+                    unresolved_vertex_count += 1
+            else:
+                unresolved_vertex_count += 1
+            vertices.append((x, y, z))
+            # The GL replacement bridge represents edgerun dots as point
+            # primitives. The current runtime comparison treats their source
+            # color as 0 because the legacy GL path shades edgeruns by distance
+            # instead of using a fixed face/line palette byte.
+            lines.append((len(vertices) - 1, len(vertices) - 1, 0))
+        return {
+            "render_mode": render_mode,
+            "vertices": vertices,
+            "edges": [],
+            "triangles": [],
+            "triangle_colors": [],
+            "lines": lines,
+            "metadata": {
+                "form": "edgerun",
+                "run_refs": refs,
+                "unresolved_vertex_count": unresolved_vertex_count,
+                "lod_records": lod_records,
+                "transform_records": transform_records,
+            },
+        }
+
     face_info = stream[cursor]
     cursor += 1
     face_count = face_info & 0x1F
@@ -840,14 +904,14 @@ def _decode_model_edges_and_primitives(
             edge_key = tuple(sorted((a, b)))
             if edge_key in colored_line_edges:
                 continue
+            color = face_edge_colors_by_index.get(edge_idx, face_edge_colors.get(edge_key))
+            if color is None:
+                continue
             lines.append(
                 (
                     a,
                     b,
-                    face_edge_colors_by_index.get(
-                        edge_idx,
-                        face_edge_colors.get(edge_key, dominant_face_color),
-                    ),
+                    color,
                 )
             )
 
@@ -1205,7 +1269,13 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
             gltf["accessors"][pos_acc]["max"] = [float(x) for x in maxs]
 
             if triangles:
-                triangles_by_color: Dict[Optional[int], List[int]] = {}
+                # Do not batch triangles by material/color here. The original
+                # renderer's display-list order is part of the asset semantics:
+                # many aircraft/building details are coplanar or intentionally
+                # z-fighting, so reordering faces can visibly change which color
+                # wins. One glTF primitive per decoded triangle is larger than
+                # color batching but preserves source draw order for validation
+                # and for the runtime GLMESH cache.
                 for tri_index, tri in enumerate(triangles):
                     if len(tri) != 3:
                         continue
@@ -1216,9 +1286,8 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     )
                     _bump_color_count(shape_color_usage["faces"], color)
                     _bump_color_count(gltf["extras"]["raw_color_usage"]["faces"], color)
-                    triangles_by_color.setdefault(color, []).extend(int(v) for v in tri)
 
-                for color, tri_indices in triangles_by_color.items():
+                    tri_indices = [int(v) for v in tri]
                     tri_bin, tri_type = _pack_indices(tri_indices)
                     tri_view = _emit_buffer_view(gltf, tri_bin, 34963)
                     tri_acc = _emit_accessor(
@@ -1258,12 +1327,20 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                             "indices": tri_acc,
                             "mode": 4,
                             "material": material_index,
+                            "extras": {
+                                "source_primitive_kind": "triangle",
+                                "source_primitive_index": tri_index,
+                                "source_color": color,
+                                "source_order_sensitive": True,
+                            },
                         }
                     )
 
-            lines_by_color: Dict[Optional[int], set[Tuple[int, int]]] = {}
-            points_by_color: Dict[Optional[int], set[int]] = {}
-            for line in lines:
+            # Lines and degenerate point features carry visible model detail
+            # (antennas, masts, deck markings). Emit one primitive per decoded
+            # source item so different-colored line/point features are not
+            # accidentally reordered by material batching.
+            for line_index, line in enumerate(lines):
                 if len(line) == 2:
                     a, b = int(line[0]), int(line[1])
                     color = None
@@ -1272,62 +1349,56 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                     color = line[2]
                     color = None if color is None else int(color)
                 if a == b:
-                    if 0 <= a < len(vertices):
-                        points_by_color.setdefault(color, set()).add(a)
-                        _bump_color_count(shape_color_usage["points"], color)
-                        _bump_color_count(gltf["extras"]["raw_color_usage"]["points"], color)
-                    continue
-                lines_by_color.setdefault(color, set()).add(tuple(sorted((a, b))))
-                _bump_color_count(shape_color_usage["lines"], color)
-                _bump_color_count(gltf["extras"]["raw_color_usage"]["lines"], color)
-
-            for color, point_set in sorted(points_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
-                uniq_points = sorted(point_set)
-                if not uniq_points:
-                    continue
-                point_bin, point_type = _pack_indices(uniq_points)
-                point_view = _emit_buffer_view(gltf, point_bin, 34963)
-                point_acc = _emit_accessor(
-                    gltf,
-                    point_view,
-                    component_type=point_type,
-                    type_name="SCALAR",
-                    count=len(uniq_points),
-                )
-                gltf["accessors"][point_acc]["min"] = [0]
-                gltf["accessors"][point_acc]["max"] = [max(0, len(vertices) - 1)]
-
-                if color is None:
-                    material_index = 0
-                else:
-                    r, g, b, a = _face_material_color(color)
-                    material_index = len(gltf["materials"])
-                    gltf["materials"].append(
+                    if not (0 <= a < len(vertices)):
+                        continue
+                    point_bin, point_type = _pack_indices([a])
+                    point_view = _emit_buffer_view(gltf, point_bin, 34963)
+                    point_acc = _emit_accessor(
+                        gltf,
+                        point_view,
+                        component_type=point_type,
+                        type_name="SCALAR",
+                        count=1,
+                    )
+                    gltf["accessors"][point_acc]["min"] = [0]
+                    gltf["accessors"][point_acc]["max"] = [max(0, len(vertices) - 1)]
+                    if color is None:
+                        material_index = 0
+                    else:
+                        r, g, b, a_rgba = _face_material_color(color)
+                        material_index = len(gltf["materials"])
+                        gltf["materials"].append(
+                            {
+                                "name": f"points_color_0x{color:02x}_{line_index:03d}",
+                                "doubleSided": True,
+                                "pbrMetallicRoughness": {
+                                    "baseColorFactor": [r, g, b, a_rgba],
+                                    "metallicFactor": 0.0,
+                                    "roughnessFactor": 1.0,
+                                },
+                            }
+                        )
+                    _bump_color_count(shape_color_usage["points"], color)
+                    _bump_color_count(gltf["extras"]["raw_color_usage"]["points"], color)
+                    primitives.append(
                         {
-                            "name": f"points_color_0x{color:02x}",
-                            "doubleSided": True,
-                            "pbrMetallicRoughness": {
-                                "baseColorFactor": [r, g, b, a],
-                                "metallicFactor": 0.0,
-                                "roughnessFactor": 1.0,
+                            "attributes": {"POSITION": pos_acc},
+                            "indices": point_acc,
+                            "mode": 0,
+                            "material": material_index,
+                            "extras": {
+                                "source_primitive_kind": "points",
+                                "source_primitive_index": line_index,
+                                "source_color": color,
+                                "source_order_sensitive": True,
                             },
                         }
                     )
-
-                primitives.append(
-                    {
-                        "attributes": {"POSITION": pos_acc},
-                        "indices": point_acc,
-                        "mode": 0,
-                        "material": material_index,
-                    }
-                )
-
-            for color, line_set in sorted(lines_by_color.items(), key=lambda item: -1 if item[0] is None else item[0]):
-                uniq_lines = sorted(line_set)
-                if not uniq_lines:
                     continue
-                line_indices = [int(v) for edge in uniq_lines for v in edge]
+
+                if not (0 <= a < len(vertices) and 0 <= b < len(vertices)):
+                    continue
+                line_indices = [a, b]
                 line_bin, line_type = _pack_indices(line_indices)
                 line_view = _emit_buffer_view(gltf, line_bin, 34963)
                 line_acc = _emit_accessor(
@@ -1343,26 +1414,34 @@ def export_3d3_to_gltf(payload: Dict[str, Any]) -> Dict[str, Any]:
                 if color is None:
                     material_index = 0
                 else:
-                    r, g, b, a = _face_material_color(color)
+                    r, g, b_rgb, a_rgba = _face_material_color(color)
                     material_index = len(gltf["materials"])
                     gltf["materials"].append(
                         {
-                            "name": f"lines_color_0x{color:02x}",
+                            "name": f"lines_color_0x{color:02x}_{line_index:03d}",
                             "doubleSided": True,
                             "pbrMetallicRoughness": {
-                                "baseColorFactor": [r, g, b, a],
+                                "baseColorFactor": [r, g, b_rgb, a_rgba],
                                 "metallicFactor": 0.0,
                                 "roughnessFactor": 1.0,
                             },
                         }
                     )
 
+                _bump_color_count(shape_color_usage["lines"], color)
+                _bump_color_count(gltf["extras"]["raw_color_usage"]["lines"], color)
                 primitives.append(
                     {
                         "attributes": {"POSITION": pos_acc},
                         "indices": line_acc,
                         "mode": 1,
                         "material": material_index,
+                        "extras": {
+                            "source_primitive_kind": "lines",
+                            "source_primitive_index": line_index,
+                            "source_color": color,
+                            "source_order_sensitive": True,
+                        },
                     }
                 )
 
@@ -1419,6 +1498,112 @@ def export_3d3_to_glb(payload: Dict[str, Any]) -> bytes:
     """Export a ``3D3`` payload as a binary glTF (`.glb`) blob."""
     gltf = export_3d3_to_gltf(payload)
     return export_3d3_gltf_to_glb(gltf)
+
+
+def _minimized_single_mesh_gltf(gltf: Dict[str, Any], mesh: Dict[str, Any], shape_index: int, shape_name: str) -> Dict[str, Any]:
+    """Build a self-contained glTF containing one mesh and only referenced data."""
+    buffer_uri = gltf["buffers"][0].get("uri", "")
+    if not buffer_uri.startswith("data:application/octet-stream;base64,"):
+        raise ValueError("expected embedded binary buffer URI in glTF payload")
+    src_buffer = from_base64(buffer_uri.split(",", 1)[1])
+
+    accessor_map: Dict[int, int] = {}
+    buffer_view_map: Dict[int, int] = {}
+    material_map: Dict[int, int] = {}
+    out_buffer = bytearray()
+    out: Dict[str, Any] = {
+        "asset": copy.deepcopy(gltf.get("asset", {"version": "2.0"})),
+        "scene": 0,
+        "scenes": [{"name": "default", "nodes": [0]}],
+        "nodes": [{"name": shape_name, "mesh": 0}],
+        "meshes": [],
+        "accessors": [],
+        "bufferViews": [],
+        "buffers": [{"byteLength": 0, "uri": "data:application/octet-stream;base64,"}],
+        "materials": [],
+        "extras": copy.deepcopy(gltf.get("extras", {})),
+    }
+    out["extras"]["source_shape_index"] = shape_index
+    out["extras"]["source_shape_name"] = shape_name
+    out["extras"]["minimized_per_shape_glb"] = True
+
+    def remap_buffer_view(old_view_index: int) -> int:
+        if old_view_index in buffer_view_map:
+            return buffer_view_map[old_view_index]
+        old_view = gltf["bufferViews"][old_view_index]
+        src_offset = int(old_view.get("byteOffset", 0))
+        src_length = int(old_view.get("byteLength", 0))
+        out_buffer.extend(b"\x00" * _align4(len(out_buffer)))
+        dst_offset = len(out_buffer)
+        out_buffer.extend(src_buffer[src_offset : src_offset + src_length])
+        new_view = copy.deepcopy(old_view)
+        new_view["buffer"] = 0
+        new_view["byteOffset"] = dst_offset
+        new_view["byteLength"] = src_length
+        new_index = len(out["bufferViews"])
+        out["bufferViews"].append(new_view)
+        buffer_view_map[old_view_index] = new_index
+        return new_index
+
+    def remap_accessor(old_accessor_index: int) -> int:
+        if old_accessor_index in accessor_map:
+            return accessor_map[old_accessor_index]
+        old_accessor = gltf["accessors"][old_accessor_index]
+        new_accessor = copy.deepcopy(old_accessor)
+        if "bufferView" in new_accessor:
+            new_accessor["bufferView"] = remap_buffer_view(int(new_accessor["bufferView"]))
+        new_index = len(out["accessors"])
+        out["accessors"].append(new_accessor)
+        accessor_map[old_accessor_index] = new_index
+        return new_index
+
+    def remap_material(old_material_index: int) -> int:
+        if old_material_index in material_map:
+            return material_map[old_material_index]
+        new_index = len(out["materials"])
+        out["materials"].append(copy.deepcopy(gltf["materials"][old_material_index]))
+        material_map[old_material_index] = new_index
+        return new_index
+
+    new_mesh = copy.deepcopy(mesh)
+    for prim in new_mesh.get("primitives", []):
+        attrs = prim.get("attributes", {})
+        if isinstance(attrs, dict):
+            for attr_name, accessor_index in list(attrs.items()):
+                attrs[attr_name] = remap_accessor(int(accessor_index))
+        if "indices" in prim:
+            prim["indices"] = remap_accessor(int(prim["indices"]))
+        if "material" in prim:
+            prim["material"] = remap_material(int(prim["material"]))
+
+    out["meshes"] = [new_mesh]
+    out["buffers"][0]["uri"] = "data:application/octet-stream;base64," + to_base64(bytes(out_buffer))
+    out["buffers"][0]["byteLength"] = len(out_buffer)
+    return out
+
+
+def export_3d3_shape_gltfs(payload: Dict[str, Any]) -> List[Tuple[int, str, Dict[str, Any]]]:
+    """Export renderable 3D3 shapes as individual self-contained glTF documents.
+
+    Each returned document keeps only the accessors, bufferViews, materials, and
+    embedded binary buffer ranges referenced by the one exported mesh.
+    """
+    gltf = export_3d3_to_gltf(payload)
+    out: List[Tuple[int, str, Dict[str, Any]]] = []
+    for mesh in gltf.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        extras = mesh.get("extras", {})
+        if not isinstance(extras, dict):
+            extras = {}
+        try:
+            shape_index = int(extras.get("shape_index", len(out)))
+        except (TypeError, ValueError):
+            shape_index = len(out)
+        shape_name = str(extras.get("shape_name") or mesh.get("name") or f"shape_{shape_index:03d}")
+        shape_doc = _minimized_single_mesh_gltf(gltf, mesh, shape_index, shape_name)
+        out.append((shape_index, shape_name, shape_doc))
+    return out
 
 
 def export_3d3_gltf_to_glb(gltf: Dict[str, Any]) -> bytes:

--- a/tools/f15assets/f15assets/pic.py
+++ b/tools/f15assets/f15assets/pic.py
@@ -530,12 +530,35 @@ DEFAULT_EGA16_PALETTE_6BIT = [
     0x3F,
 ]
 
+WALL_PIC_PALETTE1_EGA16_6BIT = [
+    0x00, 0x00, 0x00,
+    0x00, 0x00, 0x2A,
+    0x00, 0x2A, 0x00,
+    0x00, 0x2A, 0x2A,
+    0x2A, 0x00, 0x00,
+    0x00, 0x00, 0x00,
+    0x2A, 0x15, 0x00,
+    0x2A, 0x2A, 0x2A,
+    0x15, 0x15, 0x15,
+    0x15, 0x15, 0x3F,
+    0x15, 0x3F, 0x15,
+    0x15, 0x3F, 0x3F,
+    0x3F, 0x15, 0x15,
+    0x3F, 0x15, 0x3F,
+    0x3F, 0x3F, 0x15,
+    0x3F, 0x3F, 0x3F,
+]
+
 _DEFAULT_VGA256_PALETTE_CACHE: Optional[List[int]] = None
 
 
 def _to_png_color_rgb8(value_6bit: int) -> int:
     value_8bit = int(value_6bit) & 0x3F
     return max(0, min(255, (value_8bit << 2) | (value_8bit >> 4)))
+
+
+def _dac6_palette_to_rgb8(values_6bit: List[int]) -> List[int]:
+    return [_to_png_color_rgb8(value) for value in values_6bit]
 
 
 def _extract_u8_array_from_source(name: str) -> Optional[List[int]]:
@@ -650,6 +673,97 @@ def _fallback_vga_palette(index_bit_depth: int) -> List[int]:
 
 def _default_palette(index_bit_depth: int) -> List[int]:
     return _fallback_vga_palette(index_bit_depth)
+
+
+RUNTIME_DAC_PALETTE1_FILES = {
+    "WALL.PIC",
+    "HISCORE.PIC",
+    "DESK.PIC",
+    "DEATH.PIC",
+    "PROMO.PIC",
+    "MEDAL.PIC",
+}
+
+RUNTIME_DAC_PALETTE4_FILES = {
+    "TITLE16.PIC",
+}
+
+
+def known_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> Optional[Dict[str, Any]]:
+    if not source_name:
+        return None
+    source_file = Path(source_name).name.upper()
+    if source_file in RUNTIME_DAC_PALETTE1_FILES:
+        dac_values = WALL_PIC_PALETTE1_EGA16_6BIT
+        palette_id = 1
+    elif source_file in RUNTIME_DAC_PALETTE4_FILES:
+        dac_values = [
+            0x00, 0x00, 0x00,
+            0x00, 0x00, 0x2A,
+            0x00, 0x00, 0x00,
+            0x00, 0x2A, 0x2A,
+            0x2A, 0x00, 0x00,
+            0x2A, 0x00, 0x2A,
+            0x2A, 0x15, 0x00,
+            0x2A, 0x2A, 0x2A,
+            0x15, 0x15, 0x15,
+            0x15, 0x15, 0x3F,
+            0x00, 0x00, 0x00,
+            0x15, 0x3F, 0x3F,
+            0x3F, 0x15, 0x15,
+            0x3F, 0x15, 0x3F,
+            0x3F, 0x3F, 0x15,
+            0x3F, 0x3F, 0x3F,
+        ]
+        palette_id = 4
+    else:
+        return None
+
+    # PIC streams carry indices only. These files are known to be displayed under
+    # a non-default gfx_setDac() state, so the self-contained PNG must embed that
+    # active DAC state rather than the generic VGA/EGA palette.
+    palette = list(_default_palette(index_bit_depth))
+    palette[:48] = _dac6_palette_to_rgb8(dac_values)
+    return {
+        "palette_rgb8": palette[:768],
+        "palette_dac6": dac_values[:],
+        "profile": {
+            "source": f"known_runtime_gfx_setDac_{palette_id}",
+            "status": "known_external_runtime_palette",
+            "source_file": source_file,
+            "index_mode": "indexed",
+            "index_bit_depth": index_bit_depth,
+            "color_mode": "palette_index",
+            "palette_format": "vga_dac_6bit_rgb_triples_first_16",
+            "notes": f"Runtime sets DAC palette {palette_id} around this screen; PNG embeds that active palette.",
+        },
+    }
+
+
+def expected_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> Dict[str, Any]:
+    known = known_runtime_pic_palette(source_name, index_bit_depth)
+    if known is not None:
+        return known
+
+    # Most static PIC/SPR files are decoded under the default low 16 DAC plus
+    # the generated VGA 256-color table. Returning this for every source makes
+    # validation compare palette bytes for all indexed PNG replacements instead
+    # of silently skipping files whose original PIC stream has no embedded DAC.
+    palette = list(_default_palette(index_bit_depth))
+    return {
+        "palette_rgb8": palette[:768],
+        "palette_dac6": [],
+        "profile": {
+            "source": "default_runtime_vga_dac",
+            "status": "expected_default_runtime_palette",
+            "source_file": Path(source_name).name if source_name else None,
+            "index_mode": "indexed",
+            "index_bit_depth": index_bit_depth,
+            "color_mode": "palette_index",
+            "palette_format": "rgb8_256_entries",
+            "notes": "Default runtime DAC palette used when no source-specific gfx_setDac context is known.",
+        },
+    }
 
 
 def to_png_data(

--- a/tools/f15assets/f15assets/pic.py
+++ b/tools/f15assets/f15assets/pic.py
@@ -22,6 +22,7 @@ _M0_PIC_IMAGE_HEADER_SIZE = 8
 
 class _PICBitReader:
     def __init__(self, data: bytes):
+        """Initialize the _PICBitReader codec state."""
         self._data = data
         # The first word is both the first compressed bits and the source for
         # the format mode byte. The original decoder consumes codes from this
@@ -33,6 +34,7 @@ class _PICBitReader:
         self._remaining = 8
 
     def read_code(self, code_width: int) -> int:
+        """Read one variable-width code from the compressed bit stream."""
         bits = self._word >> (16 - self._remaining)
         cl = self._remaining
         if cl < code_width:
@@ -56,6 +58,7 @@ class _PICBitReader:
 
 class _LZWDecoder:
     def __init__(self, bit_reader: _PICBitReader, max_width: int):
+        """Initialize the _LZWDecoder codec state."""
         self._reader = bit_reader
         self._max_width = max(9, max_width)
         self._code_width = 9
@@ -71,6 +74,7 @@ class _LZWDecoder:
         self._reset_dictionary()
 
     def _reset_dictionary(self) -> None:
+        """Perform the reset dictionary asset-processing operation."""
         for i in range(256):
             self._dict_parent[i] = 0xFFFF
             self._dict_char[i] = i
@@ -79,6 +83,7 @@ class _LZWDecoder:
         self._max_code_at_width = 0x1FF
 
     def _decode_code(self) -> List[int]:
+        """Decode code while preserving legacy semantics."""
         code = self._reader.read_code(self._code_width)
         orig_code = code
         stack: List[int] = []
@@ -119,11 +124,13 @@ class _LZWDecoder:
         return stack
 
     def get_next_byte(self) -> int:
+        """Return the next byte from the decompressed stream."""
         while len(self._out_buf) == 0:
             self._out_buf.extend(self._decode_code())
         return self._out_buf.pop(0)
 
     def decode_row(self, count: int) -> bytes:
+        """Decode row while preserving legacy semantics."""
         out = bytearray()
         safety = 0
 
@@ -156,6 +163,7 @@ class _LZWDecoder:
 
 class _LZWEncoder:
     def __init__(self, max_width: int):
+        """Initialize the _LZWEncoder codec state."""
         self._max_width = max(1, max_width)
         self._code_width = 9
         self._max_code_at_width = 0x1FF
@@ -166,11 +174,13 @@ class _LZWEncoder:
         self._packed: List[int] = []
 
     def _reset_dictionary(self) -> None:
+        """Perform the reset dictionary asset-processing operation."""
         self._next_code = 256
         self._code_width = 9
         self._max_code_at_width = 0x1FF
 
     def _emit(self, code: int) -> None:
+        """Append one code to the packed output stream."""
         mask = (1 << self._code_width) - 1
         self._bit_buffer |= (code & mask) << self._bit_count
         self._bit_count += self._code_width
@@ -180,6 +190,7 @@ class _LZWEncoder:
             self._bit_count -= 8
 
     def finalize(self) -> bytes:
+        """Flush pending bits and return the completed encoded stream."""
         if self._bit_count:
             self._packed.append(self._bit_buffer & 0xFF)
             self._bit_buffer = 0
@@ -187,6 +198,7 @@ class _LZWEncoder:
         return bytes(self._packed)
 
     def encode(self, payload: bytes) -> bytes:
+        """Encode source bytes with the game-compatible LZW variant."""
         if not payload:
             return self.finalize()
 
@@ -213,6 +225,7 @@ def decode_pic_asset(
     source_name: str | None = None,
     forced_bitstream_mode: str | None = None,
 ) -> Dict[str, Any]:
+    """Decode pic asset while preserving legacy semantics."""
     if len(data) < 2:
         raise ValueError("PIC payload is too short")
 
@@ -294,6 +307,7 @@ def _is_m0_wrapped_pic(data: bytes) -> bool:
     # M0 stores a small wrapper header, a 256-entry VGA DAC palette, then an
     # inner PIC-like compressed image. It is detected structurally because the
     # game still names these files *.PIC.
+    """Return whether m0 wrapped pic."""
     if len(data) < _M0_PIC_HEADER_SIZE + _M0_PIC_PALETTE_SIZE + _M0_PIC_IMAGE_HEADER_SIZE + 2:
         return False
     if data[:2] != b"M0":
@@ -306,10 +320,12 @@ def _is_m0_wrapped_pic(data: bytes) -> bool:
 
 def _palette_dac6_to_rgb8(palette_dac6: bytes) -> List[int]:
     # VGA DAC channels are 6-bit values. PNG palettes need 8-bit channels.
+    """Perform the palette dac6 to rgb8 asset-processing operation."""
     return [_to_png_color_rgb8(value) for value in palette_dac6[:768]]
 
 
 def _decode_m0_wrapped_pic(data: bytes, *, source_name: str | None = None) -> Dict[str, Any]:
+    """Decode m0 wrapped pic while preserving legacy semantics."""
     palette_offset = _M0_PIC_HEADER_SIZE
     image_header_offset = palette_offset + _M0_PIC_PALETTE_SIZE
     inner_offset = image_header_offset + _M0_PIC_IMAGE_HEADER_SIZE
@@ -352,6 +368,7 @@ def decode_title640_pic_asset(data: bytes, *, source_name: str | None = None) ->
     # calling the start-module PIC blitter. The decompressor still emits 320
     # bytes per row; empirically row pairs are left/right halves of one
     # 640-pixel scanline.
+    """Decode title640 pic asset while preserving legacy semantics."""
     raw_payload = decode_pic_asset(
         data,
         row_count=TITLE640_HEIGHT * 2,
@@ -391,6 +408,7 @@ def decode_title640_pic_asset(data: bytes, *, source_name: str | None = None) ->
 
 
 def _pack_nibbles(nibble_pixels: bytes) -> bytes:
+    """Pack nibbles."""
     if len(nibble_pixels) & 1:
         nibble_pixels = nibble_pixels + b"\x00"
     out = bytearray()
@@ -400,6 +418,7 @@ def _pack_nibbles(nibble_pixels: bytes) -> bytes:
 
 
 def encode_pic_asset(record: Dict[str, Any], *, source_pixels: Optional[bytes] = None) -> bytes:
+    """Encode pic asset."""
     preserved_payload = record.get("compressed_payload_base64")
     if source_pixels is None and preserved_payload:
         return from_base64(str(preserved_payload))
@@ -445,6 +464,7 @@ def encode_pic_asset(record: Dict[str, Any], *, source_pixels: Optional[bytes] =
 
 
 def _rle_encode(payload: bytes) -> bytes:
+    """Perform the rle encode asset-processing operation."""
     if not payload:
         return b""
 
@@ -474,6 +494,7 @@ def _rle_encode(payload: bytes) -> bytes:
 
 
 def decode_pic_to_raw_rgba(data: bytes, row_count: int = PIC_HEIGHT) -> List[int]:
+    """Decode pic to raw rgba while preserving legacy semantics."""
     doc = decode_pic_asset(data, row_count=row_count)
     pixels = from_base64(doc["pixels_base64"])
     return list(pixels)
@@ -553,15 +574,18 @@ _DEFAULT_VGA256_PALETTE_CACHE: Optional[List[int]] = None
 
 
 def _to_png_color_rgb8(value_6bit: int) -> int:
+    """Convert normalized asset data to png color rgb8."""
     value_8bit = int(value_6bit) & 0x3F
     return max(0, min(255, (value_8bit << 2) | (value_8bit >> 4)))
 
 
 def _dac6_palette_to_rgb8(values_6bit: List[int]) -> List[int]:
+    """Perform the dac6 palette to rgb8 asset-processing operation."""
     return [_to_png_color_rgb8(value) for value in values_6bit]
 
 
 def _extract_u8_array_from_source(name: str) -> Optional[List[int]]:
+    """Extract u8 array from source."""
     source_path = Path(__file__).resolve().parents[3] / "src" / "egdata.c"
     if not source_path.exists():
         for i in (4, 3, 2, 1):
@@ -617,6 +641,7 @@ def _extract_u8_array_from_source(name: str) -> Optional[List[int]]:
 
 
 def _build_default_vga256_palette() -> Optional[List[int]]:
+    """Build default vga256 palette from normalized asset data."""
     global _DEFAULT_VGA256_PALETTE_CACHE
     if _DEFAULT_VGA256_PALETTE_CACHE is not None:
         return _DEFAULT_VGA256_PALETTE_CACHE
@@ -649,6 +674,7 @@ def _build_default_vga256_palette() -> Optional[List[int]]:
 
 
 def _fallback_vga_palette(index_bit_depth: int) -> List[int]:
+    """Perform the fallback vga palette asset-processing operation."""
     if index_bit_depth <= 4:
         return [_to_png_color_rgb8(c) for c in DEFAULT_EGA16_PALETTE_6BIT]
 
@@ -672,6 +698,7 @@ def _fallback_vga_palette(index_bit_depth: int) -> List[int]:
 
 
 def _default_palette(index_bit_depth: int) -> List[int]:
+    """Perform the default palette asset-processing operation."""
     return _fallback_vga_palette(index_bit_depth)
 
 
@@ -690,6 +717,7 @@ RUNTIME_DAC_PALETTE4_FILES = {
 
 
 def known_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> Optional[Dict[str, Any]]:
+    """Return the palette selected by the original runtime for a known PIC."""
     if not source_name:
         return None
     source_file = Path(source_name).name.upper()
@@ -741,6 +769,7 @@ def known_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> 
 
 
 def expected_runtime_pic_palette(source_name: str | None, index_bit_depth: int) -> Dict[str, Any]:
+    """Resolve the authoritative palette for replacement validation."""
     known = known_runtime_pic_palette(source_name, index_bit_depth)
     if known is not None:
         return known
@@ -774,6 +803,7 @@ def to_png_data(
     index_bit_depth: int = 8,
     palette: Optional[List[int]] = None,
 ) -> "Image.Image":
+    """Convert normalized asset data to png data."""
     try:
         from PIL import Image
     except Exception as exc:
@@ -790,6 +820,7 @@ def to_png_data(
 
 
 def png_to_pixels(path: str) -> bytes:
+    """Perform the png to pixels asset-processing operation."""
     try:
         from PIL import Image
     except Exception as exc:

--- a/tools/f15assets/f15assets/sounds.py
+++ b/tools/f15assets/f15assets/sounds.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+import struct
 import wave
 from pathlib import Path
 from typing import Any, Dict, List
-
-from .io import to_base64
 
 # The sound drivers program the PIT in the 8 kHz range. One recovered path uses
 # a 0x98 low-byte divisor, which is about 7850 Hz on a 1.193182 MHz PIT.
 DEFAULT_SAMPLE_RATE = 7850
 SOUND_DRIVER_NAMES = ("NSOUND.EXE", "ASOUND.EXE", "ISOUND.EXE", "RSOUND.EXE", "TSOUND.EXE")
 DIGITIZED_SAMPLE_BLOB = "F15DGTL.BIN"
+ASOUND_TICK_HZ = 60
 
 # ASOUND.EXE does not store a simple monotonic split list. The game calls
 # audio_playSample(weaponIdx), and ASOUND dispatches only sample offsets 0, 2,
@@ -100,9 +101,9 @@ def decode_digitized_blob(data: bytes, *, sample_rate: int = DEFAULT_SAMPLE_RATE
             "F15DGTL.BIN is exported as a single raw unsigned 8-bit PCM stream. "
             "Enumerated cue WAV files are emitted from ASOUND.EXE playback ranges. "
             "voiceCueThresholds in egdata.c are availability guards, not the full "
-            "sample split table."
+            "sample split table. WAV files are authoritative for sample data and "
+            "audio format; JSON is supplemental cue/index metadata."
         ),
-        "source_bytes_base64": to_base64(data),
     }
 
 
@@ -132,15 +133,15 @@ def infer_digitized_segments(data: bytes) -> List[Dict[str, Any]]:
 
 
 def unresolved_sound_driver_record(path: Path, data: bytes) -> Dict[str, Any]:
-    # Preserve driver executables byte-for-byte in metadata. They contain the
-    # actual hardware playback/synthesis logic, but the exporter only decodes
-    # the external digitized blob today.
+    # Preserve only portable identification metadata for the DOS sound drivers.
+    # The executable bytes are not useful authoring files for customizers; they
+    # remain in the original game directory for future driver research.
     return {
         "format": "F15_SOUND_DRIVER",
         "version": 1,
         "id": path.name,
         "status": "unresolved",
-        "source_file": str(path),
+        "source_file": path.name,
         "source_offset": 0,
         "source_length": len(data),
         "source_bytes_sha256": _sha256(data),
@@ -150,100 +151,342 @@ def unresolved_sound_driver_record(path: Path, data: bytes) -> Dict[str, Any]:
             "Effect mapping, synthesis parameters, and sample split tables are "
             "not decoded by this exporter yet."
         ),
-        "source_bytes_base64": to_base64(data),
     }
 
 
-def export_sounds(asset_root: Path, output_root: Path, *, sample_rate: int = DEFAULT_SAMPLE_RATE) -> Dict[str, Any]:
+def _repo_root_from_tools() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _extract_asound_array(source_text: str, name: str) -> List[int]:
+    match = re.search(
+        rf"const\s+AsoundU8\s+{re.escape(name)}\[\]\s*=\s*\{{(?P<body>.*?)\}};",
+        source_text,
+        re.S,
+    )
+    if not match:
+        raise ValueError(f"missing ASOUND stream array {name}")
+    values: List[int] = []
+    for token in re.findall(r"0x[0-9a-fA-F]+|\b\d+\b", match.group("body")):
+        values.append(int(token, 0) & 0xFF)
+    return values
+
+
+def _decode_asound_stream(stream: List[int], voice: int, *, max_events: int = 10000) -> List[Dict[str, Any]]:
+    pos = 0
+    tick = 0
+    loop_pos = 0
+    loop_count = 0
+    keyoff_gap = 1
+    events: List[Dict[str, Any]] = []
+
+    for _ in range(max_events):
+        if pos >= len(stream):
+            events.append({"tick": tick, "voice": voice, "type": "stream_end", "reason": "eof"})
+            return events
+        op = stream[pos]
+        pos += 1
+        if op < 0xF8:
+            if pos >= len(stream):
+                events.append({"tick": tick, "voice": voice, "type": "decode_error", "reason": "truncated_note"})
+                return events
+            duration = stream[pos]
+            pos += 1
+            if op == 0 and duration == 0:
+                events.append({"tick": tick, "voice": voice, "type": "stream_end", "reason": "zero_note"})
+                return events
+            # The runtime schedules key-off before the full duration. Preserve
+            # both values so JSON is lossless enough for a future native loader;
+            # MIDI uses sounding_ticks for note length.
+            sounding_ticks = max(1, duration - keyoff_gap) if duration > keyoff_gap else 1
+            events.append(
+                {
+                    "tick": tick,
+                    "voice": voice,
+                    "type": "note",
+                    "note": op,
+                    "duration_ticks": duration,
+                    "sounding_ticks": sounding_ticks,
+                    "keyoff_gap_ticks": keyoff_gap,
+                }
+            )
+            tick += duration
+            continue
+        if op == 0xF8:
+            period = stream[pos] if pos < len(stream) else 0
+            step = stream[pos + 1] if pos + 1 < len(stream) else 0
+            pos += 2
+            events.append({"tick": tick, "voice": voice, "type": "volume_fade", "period": period, "step": struct.unpack("b", bytes([step]))[0]})
+        elif op == 0xF9:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "volume", "value": value})
+        elif op == 0xFA:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "pitch_delta", "value": struct.unpack("b", bytes([value]))[0]})
+        elif op == 0xFB:
+            keyoff_gap = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "keyoff_gap", "ticks": keyoff_gap})
+        elif op == 0xFC:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            events.append({"tick": tick, "voice": voice, "type": "instrument", "value": value})
+        elif op == 0xFD:
+            events.append({"tick": tick, "voice": voice, "type": "stream_end", "reason": "callback_or_end"})
+            return events
+        elif op == 0xFE:
+            loop_pos = pos
+            events.append({"tick": tick, "voice": voice, "type": "loop_start", "stream_pos": loop_pos})
+        elif op == 0xFF:
+            value = stream[pos] if pos < len(stream) else 0
+            pos += 1
+            if loop_count == 0:
+                loop_count = value
+                pos = loop_pos
+            else:
+                loop_count -= 1
+                if loop_count != 0:
+                    pos = loop_pos
+                else:
+                    loop_pos = pos
+            events.append({"tick": tick, "voice": voice, "type": "loop", "count": value, "remaining": loop_count})
+    raise ValueError("ASOUND stream decode exceeded safety event limit")
+
+
+def _write_varlen(value: int) -> bytes:
+    value = max(0, int(value))
+    out = [value & 0x7F]
+    value >>= 7
+    while value:
+        out.append(0x80 | (value & 0x7F))
+        value >>= 7
+    return bytes(reversed(out))
+
+
+def _midi_track(events: List[tuple[int, bytes]]) -> bytes:
+    events = sorted(events, key=lambda item: item[0])
+    data = bytearray()
+    last = 0
+    for tick, payload in events:
+        data.extend(_write_varlen(tick - last))
+        data.extend(payload)
+        last = tick
+    data.extend(b"\x00\xFF\x2F\x00")
+    return b"MTrk" + struct.pack(">I", len(data)) + data
+
+
+def _write_intro_midi(path: Path, voices: List[Dict[str, Any]]) -> None:
+    ppq = 480
+    midi_ticks_per_asound_tick = 16  # 60 Hz ASOUND tick at 120 BPM.
+    tracks = []
+    meta = [
+        (0, b"\xFF\x51\x03\x07\xA1\x20"),  # 120 BPM
+        (0, b"\xFF\x58\x04\x04\x02\x18\x08"),
+    ]
+    tracks.append(_midi_track(meta))
+    for voice in voices:
+        channel = int(voice["voice"]) % 16
+        track_events: List[tuple[int, bytes]] = []
+        current_program = 0
+        for event in voice["events"]:
+            tick = int(event["tick"]) * midi_ticks_per_asound_tick
+            if event["type"] == "instrument":
+                current_program = int(event["value"]) % 128
+                track_events.append((tick, bytes([0xC0 | channel, current_program])))
+            elif event["type"] == "note" and int(event["note"]) > 0:
+                note = max(0, min(127, int(event["note"])))
+                velocity = 96
+                end_tick = tick + int(event["sounding_ticks"]) * midi_ticks_per_asound_tick
+                track_events.append((tick, bytes([0x90 | channel, note, velocity])))
+                track_events.append((end_tick, bytes([0x80 | channel, note, 0])))
+        tracks.append(_midi_track(track_events))
+    header = b"MThd" + struct.pack(">IHHH", 6, 1, len(tracks), ppq)
+    path.write_bytes(header + b"".join(tracks))
+
+
+def export_intro_music(output_root: Path, *, repo_root: Path | None = None) -> Dict[str, Any]:
+    repo = repo_root or _repo_root_from_tools()
+    model_path = repo / "src" / "asound" / "asound_model.c"
+    source_text = model_path.read_text(encoding="utf-8")
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    voices: List[Dict[str, Any]] = []
+    for phase in ("intro", "release"):
+        for voice in range(6):
+            name = f"asound_{phase}_voice{voice}"
+            stream = _extract_asound_array(source_text, name)
+            voices.append(
+                {
+                    "phase": phase,
+                    "voice": voice,
+                    "source_symbol": name,
+                    "stream_bytes": stream,
+                    "events": _decode_asound_stream(stream, voice),
+                }
+            )
+
+    json_path = output_root / "intro_music.asound.json"
+    midi_path = output_root / "intro_music.mid"
+    record = {
+        "format": "F15_ASOUND_MUSIC",
+        "version": 1,
+        "source": "recovered_asound_model",
+        "source_file": "src/asound/asound_model.c",
+        "tick_hz": ASOUND_TICK_HZ,
+        "runtime_authoritative": "intro_music.asound.json",
+        "midi_preview": midi_path.name,
+        "notes": "ASOUND JSON preserves driver stream commands. MIDI is a best-effort note preview and does not preserve OPL instrument timbre.",
+        "voices": voices,
+    }
+    json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_intro_midi(midi_path, [voice for voice in voices if voice["phase"] == "intro"])
+    return {
+        "id": "intro_music",
+        "status": "decoded_recovered_asound_streams",
+        "json": json_path.name,
+        "midi": midi_path.name,
+        "runtime_authoritative": json_path.name,
+        "notes": "MIDI is for editing/preview; ASOUND JSON is the lossless replacement candidate.",
+    }
+
+
+def export_sounds(
+    asset_root: Path,
+    output_root: Path,
+    *,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    include_raw_blob: bool = False,
+    include_metadata: bool = False,
+) -> Dict[str, Any]:
     output_root.mkdir(parents=True, exist_ok=True)
     exported: List[Dict[str, Any]] = []
+
+    # Keep repeated default conversions honest: optional metadata/reference
+    # files from older runs must not linger and look like required customizer
+    # assets. The cue WAV files are the default authoring/runtime surface.
+    if not include_metadata:
+        for stale_path in output_root.glob("voice_cue_*.json"):
+            stale_path.unlink()
+        for stale_path in output_root.glob("*_driver.json"):
+            stale_path.unlink()
+        stale_index = output_root / "sounds.json"
+        if stale_index.exists():
+            stale_index.unlink()
+    if not include_raw_blob:
+        for stale_name in ("f15dgtl_raw.wav", "f15dgtl_raw.json"):
+            stale_path = output_root / stale_name
+            if stale_path.exists():
+                stale_path.unlink()
 
     blob_path = asset_root / DIGITIZED_SAMPLE_BLOB
     if blob_path.exists():
         data = blob_path.read_bytes()
-        wav_path = output_root / "f15dgtl_raw.wav"
-        json_path = output_root / "f15dgtl_raw.json"
-        write_unsigned_pcm8_wav(wav_path, data, sample_rate=sample_rate)
-        record = decode_digitized_blob(data, sample_rate=sample_rate)
-        record["source_file"] = str(blob_path)
-        record["wav_file"] = str(wav_path)
-        for segment in record["segments"]:
+        segments = infer_digitized_segments(data)
+
+        if include_raw_blob:
+            wav_path = output_root / "f15dgtl_raw.wav"
+            json_path = output_root / "f15dgtl_raw.json"
+            write_unsigned_pcm8_wav(wav_path, data, sample_rate=sample_rate)
+            record = decode_digitized_blob(data, sample_rate=sample_rate)
+            # Keep JSON portable: source_file names the original game asset, and
+            # wav/json references are relative to this sound export directory.
+            record["source_file"] = DIGITIZED_SAMPLE_BLOB
+            record["wav_file"] = wav_path.name
+            json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            exported.append(
+                {
+                    "id": "F15DGTL.BIN",
+                    "status": record["status"],
+                    "wav": wav_path.name,
+                    "json": json_path.name,
+                    "notes": "Optional full-blob reference export; runtime replacement uses voice_cue_*.wav files.",
+                }
+            )
+
+        cue_exports: List[Dict[str, Any]] = []
+        for segment in segments:
             start = int(segment["source_offset"])
             end = start + int(segment["source_length"])
             segment_wav_path = output_root / f"{segment['id']}.wav"
-            segment_json_path = output_root / f"{segment['id']}.json"
             write_unsigned_pcm8_wav(segment_wav_path, data[start:end], sample_rate=sample_rate)
-            segment_record = {
-                "format": "F15_SOUND_SEGMENT",
-                "version": 1,
+            cue_export = {
                 "id": segment["id"],
-                "status": "decoded_driver_recovered_cue",
-                "source_file": str(blob_path),
-                "parent_blob": "F15DGTL.BIN",
-                "wav_file": str(segment_wav_path),
-                "source_offset": start,
-                "source_length": end - start,
-                "source_bytes_sha256": _sha256(data[start:end]),
-                "codec": "unsigned_pcm_u8",
-                "sample_rate": sample_rate,
-                "sample_rate_status": "driver_recovered",
-                "channels": 1,
-                "bits_per_sample": 8,
-                "sample_count": end - start,
-                "duration_seconds": (end - start) / float(sample_rate) if sample_rate > 0 else 0,
+                "wav": segment_wav_path.name,
                 "boundary_status": segment["boundary_status"],
-                "boundary_source": segment["boundary_source"],
-                "play_sample_arg": segment["play_sample_arg"],
-                "variant": segment["variant"],
-                "driver_case": segment["driver_case"],
-                "source_end_inclusive": segment["source_end_inclusive"],
-                "source_bytes_base64": to_base64(data[start:end]),
             }
-            segment["wav_file"] = str(segment_wav_path)
-            segment["json_file"] = str(segment_json_path)
-            segment_json_path.write_text(
-                json.dumps(segment_record, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-        json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            if include_metadata:
+                segment_json_path = output_root / f"{segment['id']}.json"
+                segment_record = {
+                    "format": "F15_SOUND_SEGMENT",
+                    "version": 1,
+                    "id": segment["id"],
+                    "status": "decoded_driver_recovered_cue",
+                    "source_file": DIGITIZED_SAMPLE_BLOB,
+                    "parent_blob": "F15DGTL.BIN",
+                    "wav_file": segment_wav_path.name,
+                    "source_offset": start,
+                    "source_length": end - start,
+                    "source_bytes_sha256": _sha256(data[start:end]),
+                    "codec": "unsigned_pcm_u8",
+                    "sample_rate": sample_rate,
+                    "sample_rate_status": "driver_recovered",
+                    "channels": 1,
+                    "bits_per_sample": 8,
+                    "sample_count": end - start,
+                    "duration_seconds": (end - start) / float(sample_rate) if sample_rate > 0 else 0,
+                    "boundary_status": segment["boundary_status"],
+                    "boundary_source": segment["boundary_source"],
+                    "play_sample_arg": segment["play_sample_arg"],
+                    "variant": segment["variant"],
+                    "driver_case": segment["driver_case"],
+                    "source_end_inclusive": segment["source_end_inclusive"],
+                }
+                segment_json_path.write_text(
+                    json.dumps(segment_record, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                cue_export["json"] = segment_json_path.name
+            cue_exports.append(cue_export)
+
         exported.append(
             {
-                "id": "F15DGTL.BIN",
-                "status": record["status"],
-                "wav": str(wav_path),
-                "json": str(json_path),
-                "segments": [
-                    {
-                        "id": segment["id"],
-                        "wav": segment["wav_file"],
-                        "json": segment["json_file"],
-                        "boundary_status": segment["boundary_status"],
-                    }
-                    for segment in record["segments"]
-                ],
+                "id": "digitized_voice_cues",
+                "status": "decoded_driver_recovered_cues",
+                "source_file": DIGITIZED_SAMPLE_BLOB,
+                "authoring_source": "voice_cue_*.wav",
+                "runtime_authoritative": "voice_cue_*.wav",
+                "notes": "Edit the individual cue WAVs for customization. No full sound blob is needed by the replacement runtime; use --include-raw-blob only for reverse-engineering reference output.",
+                "segments": cue_exports,
             }
         )
 
-    for name in SOUND_DRIVER_NAMES:
-        driver_path = asset_root / name
-        if not driver_path.exists():
-            continue
-        data = driver_path.read_bytes()
-        json_path = output_root / f"{driver_path.stem.lower()}_driver.json"
-        record = unresolved_sound_driver_record(driver_path, data)
-        json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        exported.append(
-            {
-                "id": name,
-                "status": "unresolved",
-                "json": str(json_path),
-            }
-        )
+    if include_metadata:
+        for name in SOUND_DRIVER_NAMES:
+            driver_path = asset_root / name
+            if not driver_path.exists():
+                continue
+            data = driver_path.read_bytes()
+            json_path = output_root / f"{driver_path.stem.lower()}_driver.json"
+            record = unresolved_sound_driver_record(driver_path, data)
+            json_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            exported.append(
+                {
+                    "id": name,
+                    "status": "unresolved",
+                    "json": json_path.name,
+                }
+            )
+
+    exported.append(export_intro_music(output_root))
 
     return {
         "format": "F15_SOUND_EXPORT_INDEX",
         "version": 1,
-        "source": str(asset_root),
+        "source": "game_asset_directory",
         "sample_rate": sample_rate,
+        "metadata_included": include_metadata,
+        "raw_blob_included": include_raw_blob,
         "exported": exported,
     }

--- a/tools/f15assets/f15assets/sounds.py
+++ b/tools/f15assets/f15assets/sounds.py
@@ -64,12 +64,14 @@ ASOUND_SAMPLE_CUES = (
 
 
 def _sha256(data: bytes) -> str:
+    """Perform the sha256 asset-processing operation."""
     return hashlib.sha256(data).hexdigest()
 
 
 def write_unsigned_pcm8_wav(path: Path, samples: bytes, *, sample_rate: int = DEFAULT_SAMPLE_RATE) -> None:
     # F15DGTL.BIN is raw unsigned 8-bit PCM. WAV expects the same byte range for
     # 8-bit PCM, so no signedness conversion is needed here.
+    """Write unsigned pcm8 wav."""
     with wave.open(str(path), "wb") as wav:
         wav.setnchannels(1)
         wav.setsampwidth(1)
@@ -78,6 +80,7 @@ def write_unsigned_pcm8_wav(path: Path, samples: bytes, *, sample_rate: int = DE
 
 
 def decode_digitized_blob(data: bytes, *, sample_rate: int = DEFAULT_SAMPLE_RATE) -> Dict[str, Any]:
+    """Decode digitized blob while preserving legacy semantics."""
     segments = infer_digitized_segments(data)
     return {
         "format": "F15_SOUND",
@@ -108,6 +111,7 @@ def decode_digitized_blob(data: bytes, *, sample_rate: int = DEFAULT_SAMPLE_RATE
 
 
 def infer_digitized_segments(data: bytes) -> List[Dict[str, Any]]:
+    """Infer digitized segments."""
     segments: List[Dict[str, Any]] = []
     for idx, cue in enumerate(ASOUND_SAMPLE_CUES):
         start = int(cue["source_start"])
@@ -136,6 +140,7 @@ def unresolved_sound_driver_record(path: Path, data: bytes) -> Dict[str, Any]:
     # Preserve only portable identification metadata for the DOS sound drivers.
     # The executable bytes are not useful authoring files for customizers; they
     # remain in the original game directory for future driver research.
+    """Describe preserved sound-driver fields whose meaning remains unknown."""
     return {
         "format": "F15_SOUND_DRIVER",
         "version": 1,
@@ -155,10 +160,12 @@ def unresolved_sound_driver_record(path: Path, data: bytes) -> Dict[str, Any]:
 
 
 def _repo_root_from_tools() -> Path:
+    """Perform the repo root from tools asset-processing operation."""
     return Path(__file__).resolve().parents[3]
 
 
 def _extract_asound_array(source_text: str, name: str) -> List[int]:
+    """Extract asound array."""
     match = re.search(
         rf"const\s+AsoundU8\s+{re.escape(name)}\[\]\s*=\s*\{{(?P<body>.*?)\}};",
         source_text,
@@ -173,6 +180,7 @@ def _extract_asound_array(source_text: str, name: str) -> List[int]:
 
 
 def _decode_asound_stream(stream: List[int], voice: int, *, max_events: int = 10000) -> List[Dict[str, Any]]:
+    """Decode asound stream while preserving legacy semantics."""
     pos = 0
     tick = 0
     loop_pos = 0
@@ -256,6 +264,7 @@ def _decode_asound_stream(stream: List[int], voice: int, *, max_events: int = 10
 
 
 def _write_varlen(value: int) -> bytes:
+    """Encode one MIDI variable-length integer."""
     value = max(0, int(value))
     out = [value & 0x7F]
     value >>= 7
@@ -266,6 +275,7 @@ def _write_varlen(value: int) -> bytes:
 
 
 def _midi_track(events: List[tuple[int, bytes]]) -> bytes:
+    """Wrap encoded MIDI events in a complete track chunk."""
     events = sorted(events, key=lambda item: item[0])
     data = bytearray()
     last = 0
@@ -278,6 +288,7 @@ def _midi_track(events: List[tuple[int, bytes]]) -> bytes:
 
 
 def _write_intro_midi(path: Path, voices: List[Dict[str, Any]]) -> None:
+    """Write intro midi."""
     ppq = 480
     midi_ticks_per_asound_tick = 16  # 60 Hz ASOUND tick at 120 BPM.
     tracks = []
@@ -307,6 +318,7 @@ def _write_intro_midi(path: Path, voices: List[Dict[str, Any]]) -> None:
 
 
 def export_intro_music(output_root: Path, *, repo_root: Path | None = None) -> Dict[str, Any]:
+    """Export intro music to an editable modern format."""
     repo = repo_root or _repo_root_from_tools()
     model_path = repo / "src" / "asound" / "asound_model.c"
     source_text = model_path.read_text(encoding="utf-8")
@@ -360,6 +372,7 @@ def export_sounds(
     include_raw_blob: bool = False,
     include_metadata: bool = False,
 ) -> Dict[str, Any]:
+    """Export sounds to an editable modern format."""
     output_root.mkdir(parents=True, exist_ok=True)
     exported: List[Dict[str, Any]] = []
 

--- a/tools/f15assets/f15assets/terrain.py
+++ b/tools/f15assets/f15assets/terrain.py
@@ -9,6 +9,7 @@ SIGNATURE_3DG = 0x3232
 
 
 def parse_3dt(data: bytes) -> Dict[str, Any]:
+    """Parse 3dt."""
     if len(data) < 12:
         raise ValueError(".3DT data too short")
 
@@ -66,6 +67,7 @@ def parse_3dt(data: bytes) -> Dict[str, Any]:
 
 
 def build_3dt(payload: Dict[str, Any]) -> bytes:
+    """Build 3dt from normalized asset data."""
     if payload.get("format") != "3DT":
         raise ValueError("invalid payload format")
 
@@ -96,6 +98,7 @@ def build_3dt(payload: Dict[str, Any]) -> bytes:
 
 
 def parse_3dg(data: bytes) -> Dict[str, Any]:
+    """Parse 3dg."""
     if len(data) < 1810:
         raise ValueError(f"unexpected .3DG size: {len(data)}")
 
@@ -133,6 +136,7 @@ def parse_3dg(data: bytes) -> Dict[str, Any]:
 
 
 def build_3dg(payload: Dict[str, Any]) -> bytes:
+    """Build 3dg from normalized asset data."""
     if payload.get("format") != "3DG":
         raise ValueError("invalid payload format")
 

--- a/tools/f15assets/f15assets/validation_compare.py
+++ b/tools/f15assets/f15assets/validation_compare.py
@@ -1,0 +1,36 @@
+"""Compatibility facade for replacement-asset validation comparisons.
+
+Format-specific comparison code lives in validation_compare_* modules. Keep this
+module as the stable import point for CLI code and downstream scripts.
+"""
+
+from __future__ import annotations
+
+from .validation_compare_core import (
+    compare_byte_sequence,
+    compare_count_value,
+    compare_mapping_exact,
+    compare_sequence_exact,
+    first_byte_difference,
+)
+from .validation_compare_font import compare_font_atlas_rows, compare_font_glyph96
+from .validation_compare_image import compare_png_palette, compare_png_pixels
+from .validation_compare_model3d import compare_glmesh_primitive_streams
+from .validation_compare_sound import compare_wav_sample_rate, compare_wav_samples
+from .validation_compare_structured import compare_structured_rebuild
+
+__all__ = [
+    "compare_byte_sequence",
+    "compare_count_value",
+    "compare_font_atlas_rows",
+    "compare_font_glyph96",
+    "compare_glmesh_primitive_streams",
+    "compare_mapping_exact",
+    "compare_png_palette",
+    "compare_png_pixels",
+    "compare_sequence_exact",
+    "compare_structured_rebuild",
+    "compare_wav_sample_rate",
+    "compare_wav_samples",
+    "first_byte_difference",
+]

--- a/tools/f15assets/f15assets/validation_compare_core.py
+++ b/tools/f15assets/f15assets/validation_compare_core.py
@@ -66,6 +66,7 @@ def compare_count_value(
     actual_name: str = "actual",
     expected_name: str = "expected",
 ) -> str | None:
+    """Compare count value and report semantic mismatches."""
     if actual == expected:
         return None
     return (

--- a/tools/f15assets/f15assets/validation_compare_core.py
+++ b/tools/f15assets/f15assets/validation_compare_core.py
@@ -1,0 +1,74 @@
+"""Shared diff helpers for replacement-asset validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def first_byte_difference(expected: bytes, actual: bytes) -> int:
+    """Return the first differing offset, or -1 when only the length differs."""
+
+    return next((idx for idx, (a, b) in enumerate(zip(expected, actual)) if a != b), -1)
+
+
+def compare_byte_sequence(
+    label: str,
+    expected: bytes,
+    actual: bytes,
+    expected_name: str,
+    actual_name: str,
+    differ_text: str,
+) -> str | None:
+    """Return a single human-readable byte diff message, or None on equality."""
+
+    if expected == actual:
+        return None
+    first = first_byte_difference(expected, actual)
+    if first >= 0:
+        return (
+            f"{label}: {differ_text} at offset {first} "
+            f"({expected_name}={expected[first]}, {actual_name}={actual[first]})"
+        )
+    return (
+        f"{label}: {differ_text} length differs "
+        f"({expected_name}={len(expected)}, {actual_name}={len(actual)})"
+    )
+
+
+def compare_mapping_exact(
+    path: str,
+    what: str,
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    actual_name: str = "actual",
+    expected_name: str = "expected",
+) -> str | None:
+    """Compare small diagnostic dictionaries such as primitive-count summaries."""
+
+    if actual == expected:
+        return None
+    return f"{path}: {what} differ ({actual_name}={actual}, {expected_name}={expected})"
+
+
+def compare_sequence_exact(path: str, what: str, actual: list[Any], expected: list[Any]) -> str | None:
+    """Compare compact source-proof lists without embedding bulky geometry dumps."""
+
+    if actual == expected:
+        return None
+    return f"{path}: {what} differs"
+
+
+def compare_count_value(
+    path: str,
+    count_name: str,
+    actual: int,
+    expected: int,
+    actual_name: str = "actual",
+    expected_name: str = "expected",
+) -> str | None:
+    if actual == expected:
+        return None
+    return (
+        f"{path}: {count_name} count differs "
+        f"({actual_name}={actual}, {expected_name}={expected})"
+    )

--- a/tools/f15assets/f15assets/validation_compare_font.py
+++ b/tools/f15assets/f15assets/validation_compare_font.py
@@ -24,6 +24,7 @@ def compare_font_glyph96(
 
 
 def compare_font_atlas_rows(path: str, expected_rows: list[list[int]], actual_rows: list[list[int]]) -> str | None:
+    """Compare font atlas rows and report semantic mismatches."""
     if actual_rows != expected_rows:
         return f"{path}: atlas bitmap differs from original font rows"
     return None

--- a/tools/f15assets/f15assets/validation_compare_font.py
+++ b/tools/f15assets/f15assets/validation_compare_font.py
@@ -1,0 +1,29 @@
+"""Font replacement comparison helpers."""
+
+from __future__ import annotations
+
+
+def compare_font_glyph96(
+    path: str,
+    codepoint: int,
+    expected_rows: list[int],
+    actual_rows: list[int],
+    expected_width: int,
+    actual_width: int,
+) -> str | None:
+    """Compare one exported 96-glyph font cell after it has passed loadability checks."""
+
+    if actual_rows != expected_rows:
+        return f"{path}: bitmap differs for U+{codepoint:04X}"
+    if actual_width != expected_width:
+        return (
+            f"{path}: advance width differs for U+{codepoint:04X} "
+            f"(legacy={expected_width}, bdf={actual_width})"
+        )
+    return None
+
+
+def compare_font_atlas_rows(path: str, expected_rows: list[list[int]], actual_rows: list[list[int]]) -> str | None:
+    if actual_rows != expected_rows:
+        return f"{path}: atlas bitmap differs from original font rows"
+    return None

--- a/tools/f15assets/f15assets/validation_compare_image.py
+++ b/tools/f15assets/f15assets/validation_compare_image.py
@@ -6,10 +6,12 @@ from .validation_compare_core import compare_byte_sequence, first_byte_differenc
 
 
 def compare_png_pixels(src: str, legacy_pixels: bytes, modern_pixels: bytes) -> str | None:
+    """Compare png pixels and report semantic mismatches."""
     return compare_byte_sequence(src, legacy_pixels, modern_pixels, "legacy", "png", "PNG pixels differ")
 
 
 def compare_png_palette(src: str, legacy_palette: bytes, modern_palette: bytes) -> str | None:
+    """Compare png palette and report semantic mismatches."""
     if legacy_palette == modern_palette:
         return None
     first = first_byte_difference(legacy_palette, modern_palette)

--- a/tools/f15assets/f15assets/validation_compare_image.py
+++ b/tools/f15assets/f15assets/validation_compare_image.py
@@ -1,0 +1,23 @@
+"""Image replacement comparison helpers."""
+
+from __future__ import annotations
+
+from .validation_compare_core import compare_byte_sequence, first_byte_difference
+
+
+def compare_png_pixels(src: str, legacy_pixels: bytes, modern_pixels: bytes) -> str | None:
+    return compare_byte_sequence(src, legacy_pixels, modern_pixels, "legacy", "png", "PNG pixels differ")
+
+
+def compare_png_palette(src: str, legacy_palette: bytes, modern_palette: bytes) -> str | None:
+    if legacy_palette == modern_palette:
+        return None
+    first = first_byte_difference(legacy_palette, modern_palette)
+    if first >= 0:
+        entry = first // 3
+        channel = "rgb"[first % 3]
+        return (
+            f"{src}: PNG embedded palette differs at entry {entry} channel {channel} "
+            f"(legacy={legacy_palette[first]}, png={modern_palette[first]})"
+        )
+    return f"{src}: PNG embedded palette length differs"

--- a/tools/f15assets/f15assets/validation_compare_model3d.py
+++ b/tools/f15assets/f15assets/validation_compare_model3d.py
@@ -1,0 +1,42 @@
+"""3D model replacement comparison helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compare_glmesh_primitive_streams(
+    expected_stream: list[dict[str, Any]],
+    actual_stream: list[dict[str, Any]],
+    tolerance: float = 1e-5,
+) -> str | None:
+    """Compare reduced runtime-mesh primitive streams.
+
+    Vertex float values are allowed a tiny tolerance because GLB authoring tools
+    can round-trip text/float encodings differently. Integer source identity,
+    primitive modes, color metadata, and ordering must remain exact.
+    """
+
+    if len(expected_stream) != len(actual_stream):
+        return f"primitive count differs (expected={len(expected_stream)}, actual={len(actual_stream)})"
+
+    for prim_index, (exp, act) in enumerate(zip(expected_stream, actual_stream)):
+        for key in ("mode", "source_kind", "source_index", "source_color", "source_flags"):
+            if exp[key] != act[key]:
+                return f"primitive {prim_index} {key} differs (expected={exp[key]}, actual={act[key]})"
+        if len(exp["vertices"]) != len(act["vertices"]):
+            return (
+                f"primitive {prim_index} vertex count differs "
+                f"(expected={len(exp['vertices'])}, actual={len(act['vertices'])})"
+            )
+        for channel, (a, b) in enumerate(zip(exp["rgba"], act["rgba"])):
+            if abs(float(a) - float(b)) > tolerance:
+                return f"primitive {prim_index} rgba[{channel}] differs (expected={a}, actual={b})"
+        for vertex_index, (exp_vertex, act_vertex) in enumerate(zip(exp["vertices"], act["vertices"])):
+            for axis, (a, b) in enumerate(zip(exp_vertex, act_vertex)):
+                if abs(float(a) - float(b)) > tolerance:
+                    return (
+                        f"primitive {prim_index} vertex {vertex_index} axis {axis} differs "
+                        f"(expected={a}, actual={b})"
+                    )
+    return None

--- a/tools/f15assets/f15assets/validation_compare_music.py
+++ b/tools/f15assets/f15assets/validation_compare_music.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 
 def extract_asound_array(source_text: str, name: str) -> list[int]:
+    """Extract asound array."""
     match = re.search(
         rf"const\s+AsoundU8\s+{re.escape(name)}\[\]\s*=\s*\{{(?P<body>.*?)\}};",
         source_text,
@@ -19,6 +20,7 @@ def extract_asound_array(source_text: str, name: str) -> list[int]:
 
 
 def compare_intro_music_json(json_path: Path, source_text: str) -> list[str]:
+    """Compare intro music json and report semantic mismatches."""
     errors: list[str] = []
     try:
         payload = json.loads(json_path.read_text(encoding="utf-8"))
@@ -50,6 +52,7 @@ def compare_intro_music_json(json_path: Path, source_text: str) -> list[str]:
 
 
 def compare_intro_music_midi(midi_path: Path) -> list[str]:
+    """Compare intro music midi and report semantic mismatches."""
     if not midi_path.exists():
         return [f"missing intro music MIDI preview: {midi_path}"]
     data = midi_path.read_bytes()

--- a/tools/f15assets/f15assets/validation_compare_music.py
+++ b/tools/f15assets/f15assets/validation_compare_music.py
@@ -1,0 +1,58 @@
+"""ASOUND music replacement comparison helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def extract_asound_array(source_text: str, name: str) -> list[int]:
+    match = re.search(
+        rf"const\s+AsoundU8\s+{re.escape(name)}\[\]\s*=\s*\{{(?P<body>.*?)\}};",
+        source_text,
+        re.S,
+    )
+    if not match:
+        raise ValueError(f"missing ASOUND stream array {name}")
+    return [int(token, 0) & 0xFF for token in re.findall(r"0x[0-9a-fA-F]+|\b\d+\b", match.group("body"))]
+
+
+def compare_intro_music_json(json_path: Path, source_text: str) -> list[str]:
+    errors: list[str] = []
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [f"{json_path}: {exc}"]
+
+    voices = payload.get("voices", [])
+    if payload.get("format") != "F15_ASOUND_MUSIC":
+        errors.append(f"{json_path}: wrong music JSON format")
+    if not isinstance(voices, list) or len(voices) != 12:
+        errors.append(f"{json_path}: expected 12 intro/release voices")
+        return errors
+
+    by_symbol = {voice.get("source_symbol"): voice for voice in voices if isinstance(voice, dict)}
+    for phase in ("intro", "release"):
+        for voice_id in range(6):
+            symbol = f"asound_{phase}_voice{voice_id}"
+            voice = by_symbol.get(symbol)
+            if not isinstance(voice, dict):
+                errors.append(f"{json_path}: missing voice {symbol}")
+                continue
+            expected_stream = extract_asound_array(source_text, symbol)
+            actual_stream = [int(value) & 0xFF for value in voice.get("stream_bytes", [])]
+            if actual_stream != expected_stream:
+                errors.append(f"{json_path}: stream bytes differ for {symbol}")
+            if not isinstance(voice.get("events"), list) or not voice["events"]:
+                errors.append(f"{json_path}: missing decoded events for {symbol}")
+    return errors
+
+
+def compare_intro_music_midi(midi_path: Path) -> list[str]:
+    if not midi_path.exists():
+        return [f"missing intro music MIDI preview: {midi_path}"]
+    data = midi_path.read_bytes()
+    if len(data) < 14 or not data.startswith(b"MThd"):
+        return [f"{midi_path}: invalid MIDI header"]
+    return []

--- a/tools/f15assets/f15assets/validation_compare_sound.py
+++ b/tools/f15assets/f15assets/validation_compare_sound.py
@@ -1,0 +1,15 @@
+"""Sound replacement comparison helpers."""
+
+from __future__ import annotations
+
+from .validation_compare_core import compare_byte_sequence
+
+
+def compare_wav_samples(path: str, legacy_samples: bytes, modern_samples: bytes) -> str | None:
+    return compare_byte_sequence(path, legacy_samples, modern_samples, "legacy", "wav", "WAV samples differ")
+
+
+def compare_wav_sample_rate(path: str, expected_rate: int, actual_rate: int) -> str | None:
+    if actual_rate == expected_rate:
+        return None
+    return f"{path}: WAV sample rate differs (expected={expected_rate}, wav={actual_rate})"

--- a/tools/f15assets/f15assets/validation_compare_sound.py
+++ b/tools/f15assets/f15assets/validation_compare_sound.py
@@ -6,10 +6,12 @@ from .validation_compare_core import compare_byte_sequence
 
 
 def compare_wav_samples(path: str, legacy_samples: bytes, modern_samples: bytes) -> str | None:
+    """Compare wav samples and report semantic mismatches."""
     return compare_byte_sequence(path, legacy_samples, modern_samples, "legacy", "wav", "WAV samples differ")
 
 
 def compare_wav_sample_rate(path: str, expected_rate: int, actual_rate: int) -> str | None:
+    """Compare wav sample rate and report semantic mismatches."""
     if actual_rate == expected_rate:
         return None
     return f"{path}: WAV sample rate differs (expected={expected_rate}, wav={actual_rate})"

--- a/tools/f15assets/f15assets/validation_compare_structured.py
+++ b/tools/f15assets/f15assets/validation_compare_structured.py
@@ -1,0 +1,9 @@
+"""Structured asset rebuild comparison helpers for WLD/3DT/3DG JSON."""
+
+from __future__ import annotations
+
+from .validation_compare_core import compare_byte_sequence
+
+
+def compare_structured_rebuild(path: str, fmt: str, original: bytes, rebuilt: bytes) -> str | None:
+    return compare_byte_sequence(path, original, rebuilt, "original", "json", f"rebuilt {fmt} differs")

--- a/tools/f15assets/f15assets/validation_compare_structured.py
+++ b/tools/f15assets/f15assets/validation_compare_structured.py
@@ -6,4 +6,5 @@ from .validation_compare_core import compare_byte_sequence
 
 
 def compare_structured_rebuild(path: str, fmt: str, original: bytes, rebuilt: bytes) -> str | None:
+    """Compare structured rebuild and report semantic mismatches."""
     return compare_byte_sequence(path, original, rebuilt, "original", "json", f"rebuilt {fmt} differs")

--- a/tools/f15assets/f15assets/validation_font.py
+++ b/tools/f15assets/f15assets/validation_font.py
@@ -1,0 +1,262 @@
+"""Bitmap font BDF/PNG replacement validation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from .fonts import FONT_CODEPOINT_COUNT, FONT_CODEPOINT_START, load_font_assets
+from .validation_compare import compare_font_atlas_rows, compare_font_glyph96
+
+__all__ = ["validate_font_replacements"]
+
+RUNTIME_FONT_ATLAS_DIMS = {
+    # These are the same runtime slots and atlas cell sizes used by gfx_impl.c.
+    # They let --loadability-only validate PNG-only custom font packs even when
+    # the captured in-repo font tables are not available for equivalence proof.
+    0: (4, 5),
+    1: (8, 8),
+    3: (6, 6),
+    4: (8, 7),
+    5: (6, 6),
+}
+
+
+def _parse_bdf_font(path: Path) -> Dict[int, Dict[str, Any]]:
+    glyphs: Dict[int, Dict[str, Any]] = {}
+    current: Dict[str, Any] | None = None
+    bitmap_rows: list[int] = []
+    in_bitmap = False
+
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if line.startswith("STARTCHAR "):
+            current = {"advance_width": 0, "bitmap_rows": []}
+            bitmap_rows = []
+            in_bitmap = False
+        elif current is not None and line.startswith("ENCODING "):
+            current["encoding"] = int(line.split()[1], 0)
+        elif current is not None and line.startswith("DWIDTH "):
+            parts = line.split()
+            if len(parts) >= 2:
+                current["advance_width"] = int(parts[1], 0)
+        elif current is not None and line.startswith("BITMAP"):
+            bitmap_rows = []
+            in_bitmap = True
+        elif current is not None and line.startswith("ENDCHAR"):
+            encoding = current.get("encoding")
+            if isinstance(encoding, int):
+                current["bitmap_rows"] = bitmap_rows
+                glyphs[encoding] = current
+            current = None
+            bitmap_rows = []
+            in_bitmap = False
+        elif current is not None and in_bitmap and line:
+            bitmap_rows.append(int(line, 16) & 0xFF)
+
+    return glyphs
+
+
+def _read_font_png_rows(path: Path, cell_width: int, height: int) -> list[list[int]]:
+    try:
+        from PIL import Image
+    except Exception as exc:
+        raise RuntimeError("Pillow is required for font PNG validation") from exc
+
+    image = Image.open(path)
+    converted = None
+    try:
+        if image.mode not in {"P", "L", "RGB", "RGBA"}:
+            converted = image.convert("RGBA")
+            image.close()
+            image = converted
+        rows: list[list[int]] = []
+        cell_stride_x = cell_width + 1
+        cell_stride_y = height + 1
+        expected_w = 16 * cell_stride_x - 1
+        expected_h = 6 * cell_stride_y - 1
+        if image.size[0] < expected_w or image.size[1] < expected_h:
+            raise ValueError(f"font atlas too small: {image.size[0]}x{image.size[1]}, expected at least {expected_w}x{expected_h}")
+
+        pix = image.load()
+        for idx in range(FONT_CODEPOINT_COUNT):
+            x0 = (idx % 16) * cell_stride_x
+            y0 = (idx // 16) * cell_stride_y
+            glyph_rows: list[int] = []
+            for y in range(height):
+                bits = 0
+                for x in range(cell_width):
+                    value = pix[x0 + x, y0 + y]
+                    if isinstance(value, int):
+                        lit = value != 0
+                    else:
+                        lit = any(int(channel) != 0 for channel in value[:3])
+                        if len(value) >= 4:
+                            lit = lit and int(value[3]) != 0
+                    if lit:
+                        bits |= 0x80 >> x
+                glyph_rows.append(bits)
+            rows.append(glyph_rows)
+        return rows
+    finally:
+        image.close()
+
+
+def _font_id_from_media_path(path: Path, suffix: str) -> int | None:
+    name = path.name.lower()
+    if not name.startswith("font_") or not name.endswith(suffix):
+        return None
+    try:
+        return int(name[len("font_") : -len(suffix)], 10)
+    except ValueError:
+        return None
+
+
+def validate_font_replacements(
+    repo_root: Path,
+    output_root: Path,
+    require_all: bool,
+    loadability_only: bool = False,
+) -> tuple[int, int]:
+    font_root = output_root / "fonts"
+    checked = 0
+    failed = 0
+    checked_font_paths: set[Path] = set()
+
+    try:
+        original_fonts = load_font_assets(repo_root)
+    except Exception as exc:
+        print(f"font validation unavailable: {exc}", file=sys.stderr)
+        if not loadability_only:
+            return checked, failed + (1 if require_all else 0)
+        original_fonts = {}
+
+    for font_id, font in sorted(original_fonts.items()):
+        original_rows = font.get("glyphs", [])
+        original_widths = font.get("advance_widths", [])
+        bdf_path = font_root / f"font_{font_id}.bdf"
+        png_path = font_root / f"font_{font_id}.png"
+        bdf_errors: list[str] = []
+        has_bdf = bdf_path.exists()
+        has_png = png_path.exists()
+        if not bdf_path.exists():
+            if require_all and not has_png:
+                bdf_errors.append(f"missing replacement BDF: {bdf_path}")
+        else:
+            checked += 1
+            checked_font_paths.add(bdf_path.resolve())
+            try:
+                modern_glyphs = _parse_bdf_font(bdf_path)
+            except Exception as exc:
+                bdf_errors.append(f"{bdf_path}: {exc}")
+            else:
+                for idx in range(FONT_CODEPOINT_COUNT):
+                    codepoint = FONT_CODEPOINT_START + idx
+                    modern = modern_glyphs.get(codepoint)
+                    if modern is None:
+                        bdf_errors.append(f"{bdf_path}: missing glyph U+{codepoint:04X}")
+                        continue
+                    actual_rows = [int(row) & 0xFF for row in modern.get("bitmap_rows", [])]
+                    actual_width = int(modern.get("advance_width", -1))
+                    if not actual_rows:
+                        bdf_errors.append(f"{bdf_path}: glyph U+{codepoint:04X} has no bitmap rows")
+                        continue
+                    if actual_width <= 0:
+                        bdf_errors.append(f"{bdf_path}: glyph U+{codepoint:04X} has invalid advance width {actual_width}")
+                        continue
+                    if loadability_only:
+                        continue
+
+                    glyph_error = compare_font_glyph96(
+                        str(bdf_path),
+                        codepoint,
+                        [int(row) & 0xFF for row in original_rows[idx]],
+                        actual_rows,
+                        int(original_widths[idx]),
+                        actual_width,
+                    )
+                    if glyph_error:
+                        bdf_errors.append(glyph_error)
+
+        png_valid = False
+        if not png_path.exists():
+            if require_all and not has_bdf:
+                print(f"missing replacement font PNG: {png_path}", file=sys.stderr)
+                failed += 1
+        else:
+            checked += 1
+            checked_font_paths.add(png_path.resolve())
+            try:
+                actual_png_rows = _read_font_png_rows(
+                    png_path,
+                    int(font["cell_width"]),
+                    int(font["height"]),
+                )
+                png_valid = True
+            except Exception as exc:
+                print(f"{png_path}: {exc}", file=sys.stderr)
+                failed += 1
+            else:
+                if not loadability_only:
+                    expected_png_rows = [
+                        [int(row) & 0xFF for row in glyph_rows]
+                        for glyph_rows in original_rows
+                    ]
+                    atlas_error = compare_font_atlas_rows(str(png_path), expected_png_rows, actual_png_rows)
+                    if atlas_error:
+                        print(atlas_error, file=sys.stderr)
+                        failed += 1
+
+        if bdf_errors and (not loadability_only or not png_valid):
+            for error in bdf_errors:
+                print(error, file=sys.stderr)
+            failed += len(bdf_errors)
+        elif bdf_errors:
+            for error in bdf_errors:
+                print(f"warning: {error}; PNG atlas fallback is loadable", file=sys.stderr)
+
+    if loadability_only and font_root.exists():
+        for bdf_path in sorted(font_root.glob("font_*.bdf")):
+            if bdf_path.resolve() in checked_font_paths:
+                continue
+            checked += 1
+            try:
+                modern_glyphs = _parse_bdf_font(bdf_path)
+            except Exception as exc:
+                print(f"{bdf_path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+            for idx in range(FONT_CODEPOINT_COUNT):
+                codepoint = FONT_CODEPOINT_START + idx
+                glyph = modern_glyphs.get(codepoint)
+                if glyph is None:
+                    print(f"{bdf_path}: missing glyph U+{codepoint:04X}", file=sys.stderr)
+                    failed += 1
+                    continue
+                actual_rows = [int(row) & 0xFF for row in glyph.get("bitmap_rows", [])]
+                actual_width = int(glyph.get("advance_width", -1))
+                if not actual_rows:
+                    print(f"{bdf_path}: glyph U+{int(codepoint):04X} has no bitmap rows", file=sys.stderr)
+                    failed += 1
+                    continue
+                if actual_width <= 0:
+                    print(f"{bdf_path}: glyph U+{int(codepoint):04X} has invalid advance width {actual_width}", file=sys.stderr)
+                    failed += 1
+                    continue
+        for png_path in sorted(font_root.glob("font_*.png")):
+            if png_path.resolve() in checked_font_paths:
+                continue
+            font_id = _font_id_from_media_path(png_path, ".png")
+            dims = RUNTIME_FONT_ATLAS_DIMS.get(font_id if font_id is not None else -1)
+            if dims is None:
+                print(f"warning: {png_path}: no runtime font atlas dimensions for this font id; skipping source-free PNG loadability check", file=sys.stderr)
+                continue
+            checked += 1
+            try:
+                _read_font_png_rows(png_path, dims[0], dims[1])
+            except Exception as exc:
+                print(f"{png_path}: {exc}", file=sys.stderr)
+                failed += 1
+
+    return checked, failed

--- a/tools/f15assets/f15assets/validation_font.py
+++ b/tools/f15assets/f15assets/validation_font.py
@@ -24,6 +24,7 @@ RUNTIME_FONT_ATLAS_DIMS = {
 
 
 def _parse_bdf_font(path: Path) -> Dict[int, Dict[str, Any]]:
+    """Parse bdf font."""
     glyphs: Dict[int, Dict[str, Any]] = {}
     current: Dict[str, Any] | None = None
     bitmap_rows: list[int] = []
@@ -59,6 +60,7 @@ def _parse_bdf_font(path: Path) -> Dict[int, Dict[str, Any]]:
 
 
 def _read_font_png_rows(path: Path, cell_width: int, height: int) -> list[list[int]]:
+    """Read font png rows."""
     try:
         from PIL import Image
     except Exception as exc:
@@ -104,6 +106,7 @@ def _read_font_png_rows(path: Path, cell_width: int, height: int) -> list[list[i
 
 
 def _font_id_from_media_path(path: Path, suffix: str) -> int | None:
+    """Perform the font id from media path asset-processing operation."""
     name = path.name.lower()
     if not name.startswith("font_") or not name.endswith(suffix):
         return None
@@ -119,6 +122,7 @@ def validate_font_replacements(
     require_all: bool,
     loadability_only: bool = False,
 ) -> tuple[int, int]:
+    """Validate font replacements against runtime requirements."""
     font_root = output_root / "fonts"
     checked = 0
     failed = 0

--- a/tools/f15assets/f15assets/validation_image.py
+++ b/tools/f15assets/f15assets/validation_image.py
@@ -1,0 +1,96 @@
+"""PIC/SPR PNG replacement validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from .io import from_base64
+from .pic import decode_pic_asset, decode_title640_pic_asset, expected_runtime_pic_palette
+from .validation_compare import compare_png_palette, compare_png_pixels
+
+__all__ = ["validate_png_replacement_loadability", "validate_pic_png_replacement"]
+
+
+def _open_png_for_validation(path: Path):
+    try:
+        from PIL import Image
+    except Exception as exc:
+        raise RuntimeError("Pillow is required for replacement validation") from exc
+
+    return Image.open(path)
+
+
+def _validate_png_loadable_like_runtime(path: Path) -> None:
+    image = _open_png_for_validation(path)
+    try:
+        if image.size[0] <= 0 or image.size[1] <= 0:
+            raise ValueError(f"PNG has invalid dimensions: {path}")
+        if image.mode == "P" and not image.getpalette():
+            raise ValueError(f"expected embedded palette in indexed PNG replacement: {path}")
+    finally:
+        image.close()
+
+
+def validate_png_replacement_loadability(path: Path) -> list[str]:
+    """Validate a PNG with the same broad rules the runtime PIC/SPR loader uses."""
+
+    try:
+        _validate_png_loadable_like_runtime(path)
+    except Exception as exc:
+        return [f"{path}: {exc}"]
+    return []
+
+
+def _read_indexed_png_pixels_and_palette(path: Path, width: int, height: int) -> tuple[bytes, bytes]:
+    image = _open_png_for_validation(path)
+    if image.mode != "P":
+        raise ValueError(f"expected indexed PNG replacement for byte-for-byte comparison: {path}")
+    if image.size != (width, height):
+        raise ValueError(f"expected {width}x{height} PNG replacement: {path} is {image.size[0]}x{image.size[1]}")
+    palette = image.getpalette() or []
+    if not palette:
+        raise ValueError(f"expected embedded palette in indexed PNG replacement: {path}")
+    palette_bytes = bytes((palette[:768] + [0] * max(0, 768 - len(palette[:768])))[:768])
+    return bytes(image.tobytes()), palette_bytes
+
+
+def validate_pic_png_replacement(
+    src: Path,
+    png_path: Path,
+    read_binary: Callable[[Path], bytes],
+    loadability_only: bool = False,
+) -> list[str]:
+    errors: list[str] = []
+    is_title640 = src.name.upper() == "TITLE640.PIC"
+    data = read_binary(src)
+    payload = (
+        decode_title640_pic_asset(data, source_name=src.name)
+        if is_title640
+        else decode_pic_asset(data, source_name=src.name)
+    )
+    width = int(payload.get("decoded_width", 320))
+    height = int(payload.get("decoded_height", 200))
+    if loadability_only:
+        _validate_png_loadable_like_runtime(png_path)
+        return errors
+    legacy_pixels = from_base64(payload["pixels_base64"])[: width * height]
+    modern_pixels, modern_palette = _read_indexed_png_pixels_and_palette(png_path, width, height)
+    pixel_error = compare_png_pixels(str(src), legacy_pixels, modern_pixels)
+    if pixel_error:
+        errors.append(pixel_error)
+    try:
+        index_bit_depth = int(payload.get("palette_profile", {}).get("index_bit_depth", 8))
+    except (TypeError, ValueError):
+        index_bit_depth = 8
+    legacy_palette_b64 = payload.get("palette_rgb8_base64")
+    if isinstance(legacy_palette_b64, str):
+        legacy_palette = from_base64(legacy_palette_b64)[:768]
+    else:
+        expected_palette = expected_runtime_pic_palette(src.name, index_bit_depth)
+        legacy_palette = bytes(expected_palette["palette_rgb8"][:768])
+    legacy_palette = legacy_palette + (b"\x00" * max(0, 768 - len(legacy_palette)))
+    palette_error = compare_png_palette(str(src), legacy_palette[:768], modern_palette)
+    if palette_error:
+        errors.append(palette_error)
+    return errors

--- a/tools/f15assets/f15assets/validation_image.py
+++ b/tools/f15assets/f15assets/validation_image.py
@@ -13,6 +13,7 @@ __all__ = ["validate_png_replacement_loadability", "validate_pic_png_replacement
 
 
 def _open_png_for_validation(path: Path):
+    """Open png for validation."""
     try:
         from PIL import Image
     except Exception as exc:
@@ -22,6 +23,7 @@ def _open_png_for_validation(path: Path):
 
 
 def _validate_png_loadable_like_runtime(path: Path) -> None:
+    """Validate png loadable like runtime against runtime requirements."""
     image = _open_png_for_validation(path)
     try:
         if image.size[0] <= 0 or image.size[1] <= 0:
@@ -43,6 +45,7 @@ def validate_png_replacement_loadability(path: Path) -> list[str]:
 
 
 def _read_indexed_png_pixels_and_palette(path: Path, width: int, height: int) -> tuple[bytes, bytes]:
+    """Read indexed png pixels and palette."""
     image = _open_png_for_validation(path)
     if image.mode != "P":
         raise ValueError(f"expected indexed PNG replacement for byte-for-byte comparison: {path}")
@@ -61,6 +64,7 @@ def validate_pic_png_replacement(
     read_binary: Callable[[Path], bytes],
     loadability_only: bool = False,
 ) -> list[str]:
+    """Validate pic png replacement against runtime requirements."""
     errors: list[str] = []
     is_title640 = src.name.upper() == "TITLE640.PIC"
     data = read_binary(src)

--- a/tools/f15assets/f15assets/validation_image.py
+++ b/tools/f15assets/f15assets/validation_image.py
@@ -26,6 +26,9 @@ def _validate_png_loadable_like_runtime(path: Path) -> None:
     """Validate png loadable like runtime against runtime requirements."""
     image = _open_png_for_validation(path)
     try:
+        # Image.open is lazy: a valid header alone does not prove the pixel
+        # stream can be decoded by a replacement loader.
+        image.load()
         if image.size[0] <= 0 or image.size[1] <= 0:
             raise ValueError(f"PNG has invalid dimensions: {path}")
         if image.mode == "P" and not image.getpalette():
@@ -46,16 +49,16 @@ def validate_png_replacement_loadability(path: Path) -> list[str]:
 
 def _read_indexed_png_pixels_and_palette(path: Path, width: int, height: int) -> tuple[bytes, bytes]:
     """Read indexed png pixels and palette."""
-    image = _open_png_for_validation(path)
-    if image.mode != "P":
-        raise ValueError(f"expected indexed PNG replacement for byte-for-byte comparison: {path}")
-    if image.size != (width, height):
-        raise ValueError(f"expected {width}x{height} PNG replacement: {path} is {image.size[0]}x{image.size[1]}")
-    palette = image.getpalette() or []
-    if not palette:
-        raise ValueError(f"expected embedded palette in indexed PNG replacement: {path}")
-    palette_bytes = bytes((palette[:768] + [0] * max(0, 768 - len(palette[:768])))[:768])
-    return bytes(image.tobytes()), palette_bytes
+    with _open_png_for_validation(path) as image:
+        if image.mode != "P":
+            raise ValueError(f"expected indexed PNG replacement for byte-for-byte comparison: {path}")
+        if image.size != (width, height):
+            raise ValueError(f"expected {width}x{height} PNG replacement: {path} is {image.size[0]}x{image.size[1]}")
+        palette = image.getpalette() or []
+        if not palette:
+            raise ValueError(f"expected embedded palette in indexed PNG replacement: {path}")
+        palette_bytes = bytes((palette[:768] + [0] * max(0, 768 - len(palette[:768])))[:768])
+        return bytes(image.tobytes()), palette_bytes
 
 
 def validate_pic_png_replacement(
@@ -66,6 +69,9 @@ def validate_pic_png_replacement(
 ) -> list[str]:
     """Validate pic png replacement against runtime requirements."""
     errors: list[str] = []
+    if loadability_only:
+        _validate_png_loadable_like_runtime(png_path)
+        return errors
     is_title640 = src.name.upper() == "TITLE640.PIC"
     data = read_binary(src)
     payload = (
@@ -75,9 +81,6 @@ def validate_pic_png_replacement(
     )
     width = int(payload.get("decoded_width", 320))
     height = int(payload.get("decoded_height", 200))
-    if loadability_only:
-        _validate_png_loadable_like_runtime(png_path)
-        return errors
     legacy_pixels = from_base64(payload["pixels_base64"])[: width * height]
     modern_pixels, modern_palette = _read_indexed_png_pixels_and_palette(png_path, width, height)
     pixel_error = compare_png_pixels(str(src), legacy_pixels, modern_pixels)

--- a/tools/f15assets/f15assets/validation_model3d.py
+++ b/tools/f15assets/f15assets/validation_model3d.py
@@ -1,0 +1,917 @@
+"""3D3 JSON, GLB, and GLMESH replacement validation/build helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+from .model3d import build_3d3, export_3d3_gltf_to_glb, export_3d3_shape_gltfs, parse_3d3
+from .validation_compare import (
+    compare_byte_sequence,
+    compare_count_value,
+    compare_glmesh_primitive_streams,
+    compare_mapping_exact,
+    compare_sequence_exact,
+)
+
+__all__ = ["glb_to_glmesh_bytes", "validate_3d3_glb_replacements"]
+
+
+def _safe_output_stem(value: object) -> str:
+    text = str(value or "").strip()
+    safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in text)
+    safe = "_".join(part for part in safe.split("_") if part)
+    return safe[:96] or "model"
+
+
+def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
+    for path in (primary, *fallbacks):
+        if path.exists():
+            return path
+    return primary
+
+
+def _read_glb_json(path: Path) -> Dict[str, Any]:
+    data = path.read_bytes()
+    if len(data) < 20:
+        raise ValueError("GLB too short")
+    magic, version, total_length = struct.unpack_from("<III", data, 0)
+    if magic != 0x46546C67:
+        raise ValueError("bad GLB magic")
+    if version != 2:
+        raise ValueError(f"unsupported GLB version {version}")
+    if total_length != len(data):
+        raise ValueError(f"GLB length header mismatch: header={total_length}, actual={len(data)}")
+    json_length, chunk_type = struct.unpack_from("<II", data, 12)
+    if chunk_type != 0x4E4F534A:
+        raise ValueError("first GLB chunk is not JSON")
+    if 20 + json_length > len(data):
+        raise ValueError("truncated GLB JSON chunk")
+    return json.loads(data[20 : 20 + json_length].decode("utf-8"))
+
+
+def _read_glb_doc_and_bin(path: Path) -> tuple[Dict[str, Any], bytes]:
+    data = path.read_bytes()
+    if len(data) < 20:
+        raise ValueError("GLB too short")
+    magic, version, total_length = struct.unpack_from("<III", data, 0)
+    if magic != 0x46546C67 or version != 2 or total_length != len(data):
+        raise ValueError("invalid GLB header")
+    json_length, json_type = struct.unpack_from("<II", data, 12)
+    if json_type != 0x4E4F534A:
+        raise ValueError("first GLB chunk is not JSON")
+    json_end = 20 + json_length
+    if json_end + 8 > len(data):
+        raise ValueError("missing GLB BIN chunk")
+    bin_length, bin_type = struct.unpack_from("<II", data, json_end)
+    if bin_type != 0x004E4942:
+        raise ValueError("second GLB chunk is not BIN")
+    bin_start = json_end + 8
+    if bin_start + bin_length > len(data):
+        raise ValueError("truncated GLB BIN chunk")
+    return json.loads(data[20:json_end].decode("utf-8")), data[bin_start : bin_start + bin_length]
+
+
+def _gltf_accessor_values(doc: Dict[str, Any], blob: bytes, accessor_index: int) -> list[Any]:
+    accessor = doc["accessors"][accessor_index]
+    view = doc["bufferViews"][int(accessor["bufferView"])]
+    offset = int(view.get("byteOffset", 0)) + int(accessor.get("byteOffset", 0))
+    count = int(accessor["count"])
+    component = int(accessor["componentType"])
+    type_name = str(accessor["type"])
+    dims = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}[type_name]
+    fmt_map = {
+        5121: ("B", 1),
+        5123: ("H", 2),
+        5125: ("I", 4),
+        5126: ("f", 4),
+    }
+    if component not in fmt_map:
+        raise ValueError(f"unsupported GLB component type {component}")
+    fmt, size = fmt_map[component]
+    stride = int(view.get("byteStride", dims * size))
+    values: list[Any] = []
+    for i in range(count):
+        base = offset + i * stride
+        item = struct.unpack_from("<" + fmt * dims, blob, base)
+        values.append(item[0] if dims == 1 else item)
+    return values
+
+
+def _material_rgba(doc: Dict[str, Any], material_index: int | None) -> tuple[float, float, float, float]:
+    if material_index is None:
+        return (1.0, 1.0, 1.0, 1.0)
+    materials = doc.get("materials", [])
+    if not isinstance(materials, list) or material_index < 0 or material_index >= len(materials):
+        return (1.0, 1.0, 1.0, 1.0)
+    pbr = materials[material_index].get("pbrMetallicRoughness", {})
+    color = pbr.get("baseColorFactor", [1.0, 1.0, 1.0, 1.0])
+    if not isinstance(color, list) or len(color) < 4:
+        return (1.0, 1.0, 1.0, 1.0)
+    return tuple(float(max(0.0, min(1.0, float(v)))) for v in color[:4])
+
+
+def _source_primitive_meta(prim: Dict[str, Any]) -> tuple[int, int, int, int]:
+    extras = prim.get("extras", {})
+    if not isinstance(extras, dict):
+        # Custom GLBs exported from Blender may not preserve converter extras.
+        # Drawing still uses geometry/materials; these defaults only mean the
+        # runtime cache cannot prove original .3D3 primitive identity.
+        return (0, -1, -1, 0)
+    kind = extras.get("source_primitive_kind")
+    if kind == "triangle":
+        kind_id = 1
+    elif kind == "lines":
+        kind_id = 2
+    elif kind == "points":
+        kind_id = 3
+    else:
+        kind_id = 0
+    try:
+        source_index = int(extras.get("source_primitive_index", -1))
+    except (TypeError, ValueError):
+        source_index = -1
+    try:
+        source_color = int(extras.get("source_color", -1))
+    except (TypeError, ValueError):
+        source_color = -1
+    flags = 1 if extras.get("source_order_sensitive") is True else 0
+    return (kind_id, source_index, source_color, flags)
+
+
+def glb_to_glmesh_bytes(path: Path) -> bytes:
+    source = path.read_bytes()
+    source_md5 = hashlib.md5(source).hexdigest().encode("ascii")
+    doc, blob = _read_glb_doc_and_bin(path)
+    primitives: list[tuple[int, int, int, int, int, tuple[float, float, float, float], list[tuple[float, float, float]]]] = []
+    for mesh in doc.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        for prim in mesh.get("primitives", []):
+            if not isinstance(prim, dict):
+                continue
+            mode = int(prim.get("mode", 4))
+            if mode not in {0, 1, 4}:
+                continue
+            attrs = prim.get("attributes", {})
+            if not isinstance(attrs, dict) or "POSITION" not in attrs:
+                continue
+            positions = _gltf_accessor_values(doc, blob, int(attrs["POSITION"]))
+            indices = (
+                _gltf_accessor_values(doc, blob, int(prim["indices"]))
+                if "indices" in prim
+                else list(range(len(positions)))
+            )
+            verts = []
+            for index in indices:
+                pos = positions[int(index)]
+                verts.append((float(pos[0]), float(pos[1]), float(pos[2])))
+            kind_id, source_index, source_color, source_flags = _source_primitive_meta(prim)
+            primitives.append((mode, kind_id, source_index, source_color, source_flags, _material_rgba(doc, prim.get("material")), verts))
+
+    out = bytearray()
+    # F15GLM3 layout:
+    #   0x00  8 bytes   magic "F15GLM3\0"
+    #   0x08 32 bytes   lowercase ASCII MD5 of the source GLB
+    #   0x28  4 bytes   primitive count (uint32 LE)
+    #   0x2c...         primitive records:
+    #       mode:uint32, vertex_count:uint32,
+    #       source_kind:int32, source_index:int32, source_color:int32,
+    #       source_flags:uint32, rgba:4*float32, vertices:N*vec3(float32)
+    #
+    # The source_* fields duplicate GLB extras on purpose. GLMESH is a reduced
+    # runtime cache, and these fields let validation prove that reduction did not
+    # merge/reorder color- or z-fighting-sensitive .3D3 primitives.
+    out.extend(b"F15GLM3\0")
+    out.extend(source_md5)
+    out.extend(struct.pack("<I", len(primitives)))
+    for mode, kind_id, source_index, source_color, source_flags, rgba, verts in primitives:
+        out.extend(struct.pack("<IIiiiIffff", mode, len(verts), kind_id, source_index, source_color, source_flags, *rgba))
+        for v in verts:
+            out.extend(struct.pack("<fff", *v))
+    return bytes(out)
+
+
+def _glmesh_primitive_counts(data: bytes) -> Dict[str, int]:
+    if data.startswith(b"F15GLM3\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 40
+    elif data.startswith(b"F15GLM2\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 24
+    elif data.startswith(b"F15GLM1\0"):
+        pos = 12
+        prim_count = struct.unpack_from("<I", data, 8)[0]
+        prim_header_size = 24
+    else:
+        raise ValueError("bad GLMESH magic")
+
+    counts = {"triangles": 0, "lines": 0, "points": 0, "primitives": int(prim_count)}
+    for _ in range(int(prim_count)):
+        if pos + prim_header_size > len(data):
+            raise ValueError("truncated GLMESH primitive header")
+        mode, nverts = struct.unpack_from("<II", data, pos)
+        pos += prim_header_size
+        payload_size = int(nverts) * 12
+        if pos + payload_size > len(data):
+            raise ValueError("truncated GLMESH vertex payload")
+        if mode not in {0, 1, 4}:
+            raise ValueError(f"unsupported GLMESH primitive mode {mode}")
+        if mode == 4 and int(nverts) % 3:
+            raise ValueError("triangle GLMESH primitive has a non-multiple-of-3 vertex count")
+        if mode == 1 and int(nverts) % 2:
+            raise ValueError("line GLMESH primitive has a non-multiple-of-2 vertex count")
+        if mode == 4:
+            counts["triangles"] += int(nverts) // 3
+        elif mode == 1:
+            counts["lines"] += int(nverts) // 2
+        elif mode == 0:
+            counts["points"] += int(nverts)
+        pos += payload_size
+    if pos != len(data):
+        raise ValueError("GLMESH has trailing bytes")
+    return counts
+
+
+def _glmesh_source_meta(data: bytes) -> list[tuple[int, int, int, int]]:
+    if not data.startswith(b"F15GLM3\0"):
+        return []
+    pos = 44
+    prim_count = struct.unpack_from("<I", data, 40)[0]
+    meta: list[tuple[int, int, int, int]] = []
+    for _ in range(int(prim_count)):
+        if pos + 40 > len(data):
+            raise ValueError("truncated GLMESH primitive header")
+        _mode, nverts, kind_id, source_index, source_color, source_flags = struct.unpack_from("<IIiiiI", data, pos)
+        meta.append((int(kind_id), int(source_index), int(source_color), int(source_flags)))
+        pos += 40
+        payload_size = int(nverts) * 12
+        if pos + payload_size > len(data):
+            raise ValueError("truncated GLMESH vertex payload")
+        pos += payload_size
+    return meta
+
+
+def _glmesh_stream(data: bytes) -> list[Dict[str, Any]]:
+    if data.startswith(b"F15GLM3\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 40
+    elif data.startswith(b"F15GLM2\0"):
+        pos = 44
+        prim_count = struct.unpack_from("<I", data, 40)[0]
+        prim_header_size = 24
+    elif data.startswith(b"F15GLM1\0"):
+        pos = 12
+        prim_count = struct.unpack_from("<I", data, 8)[0]
+        prim_header_size = 24
+    else:
+        raise ValueError("bad GLMESH magic")
+
+    stream: list[Dict[str, Any]] = []
+    for _ in range(int(prim_count)):
+        if pos + prim_header_size > len(data):
+            raise ValueError("truncated GLMESH primitive header")
+        mode, nverts = struct.unpack_from("<II", data, pos)
+        if prim_header_size == 40:
+            kind_id, source_index, source_color, source_flags = struct.unpack_from("<iiiI", data, pos + 8)
+            rgba = struct.unpack_from("<ffff", data, pos + 24)
+        else:
+            kind_id, source_index, source_color, source_flags = 0, -1, -1, 0
+            rgba = struct.unpack_from("<ffff", data, pos + 8)
+        pos += prim_header_size
+        payload_size = int(nverts) * 12
+        if pos + payload_size > len(data):
+            raise ValueError("truncated GLMESH vertex payload")
+        vertices = [
+            struct.unpack_from("<fff", data, pos + vertex_offset)
+            for vertex_offset in range(0, payload_size, 12)
+        ]
+        if mode not in {0, 1, 4}:
+            raise ValueError(f"unsupported GLMESH primitive mode {mode}")
+        if mode == 4 and int(nverts) % 3:
+            raise ValueError("triangle GLMESH primitive has a non-multiple-of-3 vertex count")
+        if mode == 1 and int(nverts) % 2:
+            raise ValueError("line GLMESH primitive has a non-multiple-of-2 vertex count")
+        pos += payload_size
+        # Keep the parsed stream explicit. The validator compares this reduced
+        # runtime cache against a cache rebuilt from the edited GLB, so stale or
+        # hand-edited caches cannot silently drop geometry/color/order metadata.
+        stream.append(
+            {
+                "mode": int(mode),
+                "vertices": vertices,
+                "source_kind": int(kind_id),
+                "source_index": int(source_index),
+                "source_color": int(source_color),
+                "source_flags": int(source_flags),
+                "rgba": tuple(float(value) for value in rgba),
+            }
+        )
+    if pos != len(data):
+        raise ValueError("GLMESH has trailing bytes")
+    return stream
+
+
+def _compare_glmesh_streams(expected: bytes, actual: bytes, tolerance: float = 1e-5) -> str | None:
+    return compare_glmesh_primitive_streams(_glmesh_stream(expected), _glmesh_stream(actual), tolerance)
+
+
+def _glb_primitive_counts(doc: Dict[str, Any]) -> Dict[str, int]:
+    counts = {"triangles": 0, "lines": 0, "points": 0, "primitives": 0}
+    accessors = doc.get("accessors", [])
+    if not isinstance(accessors, list):
+        return counts
+    for mesh in doc.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        for prim in mesh.get("primitives", []):
+            if not isinstance(prim, dict):
+                continue
+            mode = int(prim.get("mode", 4))
+            count = 0
+            try:
+                if "indices" in prim:
+                    accessor_index = int(prim["indices"])
+                else:
+                    attrs = prim.get("attributes", {})
+                    if not isinstance(attrs, dict) or "POSITION" not in attrs:
+                        continue
+                    accessor_index = int(attrs["POSITION"])
+                if 0 <= accessor_index < len(accessors) and isinstance(accessors[accessor_index], dict):
+                    count = int(accessors[accessor_index].get("count", 0))
+            except (TypeError, ValueError):
+                continue
+            counts["primitives"] += 1
+            if mode == 4:
+                counts["triangles"] += count // 3
+            elif mode == 1:
+                counts["lines"] += count // 2
+            elif mode == 0:
+                counts["points"] += count
+    return counts
+
+
+def _glb_source_meta(doc: Dict[str, Any]) -> list[tuple[int, int, int, int]]:
+    meta: list[tuple[int, int, int, int]] = []
+    for mesh in doc.get("meshes", []):
+        if not isinstance(mesh, dict):
+            continue
+        for prim in mesh.get("primitives", []):
+            if isinstance(prim, dict):
+                meta.append(_source_primitive_meta(prim))
+    return meta
+
+
+def _glb_raw_color_usage(doc: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
+    extras = doc.get("extras", {})
+    if not isinstance(extras, dict):
+        return {"faces": {}, "lines": {}, "points": {}}
+    usage = extras.get("raw_color_usage", {})
+    if not isinstance(usage, dict):
+        return {"faces": {}, "lines": {}, "points": {}}
+    normalized: Dict[str, Dict[str, int]] = {}
+    for key in ("faces", "lines", "points"):
+        bucket = usage.get(key, {})
+        if not isinstance(bucket, dict):
+            normalized[key] = {}
+            continue
+        normalized[key] = {str(color): int(count) for color, count in sorted(bucket.items())}
+    return normalized
+
+
+def _validate_glb_order_sensitive_primitives(path: Path, doc: Dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    meshes = doc.get("meshes", [])
+    if not isinstance(meshes, list):
+        return [f"{path}: meshes is not a list"]
+    # The converter deliberately emits order-sensitive primitives instead of
+    # compact material batches. Per-kind monotonic source indices are the cheap
+    # invariant that catches accidental optimizer/editor rewrites which would be
+    # harmless for most modern meshes but can break this game's coplanar planes,
+    # z-fighting decals, line antennas, and color-overlap behavior.
+    previous_by_kind = {"triangle": -1, "lines": -1, "points": -1}
+    for mesh in meshes:
+        if not isinstance(mesh, dict):
+            continue
+        for primitive_index, prim in enumerate(mesh.get("primitives", [])):
+            if not isinstance(prim, dict):
+                continue
+            extras = prim.get("extras", {})
+            if not isinstance(extras, dict):
+                errors.append(f"{path}: primitive {primitive_index} missing source extras")
+                continue
+            if extras.get("source_order_sensitive") is not True:
+                errors.append(f"{path}: primitive {primitive_index} is not marked order-sensitive")
+            kind = extras.get("source_primitive_kind")
+            if kind not in {"triangle", "lines", "points"}:
+                errors.append(f"{path}: primitive {primitive_index} has invalid source kind {kind!r}")
+            if kind in previous_by_kind:
+                try:
+                    source_index = int(extras.get("source_primitive_index", -1))
+                except (TypeError, ValueError):
+                    source_index = -1
+                if source_index < 0:
+                    errors.append(f"{path}: {kind} primitive {primitive_index} missing source index")
+                elif source_index <= previous_by_kind[kind]:
+                    errors.append(
+                        f"{path}: {kind} primitive {primitive_index} source index is not monotonic "
+                        f"({source_index} after {previous_by_kind[kind]})"
+                    )
+                previous_by_kind[kind] = source_index
+    return errors
+
+
+def _validate_3d3_json_index(
+    json_path: Path,
+    original_payload: Dict[str, Any],
+    original_bytes: bytes,
+    require_all: bool,
+    loadability_only: bool,
+) -> tuple[int, int]:
+    """Validate .3D3 JSON slot metadata and optional full-byte rebuild data."""
+
+    if not json_path.exists():
+        if require_all:
+            print(f"missing .3D3 JSON index: {json_path}", file=sys.stderr)
+            return 0, 1
+        return 0, 0
+
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"{json_path}: {exc}", file=sys.stderr)
+        return 1, 1
+
+    checked = 1
+    failed = 0
+    if payload.get("format") != "3D3":
+        print(f"{json_path}: expected format=3D3", file=sys.stderr)
+        failed += 1
+
+    actual_offsets = payload.get("shape_offsets")
+    expected_offsets = original_payload.get("shape_offsets", [])
+    if not isinstance(actual_offsets, list) or not all(isinstance(v, int) for v in actual_offsets):
+        print(f"{json_path}: shape_offsets must be a list of integers", file=sys.stderr)
+        failed += 1
+    elif not loadability_only:
+        message = compare_sequence_exact(
+            str(json_path),
+            ".3D3 shape offset table",
+            [int(v) for v in actual_offsets],
+            [int(v) for v in expected_offsets],
+        )
+        if message:
+            print(message, file=sys.stderr)
+            failed += 1
+
+    actual_model_size = payload.get("model_data_size")
+    expected_model_size = int(original_payload.get("model_data_size", 0))
+    if not isinstance(actual_model_size, int) or actual_model_size < 0:
+        print(f"{json_path}: model_data_size must be a non-negative integer", file=sys.stderr)
+        failed += 1
+    elif not loadability_only:
+        message = compare_count_value(
+            str(json_path),
+            ".3D3 model_data_size",
+            int(actual_model_size),
+            expected_model_size,
+            "json",
+            "original",
+        )
+        if message:
+            print(message, file=sys.stderr)
+            failed += 1
+
+    if isinstance(actual_offsets, list) and isinstance(actual_model_size, int):
+        previous = -1
+        for idx, value in enumerate(actual_offsets):
+            if not isinstance(value, int):
+                continue
+            if value < previous:
+                print(f"{json_path}: shape_offsets[{idx}] is not monotonic", file=sys.stderr)
+                failed += 1
+                break
+            if value > actual_model_size:
+                print(f"{json_path}: shape_offsets[{idx}] exceeds model_data_size", file=sys.stderr)
+                failed += 1
+                break
+            previous = value
+
+    if "model_data" in payload:
+        try:
+            rebuilt = build_3d3(payload)
+        except Exception as exc:
+            print(f"{json_path}: failed to rebuild full .3D3 JSON: {exc}", file=sys.stderr)
+            failed += 1
+        else:
+            if not rebuilt:
+                print(f"{json_path}: rebuilt .3D3 JSON is empty", file=sys.stderr)
+                failed += 1
+            elif not loadability_only:
+                message = compare_byte_sequence(
+                    str(json_path),
+                    original_bytes,
+                    rebuilt,
+                    "original",
+                    "json",
+                    "rebuilt .3D3 differs",
+                )
+                if message:
+                    print(message, file=sys.stderr)
+                    failed += 1
+    return checked, failed
+
+
+def _validate_3d3_json_loadability(json_path: Path) -> tuple[int, int]:
+    """Validate a source-free/minimized .3D3 JSON index without original bytes."""
+
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"{json_path}: {exc}", file=sys.stderr)
+        return 1, 1
+
+    failed = 0
+    if payload.get("format") != "3D3":
+        print(f"{json_path}: expected format=3D3", file=sys.stderr)
+        failed += 1
+
+    actual_offsets = payload.get("shape_offsets")
+    actual_model_size = payload.get("model_data_size")
+    if not isinstance(actual_offsets, list) or not all(isinstance(v, int) for v in actual_offsets):
+        print(f"{json_path}: shape_offsets must be a list of integers", file=sys.stderr)
+        failed += 1
+    if not isinstance(actual_model_size, int) or actual_model_size < 0:
+        print(f"{json_path}: model_data_size must be a non-negative integer", file=sys.stderr)
+        failed += 1
+
+    if isinstance(actual_offsets, list) and isinstance(actual_model_size, int):
+        previous = -1
+        for idx, value in enumerate(actual_offsets):
+            if not isinstance(value, int):
+                continue
+            if value < previous:
+                print(f"{json_path}: shape_offsets[{idx}] is not monotonic", file=sys.stderr)
+                failed += 1
+                break
+            if value > actual_model_size:
+                print(f"{json_path}: shape_offsets[{idx}] exceeds model_data_size", file=sys.stderr)
+                failed += 1
+                break
+            previous = value
+
+    if "model_data" in payload:
+        try:
+            rebuilt = build_3d3(payload)
+        except Exception as exc:
+            print(f"{json_path}: failed to rebuild full .3D3 JSON: {exc}", file=sys.stderr)
+            failed += 1
+        else:
+            if not rebuilt:
+                print(f"{json_path}: rebuilt .3D3 JSON is empty", file=sys.stderr)
+                failed += 1
+
+    return 1, failed
+
+
+def _validate_glb_loadability(path: Path) -> tuple[int, int]:
+    try:
+        doc = _read_glb_json(path)
+        counts = _glb_primitive_counts(doc)
+    except Exception as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1, 1
+    if (
+        counts.get("triangles", 0) <= 0
+        and counts.get("lines", 0) <= 0
+        and counts.get("points", 0) <= 0
+    ):
+        print(f"{path}: GLB contains no triangles, lines, or points", file=sys.stderr)
+        return 1, 1
+    return 1, 0
+
+
+def _validate_glmesh_loadability(path: Path) -> tuple[int, int]:
+    try:
+        counts = _glmesh_primitive_counts(path.read_bytes())
+    except Exception as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1, 1
+    if (
+        counts.get("triangles", 0) <= 0
+        and counts.get("lines", 0) <= 0
+        and counts.get("points", 0) <= 0
+    ):
+        print(f"{path}: GLMESH contains no triangles, lines, or points", file=sys.stderr)
+        return 1, 1
+    return 1, 0
+
+
+def validate_3d3_glb_replacements(
+    input_root: Path,
+    output_root: Path,
+    recursive: bool,
+    require_all: bool,
+    iter_asset_paths: Callable[[Path, bool], list[Path]],
+    detect_format: Callable[[Path], str],
+    asset_output_dir: Callable[[Path, Path, Path, Path, str], Path],
+    load_shape_names_for_3d3: Callable[[Path], Dict[str, str]],
+    require_generated_cache: bool,
+    require_source_proof: bool,
+    allow_custom_glb_differences: bool,
+    loadability_only: bool,
+) -> tuple[int, int]:
+    checked = 0
+    failed = 0
+    checked_json_paths: set[Path] = set()
+    checked_glb_paths: set[Path] = set()
+    checked_glmesh_paths: set[Path] = set()
+
+    if input_root.exists():
+        for src in iter_asset_paths(input_root, recursive=recursive):
+            fmt = detect_format(src)
+            if fmt != "3D3":
+                continue
+
+            relative = src.relative_to(input_root)
+            output_base = asset_output_dir(src, relative, input_root, output_root, fmt) / src.name
+            legacy_base = output_root / relative
+            combined_glb = _first_existing_path(
+                output_base.with_name(output_base.name + ".glb"),
+                legacy_base.with_name(legacy_base.name + ".glb"),
+            )
+            shape_output_dir = combined_glb.parent if combined_glb.exists() else output_base.parent
+            data = src.read_bytes()
+            payload = parse_3d3(data)
+            payload["shape_names"] = load_shape_names_for_3d3(src)
+            json_path = _first_existing_path(
+                output_base.with_name(output_base.name + ".json"),
+                legacy_base.with_name(legacy_base.name + ".json"),
+            )
+            json_checked, json_failed = _validate_3d3_json_index(
+                json_path,
+                payload,
+                data,
+                require_all,
+                loadability_only,
+            )
+            if json_path.exists():
+                checked_json_paths.add(json_path.resolve())
+            checked += json_checked
+            failed += json_failed
+            expected_shapes = export_3d3_shape_gltfs(payload)
+            stale_root_glmesh = sorted(shape_output_dir.glob("shape_*.glmesh"))
+            if stale_root_glmesh:
+                for stale_path in stale_root_glmesh:
+                    print(
+                        f"{stale_path}: stale runtime mesh cache outside cache/ directory",
+                        file=sys.stderr,
+                    )
+                failed += len(stale_root_glmesh)
+
+            if not combined_glb.exists():
+                if require_source_proof and not loadability_only:
+                    print(f"missing replacement GLB: {combined_glb}", file=sys.stderr)
+                    failed += 1
+            else:
+                checked += 1
+                checked_glb_paths.add(combined_glb.resolve())
+                try:
+                    glb = _read_glb_json(combined_glb)
+                except Exception as exc:
+                    print(f"{combined_glb}: {exc}", file=sys.stderr)
+                    failed += 1
+                else:
+                    extras = glb.get("extras", {})
+                    if not isinstance(extras, dict) or extras.get("format") != "3D3":
+                        message = f"{combined_glb}: missing 3D3 extras metadata"
+                        if require_source_proof and not loadability_only:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                        elif not loadability_only:
+                            print(f"warning: {message}", file=sys.stderr)
+                    mesh_count = len(glb.get("meshes", [])) if isinstance(glb.get("meshes"), list) else 0
+                    if mesh_count != len(expected_shapes):
+                        message = (
+                            f"{combined_glb}: mesh count differs from renderable shape count "
+                            f"(glb={mesh_count}, expected={len(expected_shapes)})"
+                        )
+                        if require_source_proof and not loadability_only:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                        elif not loadability_only:
+                            print(f"warning: {message}", file=sys.stderr)
+
+            for shape_index, shape_name, expected_shape_gltf in expected_shapes:
+                label = _safe_output_stem(shape_name)
+                base_shape = f"shape_{shape_index:03d}"
+                base = base_shape if label == base_shape else f"{base_shape}_{label}"
+                shape_glb = shape_output_dir / f"{base}.glb"
+                if not shape_glb.exists():
+                    if require_all:
+                        print(f"missing per-shape GLB: {shape_glb}", file=sys.stderr)
+                        failed += 1
+                    continue
+                checked += 1
+                checked_glb_paths.add(shape_glb.resolve())
+                try:
+                    shape_doc = _read_glb_json(shape_glb)
+                except Exception as exc:
+                    print(f"{shape_glb}: {exc}", file=sys.stderr)
+                    failed += 1
+                    continue
+                shape_extras = shape_doc.get("extras", {})
+                if not isinstance(shape_extras, dict):
+                    message = f"{shape_glb}: missing extras metadata"
+                    if require_source_proof and not loadability_only:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    elif not loadability_only:
+                        print(f"warning: {message}", file=sys.stderr)
+                    shape_extras = {}
+                try:
+                    glb_shape_index = int(shape_extras.get("source_shape_index", -1))
+                except (TypeError, ValueError):
+                    glb_shape_index = -1
+                if glb_shape_index != int(shape_index):
+                    message = (
+                        f"{shape_glb}: source_shape_index mismatch "
+                        f"(glb={shape_extras.get('source_shape_index')}, expected={shape_index})"
+                    )
+                    if require_source_proof and not loadability_only:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    elif not loadability_only:
+                        print(f"warning: {message}", file=sys.stderr)
+                if shape_extras.get("minimized_per_shape_glb") is not True:
+                    message = f"{shape_glb}: per-shape GLB is not marked as minimized"
+                    if require_source_proof and not loadability_only:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    elif not loadability_only:
+                        print(f"warning: {message}", file=sys.stderr)
+                meshes = shape_doc.get("meshes", [])
+                nodes = shape_doc.get("nodes", [])
+                if not isinstance(meshes, list) or len(meshes) != 1:
+                    print(f"{shape_glb}: expected exactly one mesh", file=sys.stderr)
+                    failed += 1
+                if not isinstance(nodes, list) or len(nodes) != 1:
+                    print(f"{shape_glb}: expected exactly one node", file=sys.stderr)
+                    failed += 1
+                primitive_errors = _validate_glb_order_sensitive_primitives(shape_glb, shape_doc)
+                if primitive_errors and not loadability_only:
+                    for error in primitive_errors:
+                        if require_source_proof:
+                            print(error, file=sys.stderr)
+                        else:
+                            print(f"warning: {error}", file=sys.stderr)
+                    if require_source_proof:
+                        failed += len(primitive_errors)
+                expected_counts = _glb_primitive_counts(shape_doc)
+                if (
+                    expected_counts.get("triangles", 0) <= 0
+                    and expected_counts.get("lines", 0) <= 0
+                    and expected_counts.get("points", 0) <= 0
+                ):
+                    print(f"{shape_glb}: per-shape GLB contains no triangles, lines, or points", file=sys.stderr)
+                    failed += 1
+                legacy_generated_counts = _glb_primitive_counts(expected_shape_gltf)
+                if not loadability_only:
+                    message = compare_mapping_exact(
+                        str(shape_glb),
+                        "GLB primitive counts",
+                        expected_counts,
+                        legacy_generated_counts,
+                        "glb",
+                        "original",
+                    )
+                    if message:
+                        if allow_custom_glb_differences:
+                            print(f"warning: {message}", file=sys.stderr)
+                        else:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                # This compares compact source identity metadata, not duplicated
+                # geometry in JSON. It catches source primitive drops/reordering/color
+                # loss in an unmodified conversion while still allowing customizers to
+                # edit the GLB itself as the source of truth.
+                if not loadability_only:
+                    legacy_generated_meta = _glb_source_meta(expected_shape_gltf)
+                    glb_meta_from_source = _glb_source_meta(shape_doc)
+                    message = compare_sequence_exact(
+                        str(shape_glb),
+                        "GLB source primitive metadata",
+                        glb_meta_from_source,
+                        legacy_generated_meta,
+                    )
+                    if message:
+                        if require_source_proof and not allow_custom_glb_differences:
+                            print(message, file=sys.stderr)
+                            failed += 1
+                        else:
+                            print(f"warning: {message}", file=sys.stderr)
+                    color_message = compare_mapping_exact(
+                        str(shape_glb),
+                        "GLB raw face/line/point color usage",
+                        _glb_raw_color_usage(shape_doc),
+                        _glb_raw_color_usage(expected_shape_gltf),
+                        "glb",
+                        "original",
+                    )
+                    if color_message:
+                        if require_source_proof and not allow_custom_glb_differences:
+                            print(color_message, file=sys.stderr)
+                            failed += 1
+                        else:
+                            print(f"warning: {color_message}", file=sys.stderr)
+
+                shape_glmesh = shape_output_dir / "cache" / f"{base}.glmesh"
+                if not shape_glmesh.exists():
+                    if require_generated_cache:
+                        print(f"missing per-shape runtime mesh cache: {shape_glmesh}", file=sys.stderr)
+                        failed += 1
+                    continue
+                checked += 1
+                checked_glmesh_paths.add(shape_glmesh.resolve())
+                try:
+                    expected_glmesh = glb_to_glmesh_bytes(shape_glb)
+                    actual_glmesh = shape_glmesh.read_bytes()
+                    actual_counts = _glmesh_primitive_counts(actual_glmesh)
+                    glb_meta = _glb_source_meta(shape_doc)
+                    glmesh_meta = _glmesh_source_meta(actual_glmesh)
+                    stream_error = _compare_glmesh_streams(expected_glmesh, actual_glmesh)
+                except Exception as exc:
+                    print(f"{shape_glmesh}: {exc}", file=sys.stderr)
+                    failed += 1
+                    continue
+                if stream_error:
+                    print(f"{shape_glmesh}: runtime mesh stream differs from source GLB: {stream_error}", file=sys.stderr)
+                    failed += 1
+                if glmesh_meta:
+                    message = compare_sequence_exact(
+                        str(shape_glmesh),
+                        "source primitive metadata",
+                        glmesh_meta,
+                        glb_meta,
+                    )
+                else:
+                    message = None
+                if message:
+                    if require_source_proof:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    else:
+                        print(f"warning: {message}", file=sys.stderr)
+                if not glmesh_meta:
+                    message = f"{shape_glmesh}: runtime mesh cache does not preserve source primitive metadata"
+                    if require_source_proof:
+                        print(message, file=sys.stderr)
+                        failed += 1
+                    else:
+                        print(f"warning: {message}", file=sys.stderr)
+                for count_key in ("triangles", "lines", "points"):
+                    count_error = compare_count_value(
+                        str(shape_glmesh),
+                        count_key,
+                        actual_counts[count_key],
+                        expected_counts[count_key],
+                        "glmesh",
+                        "glb",
+                    )
+                    if count_error:
+                        print(count_error, file=sys.stderr)
+                        failed += 1
+                if actual_glmesh != expected_glmesh:
+                    print(f"{shape_glmesh}: runtime mesh cache differs from source GLB", file=sys.stderr)
+                    failed += 1
+
+    if loadability_only:
+        for json_path in sorted(output_root.rglob("*.json")):
+            if json_path.resolve() in checked_json_paths:
+                continue
+            if not json_path.name.upper().endswith(".3D3.JSON"):
+                continue
+            extra_checked, extra_failed = _validate_3d3_json_loadability(json_path)
+            checked += extra_checked
+            failed += extra_failed
+        for glb_path in sorted(output_root.rglob("*.glb")):
+            if glb_path.resolve() in checked_glb_paths:
+                continue
+            extra_checked, extra_failed = _validate_glb_loadability(glb_path)
+            checked += extra_checked
+            failed += extra_failed
+        for glmesh_path in sorted(output_root.rglob("*.glmesh")):
+            if glmesh_path.resolve() in checked_glmesh_paths:
+                continue
+            extra_checked, extra_failed = _validate_glmesh_loadability(glmesh_path)
+            checked += extra_checked
+            failed += extra_failed
+
+    return checked, failed

--- a/tools/f15assets/f15assets/validation_model3d.py
+++ b/tools/f15assets/f15assets/validation_model3d.py
@@ -22,6 +22,7 @@ __all__ = ["glb_to_glmesh_bytes", "validate_3d3_glb_replacements"]
 
 
 def _safe_output_stem(value: object) -> str:
+    """Return a portable output stem derived from an asset filename."""
     text = str(value or "").strip()
     safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in text)
     safe = "_".join(part for part in safe.split("_") if part)
@@ -29,6 +30,7 @@ def _safe_output_stem(value: object) -> str:
 
 
 def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
+    """Return the first candidate path that exists."""
     for path in (primary, *fallbacks):
         if path.exists():
             return path
@@ -36,6 +38,7 @@ def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
 
 
 def _read_glb_json(path: Path) -> Dict[str, Any]:
+    """Read glb json."""
     data = path.read_bytes()
     if len(data) < 20:
         raise ValueError("GLB too short")
@@ -55,6 +58,7 @@ def _read_glb_json(path: Path) -> Dict[str, Any]:
 
 
 def _read_glb_doc_and_bin(path: Path) -> tuple[Dict[str, Any], bytes]:
+    """Read glb doc and bin."""
     data = path.read_bytes()
     if len(data) < 20:
         raise ValueError("GLB too short")
@@ -77,6 +81,7 @@ def _read_glb_doc_and_bin(path: Path) -> tuple[Dict[str, Any], bytes]:
 
 
 def _gltf_accessor_values(doc: Dict[str, Any], blob: bytes, accessor_index: int) -> list[Any]:
+    """Perform the gltf accessor values asset-processing operation."""
     accessor = doc["accessors"][accessor_index]
     view = doc["bufferViews"][int(accessor["bufferView"])]
     offset = int(view.get("byteOffset", 0)) + int(accessor.get("byteOffset", 0))
@@ -103,6 +108,7 @@ def _gltf_accessor_values(doc: Dict[str, Any], blob: bytes, accessor_index: int)
 
 
 def _material_rgba(doc: Dict[str, Any], material_index: int | None) -> tuple[float, float, float, float]:
+    """Resolve one glTF material to normalized RGBA values."""
     if material_index is None:
         return (1.0, 1.0, 1.0, 1.0)
     materials = doc.get("materials", [])
@@ -116,6 +122,7 @@ def _material_rgba(doc: Dict[str, Any], material_index: int | None) -> tuple[flo
 
 
 def _source_primitive_meta(prim: Dict[str, Any]) -> tuple[int, int, int, int]:
+    """Read preserved renderer semantics from a glTF primitive."""
     extras = prim.get("extras", {})
     if not isinstance(extras, dict):
         # Custom GLBs exported from Blender may not preserve converter extras.
@@ -144,6 +151,7 @@ def _source_primitive_meta(prim: Dict[str, Any]) -> tuple[int, int, int, int]:
 
 
 def glb_to_glmesh_bytes(path: Path) -> bytes:
+    """Perform the glb to glmesh bytes asset-processing operation."""
     source = path.read_bytes()
     source_md5 = hashlib.md5(source).hexdigest().encode("ascii")
     doc, blob = _read_glb_doc_and_bin(path)
@@ -197,6 +205,7 @@ def glb_to_glmesh_bytes(path: Path) -> bytes:
 
 
 def _glmesh_primitive_counts(data: bytes) -> Dict[str, int]:
+    """Perform the glmesh primitive counts asset-processing operation."""
     if data.startswith(b"F15GLM3\0"):
         pos = 44
         prim_count = struct.unpack_from("<I", data, 40)[0]
@@ -240,6 +249,7 @@ def _glmesh_primitive_counts(data: bytes) -> Dict[str, int]:
 
 
 def _glmesh_source_meta(data: bytes) -> list[tuple[int, int, int, int]]:
+    """Perform the glmesh source meta asset-processing operation."""
     if not data.startswith(b"F15GLM3\0"):
         return []
     pos = 44
@@ -259,6 +269,7 @@ def _glmesh_source_meta(data: bytes) -> list[tuple[int, int, int, int]]:
 
 
 def _glmesh_stream(data: bytes) -> list[Dict[str, Any]]:
+    """Decode the ordered primitive stream from a runtime mesh cache."""
     if data.startswith(b"F15GLM3\0"):
         pos = 44
         prim_count = struct.unpack_from("<I", data, 40)[0]
@@ -320,10 +331,12 @@ def _glmesh_stream(data: bytes) -> list[Dict[str, Any]]:
 
 
 def _compare_glmesh_streams(expected: bytes, actual: bytes, tolerance: float = 1e-5) -> str | None:
+    """Compare glmesh streams and report semantic mismatches."""
     return compare_glmesh_primitive_streams(_glmesh_stream(expected), _glmesh_stream(actual), tolerance)
 
 
 def _glb_primitive_counts(doc: Dict[str, Any]) -> Dict[str, int]:
+    """Perform the glb primitive counts asset-processing operation."""
     counts = {"triangles": 0, "lines": 0, "points": 0, "primitives": 0}
     accessors = doc.get("accessors", [])
     if not isinstance(accessors, list):
@@ -359,6 +372,7 @@ def _glb_primitive_counts(doc: Dict[str, Any]) -> Dict[str, int]:
 
 
 def _glb_source_meta(doc: Dict[str, Any]) -> list[tuple[int, int, int, int]]:
+    """Perform the glb source meta asset-processing operation."""
     meta: list[tuple[int, int, int, int]] = []
     for mesh in doc.get("meshes", []):
         if not isinstance(mesh, dict):
@@ -370,6 +384,7 @@ def _glb_source_meta(doc: Dict[str, Any]) -> list[tuple[int, int, int, int]]:
 
 
 def _glb_raw_color_usage(doc: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
+    """Perform the glb raw color usage asset-processing operation."""
     extras = doc.get("extras", {})
     if not isinstance(extras, dict):
         return {"faces": {}, "lines": {}, "points": {}}
@@ -387,6 +402,7 @@ def _glb_raw_color_usage(doc: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
 
 
 def _validate_glb_order_sensitive_primitives(path: Path, doc: Dict[str, Any]) -> list[str]:
+    """Validate glb order sensitive primitives against runtime requirements."""
     errors: list[str] = []
     meshes = doc.get("meshes", [])
     if not isinstance(meshes, list):
@@ -582,6 +598,7 @@ def _validate_3d3_json_loadability(json_path: Path) -> tuple[int, int]:
 
 
 def _validate_glb_loadability(path: Path) -> tuple[int, int]:
+    """Validate glb loadability against runtime requirements."""
     try:
         doc = _read_glb_json(path)
         counts = _glb_primitive_counts(doc)
@@ -599,6 +616,7 @@ def _validate_glb_loadability(path: Path) -> tuple[int, int]:
 
 
 def _validate_glmesh_loadability(path: Path) -> tuple[int, int]:
+    """Validate glmesh loadability against runtime requirements."""
     try:
         counts = _glmesh_primitive_counts(path.read_bytes())
     except Exception as exc:
@@ -628,6 +646,7 @@ def validate_3d3_glb_replacements(
     allow_custom_glb_differences: bool,
     loadability_only: bool,
 ) -> tuple[int, int]:
+    """Validate 3d3 glb replacements against runtime requirements."""
     checked = 0
     failed = 0
     checked_json_paths: set[Path] = set()

--- a/tools/f15assets/f15assets/validation_model3d.py
+++ b/tools/f15assets/f15assets/validation_model3d.py
@@ -155,6 +155,9 @@ def glb_to_glmesh_bytes(path: Path) -> bytes:
     source = path.read_bytes()
     source_md5 = hashlib.md5(source).hexdigest().encode("ascii")
     doc, blob = _read_glb_doc_and_bin(path)
+    from .gltf_scene import flatten_scene
+
+    doc, blob = flatten_scene(doc, blob, _gltf_accessor_values)
     primitives: list[tuple[int, int, int, int, int, tuple[float, float, float, float], list[tuple[float, float, float]]]] = []
     for mesh in doc.get("meshes", []):
         if not isinstance(mesh, dict):

--- a/tools/f15assets/f15assets/validation_model3d.py
+++ b/tools/f15assets/f15assets/validation_model3d.py
@@ -602,6 +602,8 @@ def _validate_3d3_json_loadability(json_path: Path) -> tuple[int, int]:
 
 def _validate_glb_loadability(path: Path) -> tuple[int, int]:
     """Validate glb loadability against runtime requirements."""
+    # Header counts alone do not establish that geometry can be imported.
+    glb_to_glmesh_bytes(path)
     try:
         doc = _read_glb_json(path)
         counts = _glb_primitive_counts(doc)

--- a/tools/f15assets/f15assets/validation_model3d.py
+++ b/tools/f15assets/f15assets/validation_model3d.py
@@ -80,31 +80,10 @@ def _read_glb_doc_and_bin(path: Path) -> tuple[Dict[str, Any], bytes]:
     return json.loads(data[20:json_end].decode("utf-8")), data[bin_start : bin_start + bin_length]
 
 
-def _gltf_accessor_values(doc: Dict[str, Any], blob: bytes, accessor_index: int) -> list[Any]:
-    """Perform the gltf accessor values asset-processing operation."""
-    accessor = doc["accessors"][accessor_index]
-    view = doc["bufferViews"][int(accessor["bufferView"])]
-    offset = int(view.get("byteOffset", 0)) + int(accessor.get("byteOffset", 0))
-    count = int(accessor["count"])
-    component = int(accessor["componentType"])
-    type_name = str(accessor["type"])
-    dims = {"SCALAR": 1, "VEC2": 2, "VEC3": 3, "VEC4": 4}[type_name]
-    fmt_map = {
-        5121: ("B", 1),
-        5123: ("H", 2),
-        5125: ("I", 4),
-        5126: ("f", 4),
-    }
-    if component not in fmt_map:
-        raise ValueError(f"unsupported GLB component type {component}")
-    fmt, size = fmt_map[component]
-    stride = int(view.get("byteStride", dims * size))
-    values: list[Any] = []
-    for i in range(count):
-        base = offset + i * stride
-        item = struct.unpack_from("<" + fmt * dims, blob, base)
-        values.append(item[0] if dims == 1 else item)
-    return values
+def _gltf_accessor_values(doc, blob, idx):
+    """Read geometry through the shared bounds-checked GLB accessor reader."""
+    from .gltf_accessor import accessor_values
+    return accessor_values(doc, blob, idx)
 
 
 def _material_rgba(doc: Dict[str, Any], material_index: int | None) -> tuple[float, float, float, float]:

--- a/tools/f15assets/f15assets/validation_sound.py
+++ b/tools/f15assets/f15assets/validation_sound.py
@@ -14,6 +14,7 @@ __all__ = ["validate_sound_replacements"]
 
 
 def _read_pcm8_mono_wav(path: Path) -> tuple[int, bytes]:
+    """Read pcm8 mono wav."""
     with wave.open(str(path), "rb") as wav:
         if wav.getnchannels() != 1:
             raise ValueError(f"expected mono WAV: {path}")
@@ -27,10 +28,12 @@ def _read_pcm8_mono_wav(path: Path) -> tuple[int, bytes]:
 
 
 def _repo_root_from_tools() -> Path:
+    """Perform the repo root from tools asset-processing operation."""
     return Path(__file__).resolve().parents[3]
 
 
 def _validate_intro_music_export(sound_root: Path, require_all: bool) -> tuple[int, int]:
+    """Validate intro music export against runtime requirements."""
     checked = 0
     failed = 0
     json_path = sound_root / "intro_music.asound.json"
@@ -68,6 +71,7 @@ def validate_sound_replacements(
     require_all: bool,
     loadability_only: bool = False,
 ) -> tuple[int, int]:
+    """Validate sound replacements against runtime requirements."""
     blob_path = input_root / DIGITIZED_SAMPLE_BLOB
     sound_root = output_root / "sounds"
     checked = 0

--- a/tools/f15assets/f15assets/validation_sound.py
+++ b/tools/f15assets/f15assets/validation_sound.py
@@ -1,0 +1,145 @@
+"""Digitized cue WAV replacement validation."""
+
+from __future__ import annotations
+
+import sys
+import wave
+from pathlib import Path
+
+from .sounds import ASOUND_SAMPLE_CUES, DEFAULT_SAMPLE_RATE, DIGITIZED_SAMPLE_BLOB
+from .validation_compare import compare_wav_sample_rate, compare_wav_samples
+from .validation_compare_music import compare_intro_music_json, compare_intro_music_midi
+
+__all__ = ["validate_sound_replacements"]
+
+
+def _read_pcm8_mono_wav(path: Path) -> tuple[int, bytes]:
+    with wave.open(str(path), "rb") as wav:
+        if wav.getnchannels() != 1:
+            raise ValueError(f"expected mono WAV: {path}")
+        if wav.getsampwidth() != 1:
+            raise ValueError(f"expected unsigned 8-bit PCM WAV: {path}")
+        if wav.getcomptype() != "NONE":
+            raise ValueError(f"expected uncompressed PCM WAV: {path}")
+        sample_rate = int(wav.getframerate())
+        samples = wav.readframes(wav.getnframes())
+    return sample_rate, samples
+
+
+def _repo_root_from_tools() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _validate_intro_music_export(sound_root: Path, require_all: bool) -> tuple[int, int]:
+    checked = 0
+    failed = 0
+    json_path = sound_root / "intro_music.asound.json"
+    midi_path = sound_root / "intro_music.mid"
+    if not json_path.exists() and not midi_path.exists():
+        if require_all:
+            print(f"missing intro music ASOUND JSON: {json_path}", file=sys.stderr)
+            print(f"missing intro music MIDI preview: {midi_path}", file=sys.stderr)
+            return checked, 2
+        return checked, failed
+
+    if not json_path.exists():
+        print(f"missing intro music ASOUND JSON: {json_path}", file=sys.stderr)
+        failed += 1
+    else:
+        checked += 1
+        source_text = (_repo_root_from_tools() / "src" / "asound" / "asound_model.c").read_text(encoding="utf-8")
+        errors = compare_intro_music_json(json_path, source_text)
+        for error in errors:
+            print(error, file=sys.stderr)
+        failed += len(errors)
+
+    if midi_path.exists():
+        checked += 1
+    midi_errors = compare_intro_music_midi(midi_path)
+    for error in midi_errors:
+        print(error, file=sys.stderr)
+    failed += len(midi_errors)
+    return checked, failed
+
+
+def validate_sound_replacements(
+    input_root: Path,
+    output_root: Path,
+    require_all: bool,
+    loadability_only: bool = False,
+) -> tuple[int, int]:
+    blob_path = input_root / DIGITIZED_SAMPLE_BLOB
+    sound_root = output_root / "sounds"
+    checked = 0
+    failed = 0
+    checked_wav_paths: set[Path] = set()
+
+    blob = blob_path.read_bytes() if blob_path.exists() else None
+    for cue in ASOUND_SAMPLE_CUES:
+        cue_id = str(cue["id"])
+        wav_path = sound_root / f"{cue_id}.wav"
+        if not wav_path.exists():
+            if require_all:
+                print(f"missing replacement WAV: {wav_path}", file=sys.stderr)
+                failed += 1
+            continue
+
+        checked += 1
+        checked_wav_paths.add(wav_path.resolve())
+        legacy_samples = b""
+        if blob is not None:
+            start = int(cue["source_start"])
+            end = min(int(cue["source_end_inclusive"]) + 1, len(blob))
+            legacy_samples = blob[start:end]
+        try:
+            sample_rate, modern_samples = _read_pcm8_mono_wav(wav_path)
+        except Exception as exc:
+            print(f"{wav_path}: {exc}", file=sys.stderr)
+            failed += 1
+            continue
+
+        if sample_rate <= 0:
+            print(f"{wav_path}: invalid sample rate {sample_rate}", file=sys.stderr)
+            failed += 1
+        if not modern_samples:
+            print(f"{wav_path}: WAV contains no samples", file=sys.stderr)
+            failed += 1
+            continue
+        if not loadability_only and blob is not None:
+            rate_error = compare_wav_sample_rate(str(wav_path), DEFAULT_SAMPLE_RATE, sample_rate)
+            if rate_error:
+                print(rate_error, file=sys.stderr)
+                failed += 1
+            sample_error = compare_wav_samples(str(wav_path), legacy_samples, modern_samples)
+            if sample_error:
+                print(sample_error, file=sys.stderr)
+                failed += 1
+        elif not loadability_only and blob is None:
+            print(
+                f"warning: {blob_path} is missing; validated {wav_path} loadability but skipped legacy sample comparison",
+                file=sys.stderr,
+            )
+
+    if loadability_only and sound_root.exists():
+        for wav_path in sorted(sound_root.glob("voice_cue_*.wav")):
+            if wav_path.resolve() in checked_wav_paths:
+                continue
+            checked += 1
+            try:
+                sample_rate, modern_samples = _read_pcm8_mono_wav(wav_path)
+            except Exception as exc:
+                print(f"{wav_path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+            if sample_rate <= 0:
+                print(f"{wav_path}: invalid sample rate {sample_rate}", file=sys.stderr)
+                failed += 1
+            if not modern_samples:
+                print(f"{wav_path}: WAV contains no samples", file=sys.stderr)
+                failed += 1
+
+    music_checked, music_failed = _validate_intro_music_export(sound_root, require_all)
+    checked += music_checked
+    failed += music_failed
+
+    return checked, failed

--- a/tools/f15assets/f15assets/validation_structured.py
+++ b/tools/f15assets/f15assets/validation_structured.py
@@ -15,6 +15,7 @@ __all__ = ["validate_structured_json_replacements"]
 
 
 def _format_from_structured_json_path(path: Path) -> str | None:
+    """Perform the format from structured json path asset-processing operation."""
     name = path.name.upper()
     for fmt in ("WLD", "3DT", "3DG"):
         if name.endswith(f".{fmt}.JSON"):
@@ -23,6 +24,7 @@ def _format_from_structured_json_path(path: Path) -> str | None:
 
 
 def _validate_structured_json_loadability(path: Path, fmt: str, builder: Callable[[dict], bytes]) -> tuple[int, int]:
+    """Validate structured json loadability against runtime requirements."""
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
         rebuilt = builder(payload)
@@ -36,11 +38,13 @@ def _validate_structured_json_loadability(path: Path, fmt: str, builder: Callabl
 
 
 def _legacy_structured_json_path(relative: Path, output_root: Path) -> Path:
+    """Perform the legacy structured json path asset-processing operation."""
     legacy_base = output_root / relative
     return legacy_base.with_name(legacy_base.name + ".json")
 
 
 def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
+    """Return the first candidate path that exists."""
     for path in (primary, *fallbacks):
         if path.exists():
             return path
@@ -57,6 +61,7 @@ def validate_structured_json_replacements(
     structured_json_path: Callable[[Path, Path, Path, Path, str], Path],
     loadability_only: bool = False,
 ) -> tuple[int, int]:
+    """Validate structured json replacements against runtime requirements."""
     builders = {
         "WLD": build_wld,
         "3DT": build_3dt,

--- a/tools/f15assets/f15assets/validation_structured.py
+++ b/tools/f15assets/f15assets/validation_structured.py
@@ -1,0 +1,119 @@
+"""Structured WLD/3DT/3DG JSON replacement validation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Callable
+
+from .terrain import build_3dg, build_3dt
+from .validation_compare import compare_structured_rebuild
+from .world import build_wld
+
+__all__ = ["validate_structured_json_replacements"]
+
+
+def _format_from_structured_json_path(path: Path) -> str | None:
+    name = path.name.upper()
+    for fmt in ("WLD", "3DT", "3DG"):
+        if name.endswith(f".{fmt}.JSON"):
+            return fmt
+    return None
+
+
+def _validate_structured_json_loadability(path: Path, fmt: str, builder: Callable[[dict], bytes]) -> tuple[int, int]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        rebuilt = builder(payload)
+    except Exception as exc:
+        print(f"{path}: {exc}", file=sys.stderr)
+        return 1, 1
+    if not rebuilt:
+        print(f"{path}: rebuilt {fmt} is empty", file=sys.stderr)
+        return 1, 1
+    return 1, 0
+
+
+def _legacy_structured_json_path(relative: Path, output_root: Path) -> Path:
+    legacy_base = output_root / relative
+    return legacy_base.with_name(legacy_base.name + ".json")
+
+
+def _first_existing_path(primary: Path, *fallbacks: Path) -> Path:
+    for path in (primary, *fallbacks):
+        if path.exists():
+            return path
+    return primary
+
+
+def validate_structured_json_replacements(
+    input_root: Path,
+    output_root: Path,
+    recursive: bool,
+    require_all: bool,
+    iter_asset_paths: Callable[[Path, bool], list[Path]],
+    detect_format: Callable[[Path], str],
+    structured_json_path: Callable[[Path, Path, Path, Path, str], Path],
+    loadability_only: bool = False,
+) -> tuple[int, int]:
+    builders = {
+        "WLD": build_wld,
+        "3DT": build_3dt,
+        "3DG": build_3dg,
+    }
+    checked = 0
+    failed = 0
+    checked_json_paths: set[Path] = set()
+
+    if input_root.exists():
+        for src in iter_asset_paths(input_root, recursive=recursive):
+            fmt = detect_format(src)
+            if fmt not in builders:
+                continue
+
+            relative = src.relative_to(input_root)
+            json_path = _first_existing_path(
+                structured_json_path(src, relative, input_root, output_root, fmt),
+                _legacy_structured_json_path(relative, output_root),
+            )
+            if not json_path.exists():
+                if require_all:
+                    print(f"missing replacement JSON: {json_path}", file=sys.stderr)
+                    failed += 1
+                continue
+
+            checked += 1
+            checked_json_paths.add(json_path.resolve())
+            try:
+                payload = json.loads(json_path.read_text(encoding="utf-8"))
+                rebuilt = builders[fmt](payload)
+                if not rebuilt:
+                    print(f"{json_path}: rebuilt {fmt} is empty", file=sys.stderr)
+                    failed += 1
+                    continue
+                if loadability_only:
+                    continue
+                original = src.read_bytes()
+            except Exception as exc:
+                print(f"{json_path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+
+            rebuild_error = compare_structured_rebuild(str(json_path), fmt, original, rebuilt)
+            if rebuild_error:
+                print(rebuild_error, file=sys.stderr)
+                failed += 1
+
+    if loadability_only:
+        for json_path in sorted(output_root.rglob("*.json")):
+            fmt = _format_from_structured_json_path(json_path)
+            if fmt not in builders:
+                continue
+            if json_path.resolve() in checked_json_paths:
+                continue
+            extra_checked, extra_failed = _validate_structured_json_loadability(json_path, fmt, builders[fmt])
+            checked += extra_checked
+            failed += extra_failed
+
+    return checked, failed

--- a/tools/f15assets/f15assets/world.py
+++ b/tools/f15assets/f15assets/world.py
@@ -16,6 +16,7 @@ WORLD_BUFSZ = 750
 
 
 def parse_wld(data: bytes) -> Dict[str, Any]:
+    """Parse wld."""
     offset = 0
     if len(data) < 2 + 2 + 2 + 2:
         raise ValueError(".WLD data too short")
@@ -145,6 +146,7 @@ def parse_wld(data: bytes) -> Dict[str, Any]:
 
 
 def build_wld(payload: Dict[str, Any]) -> bytes:
+    """Build wld from normalized asset data."""
     if payload.get("format") != "WLD":
         raise ValueError("invalid payload format")
 

--- a/tools/f15assets/map_editor.html
+++ b/tools/f15assets/map_editor.html
@@ -536,10 +536,19 @@
         GULF: "PG",
       }[theaterKey()] || theaterKey() || base;
       const names = [...new Set([
+        `${base}/${modelBase}.3D3.glb`,
+        `${modelBase}/${modelBase}.3D3.glb`,
+        `${base}/${base}.3D3.glb`,
+        `${modelBase}.3D3/${modelBase}.3D3.glb`,
+        `${base}.3D3/${base}.3D3.glb`,
         `${modelBase}.3D3.glb`,
         `${base}.3D3.glb`,
+        `${modelBase}/${modelBase}.glb`,
+        `${base}/${base}.glb`,
         `${modelBase}.glb`,
         `${base}.glb`,
+        `${modelBase}.WLD/${modelBase}.WLD.glb`,
+        `${base}.WLD/${base}.WLD.glb`,
         `${modelBase}.WLD.glb`,
         `${base}.WLD.glb`,
       ])];

--- a/tools/f15assets/model_viewer.html
+++ b/tools/f15assets/model_viewer.html
@@ -284,9 +284,17 @@
     }
 
     function candidates(name) {
+      const dirName = name.replace(/\.(json|glb|gltf)$/i, "");
+      const assetDirName = dirName.replace(/\.(3D3|WLD)$/i, "");
       return [
+        `../../converted_assets_all/${assetDirName}/${name}`,
+        `../../converted_assets_all/${dirName}/${name}`,
         `../../converted_assets_all/${name}`,
+        `/converted_assets_all/${assetDirName}/${name}`,
+        `/converted_assets_all/${dirName}/${name}`,
         `/converted_assets_all/${name}`,
+        `./${assetDirName}/${name}`,
+        `./${dirName}/${name}`,
         `./${name}`,
       ];
     }

--- a/tools/f15assets/tests/test_full_assets.py
+++ b/tools/f15assets/tests/test_full_assets.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 import base64
+import os
 import unittest
 from pathlib import Path
 
 from f15assets import decode_pic_asset, encode_pic_asset, parse_3d3, parse_3dg, parse_3dt, parse_wld
 
-ASSET_ROOT = Path("/home/xor/games/f15")
-HAS_ASSETS = ASSET_ROOT.exists()
+ASSET_PATH = os.environ.get("F15SE2_ORIGINAL_ASSETS")
+ASSET_ROOT = Path(ASSET_PATH) if ASSET_PATH else None
+HAS_ASSETS = ASSET_ROOT is not None and ASSET_ROOT.is_dir()
 
 
-@unittest.skipIf(not HAS_ASSETS, f"missing asset tree: {ASSET_ROOT}")
+def asset_paths(*extensions):
+    return sorted(path for path in ASSET_ROOT.rglob("*")
+                  if path.is_file() and path.suffix.upper() in extensions)
+
+
+@unittest.skipIf(not HAS_ASSETS, "set F15SE2_ORIGINAL_ASSETS to an installed game folder")
 class FullAssetRoundTripTest(unittest.TestCase):
     @staticmethod
     def _roundtrip_pic(path: Path) -> None:
@@ -30,7 +37,7 @@ class FullAssetRoundTripTest(unittest.TestCase):
             raise AssertionError(f"bad parsed format for {path.name}: {payload.get('format')}")
 
     def test_full_pic_and_spr_roundtrip(self) -> None:
-        paths = sorted(ASSET_ROOT.glob("*.PIC")) + sorted(ASSET_ROOT.glob("*.pic")) + sorted(ASSET_ROOT.glob("*.SPR")) + sorted(ASSET_ROOT.glob("*.spr"))
+        paths = asset_paths(".PIC", ".SPR")
         if not paths:
             self.skipTest("no .PIC/.SPR files found")
         for path in paths:
@@ -38,7 +45,7 @@ class FullAssetRoundTripTest(unittest.TestCase):
                 self._roundtrip_pic(path)
 
     def test_full_pic_and_spr_decode(self) -> None:
-        paths = sorted(ASSET_ROOT.glob("*.PIC")) + sorted(ASSET_ROOT.glob("*.pic")) + sorted(ASSET_ROOT.glob("*.SPR")) + sorted(ASSET_ROOT.glob("*.spr"))
+        paths = asset_paths(".PIC", ".SPR")
         if not paths:
             self.skipTest("no .PIC/.SPR files found")
         for path in paths:
@@ -46,7 +53,7 @@ class FullAssetRoundTripTest(unittest.TestCase):
                 self._parse_only(path, decode_pic_asset, "PIC")
 
     def test_full_3d3_decode(self) -> None:
-        paths = sorted(ASSET_ROOT.glob("*.3D3")) + sorted(ASSET_ROOT.glob("*.3d3"))
+        paths = asset_paths(".3D3")
         if not paths:
             self.skipTest("no .3D3 files found")
         for path in paths:
@@ -54,7 +61,7 @@ class FullAssetRoundTripTest(unittest.TestCase):
                 self._parse_only(path, parse_3d3, "3D3")
 
     def test_full_3dt_decode(self) -> None:
-        paths = sorted(ASSET_ROOT.glob("*.3DT")) + sorted(ASSET_ROOT.glob("*.3dt"))
+        paths = asset_paths(".3DT")
         if not paths:
             self.skipTest("no .3DT files found")
         for path in paths:
@@ -62,7 +69,7 @@ class FullAssetRoundTripTest(unittest.TestCase):
                 self._parse_only(path, parse_3dt, "3DT")
 
     def test_full_3dg_decode(self) -> None:
-        paths = sorted(ASSET_ROOT.glob("*.3DG")) + sorted(ASSET_ROOT.glob("*.3dg"))
+        paths = asset_paths(".3DG")
         if not paths:
             self.skipTest("no .3DG files found")
         for path in paths:
@@ -70,7 +77,7 @@ class FullAssetRoundTripTest(unittest.TestCase):
                 self._parse_only(path, parse_3dg, "3DG")
 
     def test_full_wld_decode(self) -> None:
-        paths = sorted(ASSET_ROOT.glob("*.WLD")) + sorted(ASSET_ROOT.glob("*.wld"))
+        paths = asset_paths(".WLD")
         if not paths:
             self.skipTest("no .WLD files found")
         for path in paths:

--- a/tools/f15assets/tests/test_gltf_accessor.py
+++ b/tools/f15assets/tests/test_gltf_accessor.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import copy
+import struct
+import unittest
+
+from f15assets.gltf_accessor import accessor_values
+from f15assets.validation_model3d import _gltf_accessor_values
+
+
+class GltfAccessorTest(unittest.TestCase):
+    def setUp(self):
+        self.blob = struct.pack("<6f", 1, 2, 3, 4, 5, 6)
+        self.doc = {
+            "buffers": [{"byteLength": 24}],
+            "bufferViews": [{"buffer": 0, "byteLength": 24}],
+            "accessors": [{"bufferView": 0, "componentType": 5126,
+                           "count": 2, "type": "VEC3"}],
+        }
+
+    def test_runtime_bridge_uses_checked_reader(self):
+        self.assertEqual(_gltf_accessor_values(self.doc, self.blob, 0),
+                         [(1, 2, 3), (4, 5, 6)])
+        self.doc["bufferViews"][0]["byteLength"] = 12
+        with self.assertRaises(ValueError):
+            _gltf_accessor_values(self.doc, self.blob, 0)
+
+    def test_interleaved_positions(self):
+        self.blob = struct.pack("<8f", 1, 2, 3, 99, 4, 5, 6, 99)
+        self.doc["buffers"][0]["byteLength"] = 32
+        self.doc["bufferViews"][0].update(byteLength=32, byteStride=16)
+        self.assertEqual(accessor_values(self.doc, self.blob, 0),
+                         [(1, 2, 3), (4, 5, 6)])
+
+    def test_invalid_metadata(self):
+        cases = [
+            ("accessors", "bufferView", -1),
+            ("accessors", "byteOffset", -4),
+            ("accessors", "byteOffset", 2),
+            ("accessors", "count", 0),
+            ("accessors", "count", 3),
+            ("accessors", "count", 1.5),
+            ("accessors", "count", True),
+            ("accessors", "sparse", {}),
+            ("accessors", "normalized", True),
+            ("accessors", "componentType", 5122),
+            ("accessors", "type", "MAT4"),
+            ("bufferViews", "buffer", 1),
+            ("bufferViews", "byteLength", 12),
+            ("bufferViews", "byteOffset", -1),
+            ("bufferViews", "byteOffset", 4),
+            ("bufferViews", "byteStride", 8),
+            ("bufferViews", "byteStride", 14),
+            ("bufferViews", "byteStride", 256),
+            ("buffers", "byteLength", 12),
+            ("buffers", "byteLength", 28),
+            ("buffers", "uri", "external.bin"),
+        ]
+        for table, field, value in cases:
+            with self.subTest(table=table, field=field, value=value):
+                doc = copy.deepcopy(self.doc)
+                doc[table][0][field] = value
+                with self.assertRaises(ValueError):
+                    accessor_values(doc, self.blob, 0)
+
+    def test_invalid_index(self):
+        for index in (-1, 1, True, 0.5):
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                accessor_values(self.doc, self.blob, index)
+
+    def test_non_finite_positions(self):
+        for value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                accessor_values(self.doc, struct.pack("<6f", value, 2, 3, 4, 5, 6), 0)
+
+    def test_unsigned_indices(self):
+        for component, fmt in ((5121, "B"), (5123, "H"), (5125, "I")):
+            with self.subTest(component=component):
+                blob = struct.pack("<3" + fmt, 0, 1, 2)
+                self.doc["buffers"][0]["byteLength"] = len(blob)
+                self.doc["bufferViews"][0]["byteLength"] = len(blob)
+                self.doc["accessors"][0].update(componentType=component, count=3, type="SCALAR")
+                self.assertEqual(accessor_values(self.doc, blob, 0), [0, 1, 2])

--- a/tools/f15assets/tests/test_gltf_loadability.py
+++ b/tools/f15assets/tests/test_gltf_loadability.py
@@ -1,0 +1,40 @@
+import json
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from f15assets.validation_model3d import _validate_glb_loadability
+
+
+class GltfLoadabilityTest(unittest.TestCase):
+    def validate(self, vertices=3, vertex_colors=False):
+        payload = struct.pack("<" + "3f" * vertices, *([1, 0, 0] * vertices))
+        attributes = {"POSITION": 0}
+        if vertex_colors:
+            attributes["COLOR_0"] = 0
+        doc = {"asset": {"version": "2.0"}, "buffers": [{"byteLength": len(payload)}],
+               "bufferViews": [{"buffer": 0, "byteLength": len(payload)}],
+               "accessors": [{"bufferView": 0, "componentType": 5126, "count": 3, "type": "VEC3"}],
+               "meshes": [{"primitives": [{"attributes": attributes, "mode": 4}]}],
+               "nodes": [{"mesh": 0}], "scenes": [{"nodes": [0]}], "scene": 0}
+        encoded = json.dumps(doc).encode()
+        encoded += b" " * (-len(encoded) % 4)
+        data = struct.pack("<III", 0x46546c67, 2, 28 + len(encoded) + len(payload))
+        data += struct.pack("<II", len(encoded), 0x4e4f534a) + encoded
+        data += struct.pack("<II", len(payload), 0x004e4942) + payload
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "shape.glb"
+            path.write_bytes(data)
+            return _validate_glb_loadability(path)
+
+    def test_valid_geometry(self):
+        self.assertEqual(self.validate(), (1, 0))
+
+    def test_truncated_geometry_is_not_loadable(self):
+        with self.assertRaises((ValueError, struct.error)):
+            self.validate(vertices=1)
+
+    def test_unsupported_color_data_is_not_loadable(self):
+        with self.assertRaises(ValueError):
+            self.validate(vertex_colors=True)

--- a/tools/f15assets/tests/test_gltf_primitive.py
+++ b/tools/f15assets/tests/test_gltf_primitive.py
@@ -1,0 +1,37 @@
+import copy
+import unittest
+
+from f15assets.gltf_primitive import validate_primitive
+
+
+class GltfPrimitiveTest(unittest.TestCase):
+    def setUp(self):
+        self.doc = {"accessors": [{"type": "VEC3", "componentType": 5126, "count": 3}],
+                    "materials": [{"pbrMetallicRoughness": {"baseColorFactor": [1, 0, 0, 1]}}]}
+        self.primitive = {"attributes": {"POSITION": 0}, "material": 0}
+
+    def test_flat_material_triangle(self):
+        validate_primitive(self.doc, self.primitive)
+
+    def test_unsupported_geometry(self):
+        for fields in ({"mode": 5}, {"mode": True}, {"attributes": {}},
+                       {"attributes": {"POSITION": -1}},
+                       {"attributes": {"POSITION": 0, "COLOR_0": 1}},
+                       {"indices": 0}, {"mode": 1}, {"material": -1}):
+            with self.subTest(fields=fields), self.assertRaises(ValueError):
+                validate_primitive(self.doc, {**self.primitive, **fields})
+
+    def test_unsupported_material(self):
+        for pbr in ({"baseColorTexture": {"index": 0}},
+                    {"baseColorFactor": [float("nan"), 0, 0, 1]},
+                    {"baseColorFactor": [2, 0, 0, 1]},
+                    {"baseColorFactor": [1, 0, 0]}, None):
+            with self.subTest(pbr=pbr), self.assertRaises(ValueError):
+                doc = copy.deepcopy(self.doc)
+                doc["materials"][0]["pbrMetallicRoughness"] = pbr
+                validate_primitive(doc, self.primitive)
+
+    def test_indexed_line(self):
+        self.doc["accessors"].append({"type": "SCALAR", "componentType": 5123, "count": 2})
+        self.primitive.update(mode=1, indices=1)
+        validate_primitive(self.doc, self.primitive)

--- a/tools/f15assets/tests/test_gltf_scene.py
+++ b/tools/f15assets/tests/test_gltf_scene.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import copy
+import json
+import math
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from f15assets.validation_model3d import glb_to_glmesh_bytes
+
+
+class GltfSceneTest(unittest.TestCase):
+    def setUp(self):
+        self.doc = {
+            "asset": {"version": "2.0"}, "buffers": [{"byteLength": 36}],
+            "bufferViews": [{"buffer": 0, "byteLength": 36}],
+            "accessors": [{"bufferView": 0, "componentType": 5126,
+                           "count": 3, "type": "VEC3"}],
+            "meshes": [{"primitives": [{"attributes": {"POSITION": 0}, "mode": 4}]}],
+            "nodes": [{"mesh": 0}], "scenes": [{"nodes": [0]}], "scene": 0,
+        }
+
+    def convert(self):
+        payload = struct.pack("<9f", 1, 0, 0, 0, 1, 0, 0, 0, 0)
+        encoded = json.dumps(self.doc).encode()
+        encoded += b" " * (-len(encoded) % 4)
+        data = struct.pack("<III", 0x46546c67, 2, 28 + len(encoded) + len(payload))
+        data += struct.pack("<II", len(encoded), 0x4e4f534a) + encoded
+        data += struct.pack("<II", len(payload), 0x004e4942) + payload
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "scene.glb"
+            path.write_bytes(data)
+            mesh = glb_to_glmesh_bytes(path)
+        count = struct.unpack_from("<I", mesh, 40)[0]
+        cursor = 44
+        primitives = []
+        for _ in range(count):
+            mode, vertices = struct.unpack_from("<II", mesh, cursor)
+            self.assertEqual(mode, 4)
+            cursor += 40
+            primitives.append([struct.unpack_from("<3f", mesh, cursor + i*12)
+                               for i in range(vertices)])
+            cursor += vertices * 12
+        self.assertEqual(cursor, len(mesh))
+        return primitives
+
+    def test_identity(self):
+        self.assertEqual(self.convert(), [[(1, 0, 0), (0, 1, 0), (0, 0, 0)]])
+
+    def test_translation(self):
+        self.doc["nodes"][0]["translation"] = [10, 0, 0]
+        self.assertEqual(self.convert()[0], [(11, 0, 0), (10, 1, 0), (10, 0, 0)])
+
+    def test_parent_transform_and_trs_order(self):
+        self.doc["nodes"] = [
+            {"children": [1], "translation": [10, 0, 0]},
+            {"mesh": 0, "translation": [1, 2, 3], "scale": [2, 3, 4],
+             "rotation": [0, 0, math.sqrt(0.5), math.sqrt(0.5)]},
+        ]
+        points = self.convert()[0]
+        for actual, expected in zip(points, [(11, 4, 3), (8, 2, 3), (11, 2, 3)]):
+            for value, reference in zip(actual, expected):
+                self.assertAlmostEqual(value, reference, places=5)
+
+    def test_matrix_and_mesh_instances(self):
+        self.doc["nodes"] = [
+            {"mesh": 0},
+            {"mesh": 0, "matrix": [1,0,0,0, 0,1,0,0, 0,0,1,0, 5,6,7,1]},
+        ]
+        self.doc["scenes"][0]["nodes"] = [0, 1]
+        instances = self.convert()
+        self.assertEqual(len(instances), 2)
+        self.assertEqual(instances[0][0], (1, 0, 0))
+        self.assertEqual(instances[1][0], (6, 6, 7))
+
+    def test_selected_scene_omits_unused_meshes(self):
+        self.doc["meshes"].append(copy.deepcopy(self.doc["meshes"][0]))
+        self.doc["nodes"].append({"mesh": 1, "translation": [5, 0, 0]})
+        self.doc["scenes"].append({"nodes": [1]})
+        self.doc["scene"] = 1
+        instances = self.convert()
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0][0], (6, 0, 0))
+
+    def test_scene_less_hierarchy(self):
+        del self.doc["scenes"]
+        del self.doc["scene"]
+        self.doc["nodes"] = [{"children": [1]}, {"mesh": 0}]
+        self.assertEqual(len(self.convert()), 1)
+
+    def test_invalid_scene_graph(self):
+        for roots, nodes in [([-1], [{"mesh": 0}]), ([2], [{"mesh": 0}]),
+                             ([0], [{"mesh": -1}]),
+                             ([0], [{"children": [0]}]),
+                             ([0, 0], [{"mesh": 0}]),
+                             ([0], [{"children": [1, 1]}, {"mesh": 0}])]:
+            with self.subTest(roots=roots, nodes=nodes):
+                self.doc["nodes"] = nodes
+                self.doc["scenes"] = [{"nodes": roots}]
+                with self.assertRaises(ValueError):
+                    self.convert()
+
+    def test_invalid_or_unrepresentable_transform(self):
+        for transform in [{"translation": [1, 2]}, {"rotation": [0, 0, 0, 0]},
+                          {"translation": [float("inf"), 0, 0]},
+                          {"scale": [1e40, 1, 1]},
+                          {"matrix": [1]*16},
+                          {"matrix": [1]*16, "scale": [1, 1, 1]}]:
+            with self.subTest(transform=transform):
+                self.doc["nodes"] = [{"mesh": 0, **transform}]
+                with self.assertRaises(ValueError):
+                    self.convert()
+
+    def test_unsupported_deformation_is_not_silently_ignored(self):
+        for key, value in [("skin", 0), ("weights", [1])]:
+            with self.subTest(key=key):
+                self.doc["nodes"] = [{"mesh": 0, key: value}]
+                with self.assertRaises(ValueError):
+                    self.convert()
+        self.doc["nodes"] = [{"mesh": 0}]
+        self.doc["animations"] = [{}]
+        with self.assertRaises(ValueError):
+            self.convert()

--- a/tools/f15assets/tests/test_smoke.py
+++ b/tools/f15assets/tests/test_smoke.py
@@ -7,7 +7,7 @@ import struct
 import tempfile
 import unittest
 
-from f15assets import decode_pic_asset, encode_pic_asset, export_3d3_to_gltf, export_3d3_to_glb
+from f15assets import decode_pic_asset, encode_pic_asset, export_3d3_to_gltf, export_3d3_to_glb, export_3d3_shape_gltfs, export_3d3_gltf_to_glb
 from f15assets import parse_3d3, build_3d3, parse_3dg, build_3dg, parse_3dt, build_3dt, parse_wld, build_wld
 from tools.f15assets import cli as cli_module
 
@@ -414,7 +414,41 @@ class SmokeConvertersTest(unittest.TestCase):
         self.assertEqual(glb[16:20], b"JSON")
         self.assertGreaterEqual(len(glb), 20 + json_chunk_length)
 
-    def test_3d3_to_gltf_tolerates_truncated_shape_payload(self):
+    def test_3d3_shape_glmesh_cache_matches_glb_source(self):
+        render_mode = bytes([0x00])
+        face_info = bytes([0x04] + [0x00] * 32)
+        vertices = bytes(
+            [0x03,
+             0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+             0xFF, 0xFF, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]
+        )
+        edges = bytes([0x03, 0xFF, 0xFF, 0x00, 0x01, 0xFF, 0xFF, 0x01, 0x02, 0xFF, 0xFF, 0x02, 0x00])
+        primitive = bytes([0x01, 0x05, 0x03, 0x00, 0x01, 0x02, 0x01])
+        shape_data = render_mode + face_info + vertices + edges + primitive
+
+        blob = bytearray()
+        blob.extend((0x33, 0x33))
+        blob.extend((1, 0))
+        blob.extend((0, 0))
+        blob.extend((len(shape_data) & 0xFF, (len(shape_data) >> 8) & 0xFF))
+        blob.extend(shape_data)
+
+        payload = parse_3d3(bytes(blob))
+        shapes = export_3d3_shape_gltfs(payload)
+        self.assertEqual(len(shapes), 1)
+
+        with tempfile.TemporaryDirectory() as workdir:
+            glb_path = pathlib.Path(workdir) / "shape_000.glb"
+            glmesh_path = pathlib.Path(workdir) / "shape_000.glmesh"
+            glb_path.write_bytes(export_3d3_gltf_to_glb(shapes[0][2]))
+            glmesh_path.write_bytes(cli_module._glb_to_glmesh_bytes(glb_path))
+            glmesh = glmesh_path.read_bytes()
+            self.assertEqual(glmesh, cli_module._glb_to_glmesh_bytes(glb_path))
+            self.assertEqual(glmesh[:8], b"F15GLM3\x00")
+            self.assertGreater(len(glmesh), 12)
+
+    def test_3d3_to_gltf_exports_edge_run_shape_payload(self):
         payload = {
             "format": "3D3",
             "shape_offsets": [0],
@@ -425,146 +459,10 @@ class SmokeConvertersTest(unittest.TestCase):
         }
 
         gltf = export_3d3_to_gltf(payload)
-        self.assertEqual(len(gltf["meshes"]), 0)
-        self.assertEqual(
-            gltf["extras"]["skipped_shapes"][0]["shape_payload"]["render_error"],
-            "truncated 3D3 face-normal block",
-        )
-
-    def test_yaml_sidecar_export_and_roundtrip(self):
-        try:
-            import yaml
-        except Exception:
-            self.skipTest("PyYAML unavailable")
-
-        payload = {
-            "format": "3DT",
-            "version": 1,
-            "levels": [
-                {
-                    "level": 0,
-                    "objects": [
-                        {
-                            "tile_index": 0,
-                            "objects": [
-                                {"x": 1, "y": 2, "z": 3, "shape_word": 0x00FE},
-                            ],
-                        }
-                    ],
-                },
-                {"level": 1, "objects": []},
-                {"level": 2, "objects": []},
-                {"level": 3, "objects": []},
-                {"level": 4, "objects": []},
-            ],
-        }
-
-        source = build_3dt(payload)
-        decoded = parse_3dt(source)
-        with tempfile.TemporaryDirectory() as workdir:
-            base = pathlib.Path(workdir)
-            yaml_path = base / "shape.yaml"
-            json_path = base / "shape.json"
-
-            json_path.write_text(json.dumps(decoded, indent=2, sort_keys=True), encoding="utf-8")
-            yaml_path.write_text(yaml.safe_dump(decoded, sort_keys=True), encoding="utf-8")
-
-            from_yaml = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-            self.assertEqual(from_yaml["format"], "3DT")
-            self.assertEqual(from_yaml["tile_counts"], decoded["tile_counts"])
-
-            restored = json.loads(json_path.read_text(encoding="utf-8"))
-            self.assertEqual(build_3dt(from_yaml), build_3dt(restored))
-
-    def test_yaml_encode_input_supported(self):
-        try:
-            import yaml
-        except Exception:
-            self.skipTest("PyYAML unavailable")
-
-        payload = {
-            "format": "3DT",
-            "version": 1,
-            "levels": [
-                {
-                    "level": 0,
-                    "objects": [
-                        {
-                            "tile_index": 0,
-                            "objects": [{"x": 9, "y": 8, "z": 7, "shape_word": 0x00AB}],
-                        }
-                    ],
-                },
-                {"level": 1, "objects": []},
-                {"level": 2, "objects": []},
-                {"level": 3, "objects": []},
-                {"level": 4, "objects": []},
-            ],
-        }
-
-        source = build_3dt(payload)
-        parsed = parse_3dt(source)
-
-        with tempfile.TemporaryDirectory() as workdir:
-            yaml_path = pathlib.Path(workdir) / "shape.yaml"
-            with yaml_path.open("w", encoding="utf-8") as f:
-                yaml.safe_dump(parsed, f, sort_keys=True)
-            decoded_yaml = cli_module._read_yaml(yaml_path)
-            self.assertEqual(decoded_yaml["format"], "3DT")
-            self.assertEqual(build_3dt(decoded_yaml), source)
-
-    def test_yaml_sidecar_for_3dg_and_wld(self):
-        try:
-            import yaml
-        except Exception:
-            self.skipTest("PyYAML unavailable")
-
-        grid_payload = {
-            "format": "3DG",
-            "version": 1,
-            "level4_top_grid": [1] * 16,
-            "level3_grid": [2] * 256,
-            "level2_subgrid": [3] * 512,
-            "level1_subgrid": [4] * 512,
-            "level0_subgrid": [5] * 512,
-        }
-        wld_payload = {
-            "format": "WLD",
-            "terrain_target_ids": {"land": 0x11, "water": 0x11},
-            "read_item_size": 0,
-            "ground_unit_count": 0,
-            "world_object_count": 0,
-            "world_objects": [],
-            "flight_unit_count": 0,
-            "flight_units": [],
-            "shape_target_category_table": base64.b64encode(bytes([7] * 100)).decode("ascii"),
-            "kill_tally_or_unit_flags": base64.b64encode(bytes([8] * 100)).decode("ascii"),
-            "mission_object_type_table": base64.b64encode(bytes([9] * 100)).decode("ascii"),
-            "terrain_grid": base64.b64encode(bytes(range(256))).decode("ascii"),
-            "name_table": base64.b64encode(b"ALPHA\x00BRAVO\x00").decode("ascii"),
-            "trailing_bytes": "",
-        }
-
-        grid_bytes = build_3dg(grid_payload)
-        wld_bytes = build_wld(wld_payload)
-        grid_parsed = parse_3dg(grid_bytes)
-        wld_parsed = parse_wld(wld_bytes)
-
-        with tempfile.TemporaryDirectory() as workdir:
-            base = pathlib.Path(workdir)
-            grid_yaml = base / "grid.yaml"
-            wld_yaml = base / "wld.yaml"
-            grid_yaml.write_text(yaml.safe_dump(grid_parsed, sort_keys=True), encoding="utf-8")
-            wld_yaml.write_text(yaml.safe_dump(wld_parsed, sort_keys=True), encoding="utf-8")
-
-            self.assertEqual(
-                build_3dg(cli_module._read_yaml(grid_yaml)),
-                grid_bytes,
-            )
-            self.assertEqual(
-                build_wld(cli_module._read_yaml(wld_yaml)),
-                wld_bytes,
-            )
+        self.assertEqual(len(gltf["meshes"]), 1)
+        self.assertEqual(gltf["meshes"][0]["extras"]["shape_payload"]["form"], "edgerun")
+        self.assertEqual(len(gltf["meshes"][0]["primitives"]), 7)
+        self.assertEqual(gltf["extras"]["skipped_shapes"], [])
 
     def test_cli_decode_writes_stable_sidecars(self):
         asset_root = pathlib.Path("/home/xor/games/f15")
@@ -591,12 +489,10 @@ class SmokeConvertersTest(unittest.TestCase):
             base = pathlib.Path(workdir)
 
             json_3d3 = base / "asset_3d3.json"
-            yaml_3d3 = base / "asset_3d3.yaml"
             gltf = base / "asset_3d3.gltf"
 
             if sample_pic is not None:
                 json_pic = base / "asset_pic.json"
-                yaml_pic = base / "asset_pic.yaml"
                 png_pic = base / "asset_pic.png"
                 rc = cli_module.main(
                     [
@@ -605,13 +501,10 @@ class SmokeConvertersTest(unittest.TestCase):
                         str(json_pic),
                         "--png",
                         str(png_pic),
-                        "--yaml",
-                        str(yaml_pic),
                     ]
                 )
                 self.assertEqual(rc, 0)
                 self.assertTrue(json_pic.exists())
-                self.assertTrue(yaml_pic.exists())
                 self.assertTrue(png_pic.exists())
                 payload_pic = json.loads(json_pic.read_text(encoding="utf-8"))
                 self.assertEqual(payload_pic["format"], "PIC")
@@ -623,31 +516,24 @@ class SmokeConvertersTest(unittest.TestCase):
                     str(json_3d3),
                     "--gltf",
                     str(gltf),
-                    "--yaml",
-                    str(yaml_3d3),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_3d3.exists())
-            self.assertTrue(yaml_3d3.exists())
             self.assertTrue(gltf.exists())
             payload = json.loads(json_3d3.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "3D3")
 
             json_3dt = base / "asset_3dt.json"
-            yaml_3dt = base / "asset_3dt.yaml"
             rc = cli_module.main(
                 [
                     "decode",
                     str(sample_3dt),
                     str(json_3dt),
-                    "--yaml",
-                    str(yaml_3dt),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_3dt.exists())
-            self.assertTrue(yaml_3dt.exists())
             payload = json.loads(json_3dt.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "3DT")
 
@@ -658,19 +544,15 @@ class SmokeConvertersTest(unittest.TestCase):
                 self.skipTest("missing .3DG sample")
 
             json_3dg = base / "asset_3dg.json"
-            yaml_3dg = base / "asset_3dg.yaml"
             rc = cli_module.main(
                 [
                     "decode",
                     str(sample_3dg),
                     str(json_3dg),
-                    "--yaml",
-                    str(yaml_3dg),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_3dg.exists())
-            self.assertTrue(yaml_3dg.exists())
             payload = json.loads(json_3dg.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "3DG")
 
@@ -681,19 +563,15 @@ class SmokeConvertersTest(unittest.TestCase):
                 self.skipTest("missing .WLD sample")
 
             json_wld = base / "asset_wld.json"
-            yaml_wld = base / "asset_wld.yaml"
             rc = cli_module.main(
                 [
                     "decode",
                     str(sample_wld),
                     str(json_wld),
-                    "--yaml",
-                    str(yaml_wld),
                 ]
             )
             self.assertEqual(rc, 0)
             self.assertTrue(json_wld.exists())
-            self.assertTrue(yaml_wld.exists())
             payload = json.loads(json_wld.read_text(encoding="utf-8"))
             self.assertEqual(payload["format"], "WLD")
 
@@ -781,29 +659,24 @@ class SmokeConvertersTest(unittest.TestCase):
                     str(source_root),
                     str(output_root),
                     "--recursive",
-                    "--yaml",
                     "--models",
                     "glb",
                 ]
             )
             self.assertEqual(rc, 0)
 
-            self.assertTrue((output_root / "TITLE.json").exists())
-            self.assertTrue((output_root / "TITLE.yaml").exists())
+            self.assertFalse((output_root / "TITLE.json").exists())
             self.assertTrue((output_root / "TITLE.png").exists())
 
-            self.assertTrue((output_root / "SCENERY.3D3.json").exists())
-            self.assertTrue((output_root / "SCENERY.3D3.yaml").exists())
-            self.assertTrue((output_root / "SCENERY.3D3.glb").exists())
+            self.assertTrue((output_root / "SCENERY" / "SCENERY.3D3.json").exists())
+            self.assertTrue((output_root / "SCENERY" / "SCENERY.3D3.glb").exists())
+            self.assertFalse((output_root / "SCENERY" / "shape_000.glb").exists())
 
-            self.assertTrue((output_root / "nested" / "TACTICS.json").exists())
-            self.assertTrue((output_root / "nested" / "TACTICS.yaml").exists())
+            self.assertTrue((output_root / "nested" / "TACTICS" / "TACTICS.3DT.json").exists())
 
-            self.assertTrue((output_root / "nested" / "LANDS.json").exists())
-            self.assertTrue((output_root / "nested" / "LANDS.yaml").exists())
+            self.assertTrue((output_root / "nested" / "LANDS" / "LANDS.3DG.json").exists())
 
-            self.assertTrue((output_root / "WORLD.json").exists())
-            self.assertTrue((output_root / "WORLD.yaml").exists())
+            self.assertTrue((output_root / "WORLD" / "WORLD.WLD.json").exists())
 
 
 if __name__ == "__main__":

--- a/tools/f15assets/tests/test_validation_image.py
+++ b/tools/f15assets/tests/test_validation_image.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from f15assets.validation_image import (
+    _read_indexed_png_pixels_and_palette,
+    validate_pic_png_replacement,
+    validate_png_replacement_loadability,
+)
+
+
+class ImageValidationTest(unittest.TestCase):
+    def test_truncated_pixels_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "picture.png"
+            Image.new("RGB", (16, 16), "red").save(path)
+            self.assertEqual(validate_png_replacement_loadability(path), [])
+            data = path.read_bytes()
+            path.write_bytes(data[:data.index(b"IDAT") + 6])
+            self.assertTrue(validate_png_replacement_loadability(path))
+
+    def test_loadability_does_not_read_original(self):
+        def forbidden_read(path):
+            self.fail("loadability-only must not decode the original file")
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "picture.png"
+            Image.new("RGB", (32, 32), "blue").save(path)
+            self.assertEqual(validate_pic_png_replacement(
+                Path("missing.PIC"), path, forbidden_read, loadability_only=True), [])
+
+    def test_indexed_pixel_and_palette_comparison_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "picture.png"
+            image = Image.new("P", (2, 1))
+            palette = [0, 0, 0, 255, 0, 0] + [0] * 762
+            image.putpalette(palette)
+            image.putdata([0, 1])
+            image.save(path)
+            self.assertEqual(_read_indexed_png_pixels_and_palette(path, 2, 1),
+                             (b"\x00\x01", bytes(palette)))
+            with self.assertRaises(ValueError):
+                _read_indexed_png_pixels_and_palette(path, 1, 1)


### PR DESCRIPTION
## Summary

- converts legacy PIC/SPR, 3D3, 3DT, 3DG, WLD, font, sound, and intro-music assets
- writes editable PNG, per-shape GLB, JSON, BDF, and WAV artifacts
- provides map/model viewers and customization documentation
- keeps validation code outside the game runtime

## Validation

- `PYTHONPATH=tools/f15assets python3 -m unittest discover -s tools/f15assets/tests -p "test_*.py" -v` (23 tests)
- full source-proof validation: 32 PNGs, 7 WAVs, 5 fonts, 21 structured assets, and 1,286 3D shapes

Split from #20.
