### PR TITLE
[review: medium] 10. [custom] Load optional PNG image replacements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ set(F15SE2_SOURCES
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
     ${SRC_DIR}/shared/asset_path.c
+    ${SRC_DIR}/shared/png_asset.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(png_asset_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,21 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(png_asset_behavior_tests LINK_CORE)
+if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(png_asset_full_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(png_asset_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping PNG full validation: set F15SE2_ORIGINAL_ASSETS and "
+        "F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/src/egpic.c
+++ b/src/egpic.c
@@ -1,5 +1,6 @@
 // seg000 optimization disabled (/Od) code
 #include "shared/common.h"
+#include "shared/png_asset.h"
 #include "egcode.h"
 #include "egpic.h"
 #include "egtypes.h"
@@ -11,6 +12,7 @@
 #include <memory.h>
 
 void openBlitClosePic(const char *filename, int page) { /* Original chain: OpenFile + blit/decode + CloseFile. Open, blit PIC to page, then close. */
+    if (loadReplacementPngToPage(filename, page)) return;
     SDL_IOStream *handle = openFileWrapper(filename, 0);
     /* The PIC decoder/blitter consumes the already-open file handle. */
     showPicFile(handle, page);

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/src/shared/filepic.c
+++ b/src/shared/filepic.c
@@ -4,6 +4,7 @@
  */
 
 #include "common.h"
+#include "png_asset.h"
 #include "../log.h"
 #include <SDL3/SDL.h>
 
@@ -29,6 +30,7 @@ void closeFileWrapper(SDL_IOStream *handle) /* Original: CloseFile(fh). */
 void openShowPic(const char *filename, int page) /* Original chain: OpenFile + show/decode + CloseFile. Open, draw PIC to page, then close. */
 {
     SDL_IOStream *fileHandle;
+    if (loadReplacementPngToPage(filename, page)) return;
     fileHandle = openFileWrapper(filename, 0);
     showPicFile(fileHandle, page);
     closeFileWrapper(fileHandle);
@@ -36,6 +38,7 @@ void openShowPic(const char *filename, int page) /* Original chain: OpenFile + s
 
 void loadPic(const char *filename, int segment) { /* Original chain: OpenFile + DecodePic(InSeg, OutSeg) + CloseFile. Load PIC into segment. */
     SDL_IOStream *handle;
+    if (loadReplacementPngToSprite(filename, segment)) return;
     handle = openFileWrapper(filename, 0);
     decodePic(handle, segment);
     closeFileWrapper(handle);

--- a/src/shared/png_asset.c
+++ b/src/shared/png_asset.c
@@ -26,21 +26,6 @@ static bool replacementName(const char *legacyFilename, std::string *name) {
     return true;
 }
 
-static uint8 rgb8ToDac6(uint8 value) {
-    return (uint8)(((unsigned int)value * 63U + 127U) / 255U);
-}
-
-static void installEmbeddedPalette(SDL_Palette *palette) {
-    uint8 dac[256 * 3] = {};
-    const int count = palette->ncolors < 256 ? palette->ncolors : 256;
-    for (int i = 0; i < count; ++i) {
-        dac[i * 3] = rgb8ToDac6(palette->colors[i].r);
-        dac[i * 3 + 1] = rgb8ToDac6(palette->colors[i].g);
-        dac[i * 3 + 2] = rgb8ToDac6(palette->colors[i].b);
-    }
-    gfx_setDacRange(0, (uint16)count, dac);
-}
-
 static bool copyScaledIndices(SDL_Surface *source, SDL_Surface *destination) {
     if (source->w <= 0 || source->h <= 0
         || destination->w <= 0 || destination->h <= 0
@@ -157,7 +142,11 @@ int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
             return 0;
         }
         loaded = copyScaledIndices(source, destination);
-        if (loaded) installEmbeddedPalette(palette);
+        /*
+         * PIC/SPR data contains palette indices only. The original callers
+         * select the active DAC separately, so the PNG's embedded palette is
+         * editor metadata and must not recolor the running game.
+         */
     } else {
         /* The legacy page remains indexed. Quantize true-color replacements
          * against its current DAC palette; a future native-color renderer can

--- a/src/shared/png_asset.c
+++ b/src/shared/png_asset.c
@@ -17,6 +17,7 @@
 
 namespace fs = std::filesystem;
 
+/* Derive the canonical PNG replacement name from a legacy image filename. */
 static bool replacementName(const char *legacyFilename, std::string *name) {
     if (!legacyFilename || !legacyFilename[0]) return false;
     fs::path path{legacyFilename};
@@ -26,6 +27,7 @@ static bool replacementName(const char *legacyFilename, std::string *name) {
     return true;
 }
 
+/* Scale indexed replacement pixels into legacy logical dimensions without changing indices. */
 static bool copyScaledIndices(SDL_Surface *source, SDL_Surface *destination) {
     if (source->w <= 0 || source->h <= 0
         || destination->w <= 0 || destination->h <= 0
@@ -58,6 +60,7 @@ static bool copyScaledIndices(SDL_Surface *source, SDL_Surface *destination) {
     return true;
 }
 
+/* Map an RGB replacement color to the nearest entry in the active game palette. */
 static uint8 nearestPaletteIndex(const SDL_Palette *palette, uint8 r, uint8 g, uint8 b) {
     int bestIndex = 0;
     unsigned int bestDistance = ~0U;
@@ -75,6 +78,7 @@ static uint8 nearestPaletteIndex(const SDL_Palette *palette, uint8 r, uint8 g, u
     return (uint8)bestIndex;
 }
 
+/* Scale truecolor replacement pixels and quantize them into the active game palette. */
 static bool copyScaledTruecolor(SDL_Surface *source, SDL_Surface *destination) {
     SDL_Palette *palette = gfx_getPalette();
     SDL_Surface *rgba = SDL_ConvertSurface(source, SDL_PIXELFORMAT_RGBA32);
@@ -116,6 +120,7 @@ static bool copyScaledTruecolor(SDL_Surface *source, SDL_Surface *destination) {
     return true;
 }
 
+/* Load a PNG replacement, preserving indexed pixels when possible and scaling to logical dimensions. */
 int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
     std::string relativeName;
     char replacementPath[1024];
@@ -164,16 +169,19 @@ int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
     return loaded;
 }
 
+/* Load a replacement PNG directly into a legacy full-page image buffer. */
 int loadReplacementPngToPage(const char *legacyFilename, int page) {
     (void)page; /* The port uses one page backbuffer. */
     return loadReplacementPng(legacyFilename, gfx_getCurPageSurface());
 }
 
+/* Load a replacement PNG into a sprite buffer while preserving the sprite header contract. */
 int loadReplacementPngToSprite(const char *legacyFilename, int segment) {
     SDL_Surface *destination = gfx_getSpriteSurface(segment);
     return destination ? loadReplacementPng(legacyFilename, destination) : 0;
 }
 
+/* Load and scale a replacement for the split-field high-resolution title image. */
 int loadReplacementPngToHiResTitle(const char *legacyFilename) {
     const int loaded = loadReplacementPng(legacyFilename, gfx_getHiResSurface());
     if (loaded) gfx_presentHiRes();

--- a/src/shared/png_asset.c
+++ b/src/shared/png_asset.c
@@ -122,8 +122,8 @@ static bool copyScaledTruecolor(SDL_Surface *source, SDL_Surface *destination) {
 
 /* Load a PNG replacement, preserving indexed pixels when possible and scaling to logical dimensions. */
 int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
-    std::string relativeName;
-    char replacementPath[1024];
+    std::string relativeName{};
+    char replacementPath[1024]{};
     if (!destination || !replacementName(legacyFilename, &relativeName)
         || !findAssetReplacement(relativeName.c_str(), replacementPath,
                                  sizeof(replacementPath))) {
@@ -138,7 +138,7 @@ int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
     }
 
     SDL_Palette *palette = SDL_GetSurfacePalette(source);
-    int loaded;
+    int loaded{};
     if (source->format == SDL_PIXELFORMAT_INDEX8) {
         if (!palette || palette->ncolors <= 0) {
             LogWarn(("asset replacement: indexed PNG %s has no embedded palette; "

--- a/src/shared/png_asset.c
+++ b/src/shared/png_asset.c
@@ -1,0 +1,192 @@
+/*
+ * png_asset.c - Decode self-contained PNGs into legacy 8-bit surfaces.
+ */
+
+#include "png_asset.h"
+
+#include "asset_path.h"
+#include "../gfx.h"
+#include "../gfx_impl.h"
+#include "../log.h"
+#include "../inttype.h"
+
+#include <SDL3/SDL.h>
+
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool replacementName(const char *legacyFilename, std::string *name) {
+    if (!legacyFilename || !legacyFilename[0]) return false;
+    fs::path path{legacyFilename};
+    if (path.is_absolute()) return false;
+    path.replace_extension(".png");
+    *name = path.generic_string();
+    return true;
+}
+
+static uint8 rgb8ToDac6(uint8 value) {
+    return (uint8)(((unsigned int)value * 63U + 127U) / 255U);
+}
+
+static void installEmbeddedPalette(SDL_Palette *palette) {
+    uint8 dac[256 * 3] = {};
+    const int count = palette->ncolors < 256 ? palette->ncolors : 256;
+    for (int i = 0; i < count; ++i) {
+        dac[i * 3] = rgb8ToDac6(palette->colors[i].r);
+        dac[i * 3 + 1] = rgb8ToDac6(palette->colors[i].g);
+        dac[i * 3 + 2] = rgb8ToDac6(palette->colors[i].b);
+    }
+    gfx_setDacRange(0, (uint16)count, dac);
+}
+
+static bool copyScaledIndices(SDL_Surface *source, SDL_Surface *destination) {
+    if (source->w <= 0 || source->h <= 0
+        || destination->w <= 0 || destination->h <= 0
+        || destination->format != SDL_PIXELFORMAT_INDEX8) {
+        return false;
+    }
+
+    const bool lockSource = SDL_MUSTLOCK(source);
+    const bool lockDestination = SDL_MUSTLOCK(destination);
+    if (lockSource && !SDL_LockSurface(source)) return false;
+    if (lockDestination && !SDL_LockSurface(destination)) {
+        if (lockSource) SDL_UnlockSurface(source);
+        return false;
+    }
+
+    for (int y = 0; y < destination->h; ++y) {
+        const int sourceY = (int)(((int64)y * source->h) / destination->h);
+        const uint8 *sourceRow =
+            (const uint8 *)source->pixels + (size_t)sourceY * source->pitch;
+        uint8 *destinationRow =
+            (uint8 *)destination->pixels + (size_t)y * destination->pitch;
+        for (int x = 0; x < destination->w; ++x) {
+            const int sourceX = (int)(((int64)x * source->w) / destination->w);
+            destinationRow[x] = sourceRow[sourceX];
+        }
+    }
+
+    if (lockDestination) SDL_UnlockSurface(destination);
+    if (lockSource) SDL_UnlockSurface(source);
+    return true;
+}
+
+static uint8 nearestPaletteIndex(const SDL_Palette *palette, uint8 r, uint8 g, uint8 b) {
+    int bestIndex = 0;
+    unsigned int bestDistance = ~0U;
+    for (int i = 0; i < palette->ncolors && i < 256; ++i) {
+        const int dr = (int)r - palette->colors[i].r;
+        const int dg = (int)g - palette->colors[i].g;
+        const int db = (int)b - palette->colors[i].b;
+        const unsigned int distance = (unsigned int)(dr * dr + dg * dg + db * db);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestIndex = i;
+            if (!distance) break;
+        }
+    }
+    return (uint8)bestIndex;
+}
+
+static bool copyScaledTruecolor(SDL_Surface *source, SDL_Surface *destination) {
+    SDL_Palette *palette = gfx_getPalette();
+    SDL_Surface *rgba = SDL_ConvertSurface(source, SDL_PIXELFORMAT_RGBA32);
+    if (destination->format != SDL_PIXELFORMAT_INDEX8
+        || !palette || palette->ncolors <= 0 || !rgba) {
+        if (rgba) SDL_DestroySurface(rgba);
+        return false;
+    }
+
+    const bool lockSource = SDL_MUSTLOCK(rgba);
+    const bool lockDestination = SDL_MUSTLOCK(destination);
+    if (lockSource && !SDL_LockSurface(rgba)) {
+        SDL_DestroySurface(rgba);
+        return false;
+    }
+    if (lockDestination && !SDL_LockSurface(destination)) {
+        if (lockSource) SDL_UnlockSurface(rgba);
+        SDL_DestroySurface(rgba);
+        return false;
+    }
+
+    for (int y = 0; y < destination->h; ++y) {
+        const int sourceY = (int)(((int64)y * rgba->h) / destination->h);
+        const uint8 *sourceRow =
+            (const uint8 *)rgba->pixels + (size_t)sourceY * rgba->pitch;
+        uint8 *destinationRow =
+            (uint8 *)destination->pixels + (size_t)y * destination->pitch;
+        for (int x = 0; x < destination->w; ++x) {
+            const int sourceX = (int)(((int64)x * rgba->w) / destination->w);
+            const uint8 *pixel = sourceRow + sourceX * 4;
+            destinationRow[x] =
+                nearestPaletteIndex(palette, pixel[0], pixel[1], pixel[2]);
+        }
+    }
+
+    if (lockDestination) SDL_UnlockSurface(destination);
+    if (lockSource) SDL_UnlockSurface(rgba);
+    SDL_DestroySurface(rgba);
+    return true;
+}
+
+int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
+    std::string relativeName;
+    char replacementPath[1024];
+    if (!destination || !replacementName(legacyFilename, &relativeName)
+        || !findAssetReplacement(relativeName.c_str(), replacementPath,
+                                 sizeof(replacementPath))) {
+        return 0;
+    }
+
+    SDL_Surface *source = SDL_LoadPNG(replacementPath);
+    if (!source) {
+        LogWarn(("asset replacement: cannot load %s (%s); using legacy image",
+                 replacementPath, SDL_GetError()));
+        return 0;
+    }
+
+    SDL_Palette *palette = SDL_GetSurfacePalette(source);
+    int loaded;
+    if (source->format == SDL_PIXELFORMAT_INDEX8) {
+        if (!palette || palette->ncolors <= 0) {
+            LogWarn(("asset replacement: indexed PNG %s has no embedded palette; "
+                     "using legacy image", replacementPath));
+            SDL_DestroySurface(source);
+            return 0;
+        }
+        loaded = copyScaledIndices(source, destination);
+        if (loaded) installEmbeddedPalette(palette);
+    } else {
+        /* The legacy page remains indexed. Quantize true-color replacements
+         * against its current DAC palette; a future native-color renderer can
+         * retain the source surface without changing this compatibility path. */
+        loaded = copyScaledTruecolor(source, destination);
+    }
+    if (loaded) {
+        LogInfo(("asset replacement: loaded %s for %s (%dx%d)",
+                 replacementPath, legacyFilename, source->w, source->h));
+    } else {
+        LogWarn(("asset replacement: cannot copy %s into the indexed target; "
+                 "using legacy image", replacementPath));
+    }
+    SDL_DestroySurface(source);
+    return loaded;
+}
+
+int loadReplacementPngToPage(const char *legacyFilename, int page) {
+    (void)page; /* The port uses one page backbuffer. */
+    return loadReplacementPng(legacyFilename, gfx_getCurPageSurface());
+}
+
+int loadReplacementPngToSprite(const char *legacyFilename, int segment) {
+    SDL_Surface *destination = gfx_getSpriteSurface(segment);
+    return destination ? loadReplacementPng(legacyFilename, destination) : 0;
+}
+
+int loadReplacementPngToHiResTitle(const char *legacyFilename) {
+    const int loaded = loadReplacementPng(legacyFilename, gfx_getHiResSurface());
+    if (loaded) gfx_presentHiRes();
+    return loaded;
+}

--- a/src/shared/png_asset.c
+++ b/src/shared/png_asset.c
@@ -17,6 +17,8 @@
 
 namespace fs = std::filesystem;
 
+enum { INDEX8_COLOR_COUNT = 256, RGBA_PIXEL_BYTES = 4 };
+
 /* Derive the canonical PNG replacement name from a legacy image filename. */
 static bool replacementName(const char *legacyFilename, std::string *name) {
     if (!legacyFilename || !legacyFilename[0]) return false;
@@ -64,7 +66,7 @@ static bool copyScaledIndices(SDL_Surface *source, SDL_Surface *destination) {
 static uint8 nearestPaletteIndex(const SDL_Palette *palette, uint8 r, uint8 g, uint8 b) {
     int bestIndex = 0;
     unsigned int bestDistance = ~0U;
-    for (int i = 0; i < palette->ncolors && i < 256; ++i) {
+    for (int i = 0; i < palette->ncolors && i < INDEX8_COLOR_COUNT; ++i) {
         const int dr = (int)r - palette->colors[i].r;
         const int dg = (int)g - palette->colors[i].g;
         const int db = (int)b - palette->colors[i].b;
@@ -108,7 +110,7 @@ static bool copyScaledTruecolor(SDL_Surface *source, SDL_Surface *destination) {
             (uint8 *)destination->pixels + (size_t)y * destination->pitch;
         for (int x = 0; x < destination->w; ++x) {
             const int sourceX = (int)(((int64)x * rgba->w) / destination->w);
-            const uint8 *pixel = sourceRow + sourceX * 4;
+            const uint8 *pixel = sourceRow + sourceX * RGBA_PIXEL_BYTES;
             destinationRow[x] =
                 nearestPaletteIndex(palette, pixel[0], pixel[1], pixel[2]);
         }
@@ -124,9 +126,10 @@ static bool copyScaledTruecolor(SDL_Surface *source, SDL_Surface *destination) {
 int loadReplacementPng(const char *legacyFilename, SDL_Surface *destination) {
     std::string relativeName{};
     char replacementPath[1024]{};
-    if (!destination || !replacementName(legacyFilename, &relativeName)
-        || !findAssetReplacement(relativeName.c_str(), replacementPath,
-                                 sizeof(replacementPath))) {
+    if (!destination || !replacementName(legacyFilename, &relativeName)) return 0;
+    const bool replacementFound = findAssetReplacement(
+        relativeName.c_str(), replacementPath, sizeof(replacementPath));
+    if (!replacementFound) {
         return 0;
     }
 

--- a/src/shared/png_asset.h
+++ b/src/shared/png_asset.h
@@ -1,0 +1,29 @@
+/*
+ * png_asset.h - Optional PNG replacements for legacy PIC/SPR assets.
+ */
+#ifndef PNG_ASSET_H
+#define PNG_ASSET_H
+
+struct SDL_Surface;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Load legacyFilename with a .png extension into an existing indexed surface.
+ * Indexed PNGs preserve their palette; RGB/RGBA PNGs use the active game
+ * palette, matching the legacy renderer's in-memory representation.
+ */
+int loadReplacementPng(const char *legacyFilename, struct SDL_Surface *destination);
+
+/* Hooks used by the existing PIC entry points. */
+int loadReplacementPngToPage(const char *legacyFilename, int page);
+int loadReplacementPngToSprite(const char *legacyFilename, int segment);
+int loadReplacementPngToHiResTitle(const char *legacyFilename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PNG_ASSET_H */

--- a/src/shared/png_asset.h
+++ b/src/shared/png_asset.h
@@ -12,8 +12,9 @@ extern "C" {
 
 /*
  * Load legacyFilename with a .png extension into an existing indexed surface.
- * Indexed PNGs preserve their palette; RGB/RGBA PNGs use the active game
- * palette, matching the legacy renderer's in-memory representation.
+ * Indexed PNGs preserve their index bytes while the caller's active game
+ * palette remains authoritative. RGB/RGBA PNGs are quantized to that palette,
+ * matching the legacy renderer's in-memory representation.
  */
 int loadReplacementPng(const char *legacyFilename, struct SDL_Surface *destination);
 

--- a/src/stmissn.c
+++ b/src/stmissn.c
@@ -2,6 +2,7 @@
 #include "offsets.h"
 #include "comm.h"
 #include "shared/common.h"
+#include "shared/png_asset.h"
 #include "gfx.h"
 #include "slot.h"
 #include "const.h"
@@ -179,6 +180,7 @@ void showPic640(const char *filename) {
     intRegs[0] = MODE_640_350;
     intDispatch(IRQ_VIDEO, intRegs, intRegs);
     gfx_setDac(0);
+    if (loadReplacementPngToHiResTitle(filename)) return;
     fileHandle = openFileWrapper(filename, 0);
     picBlit(fileHandle, 0);
     closeFileWrapper(fileHandle);

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";

--- a/tests/png_asset_behavior_tests.cpp
+++ b/tests/png_asset_behavior_tests.cpp
@@ -1,0 +1,105 @@
+#include "shared/png_asset.h"
+#include "gfx_impl.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-png-asset-tests";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+
+    SDL_Surface *source = SDL_CreateSurface(2, 2, SDL_PIXELFORMAT_INDEX8);
+    SDL_Palette *sourcePalette = SDL_CreatePalette(256);
+    require(source && sourcePalette, "indexed PNG fixture allocation");
+    SDL_Color colors[2] = {
+        {0, 0, 0, 255},
+        {255, 0, 0, 255},
+    };
+    require(SDL_SetPaletteColors(sourcePalette, colors, 0, 2),
+            "indexed PNG fixture palette colors");
+    require(SDL_SetSurfacePalette(source, sourcePalette),
+            "indexed PNG fixture palette attachment");
+    uint8 *pixels = (uint8 *)source->pixels;
+    pixels[0] = 0;
+    pixels[1] = 1;
+    pixels[source->pitch] = 1;
+    pixels[source->pitch + 1] = 0;
+    require(SDL_SavePNG(source, (root / "WALL.PNG").string().c_str()),
+            "indexed PNG fixture save");
+    SDL_DestroySurface(source);
+    SDL_DestroyPalette(sourcePalette);
+
+    setReplacementRoot(root.string());
+    SDL_Surface *destination = SDL_CreateSurface(4, 4, SDL_PIXELFORMAT_INDEX8);
+    require(destination, "indexed destination allocation");
+    require(loadReplacementPng("Wall.Pic", destination),
+            "PIC name resolves to an indexed PNG replacement");
+
+    const uint8 *row0 = (const uint8 *)destination->pixels;
+    const uint8 *row3 = row0 + destination->pitch * 3;
+    require(row0[0] == 0 && row0[3] == 1,
+            "replacement scales the first indexed row");
+    require(row3[0] == 1 && row3[3] == 0,
+            "replacement scales the last indexed row");
+
+    SDL_Palette *activePalette = gfx_getPalette();
+    require(activePalette && activePalette->colors[1].r == 255
+            && activePalette->colors[1].g == 0
+            && activePalette->colors[1].b == 0,
+            "replacement installs the PNG embedded palette");
+
+    SDL_Surface *truecolor = SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_RGBA32);
+    require(truecolor, "true-color PNG fixture allocation");
+    uint8 *truecolorPixel = (uint8 *)truecolor->pixels;
+    truecolorPixel[0] = 255;
+    truecolorPixel[1] = 0;
+    truecolorPixel[2] = 0;
+    truecolorPixel[3] = 255;
+    require(SDL_SavePNG(truecolor, (root / "TRUE.PNG").string().c_str()),
+            "true-color PNG fixture save");
+    SDL_DestroySurface(truecolor);
+    require(loadReplacementPng("True.Pic", destination),
+            "true-color PNG replacement converts to the active game palette");
+    require(((const uint8 *)destination->pixels)[0] == 1,
+            "true-color conversion chooses the nearest palette index");
+
+    SDL_Surface *wrongDestination =
+        SDL_CreateSurface(2, 2, SDL_PIXELFORMAT_RGBA32);
+    require(wrongDestination, "non-indexed destination allocation");
+    require(!loadReplacementPng("True.Pic", wrongDestination),
+            "legacy compatibility path rejects a non-indexed destination");
+    SDL_DestroySurface(wrongDestination);
+
+    require(!loadReplacementPng("Missing.Pic", destination),
+            "missing replacement leaves legacy fallback available");
+
+    SDL_DestroySurface(destination);
+    std::filesystem::remove_all(root);
+    std::cout << "png_asset_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/png_asset_behavior_tests.cpp
+++ b/tests/png_asset_behavior_tests.cpp
@@ -68,10 +68,10 @@ int main() {
             "replacement scales the last indexed row");
 
     SDL_Palette *activePalette = gfx_getPalette();
-    require(activePalette && activePalette->colors[1].r == 255
+    require(activePalette && activePalette->colors[1].r == 0
             && activePalette->colors[1].g == 0
-            && activePalette->colors[1].b == 0,
-            "replacement installs the PNG embedded palette");
+            && activePalette->colors[1].b == 170,
+            "indexed PNG preserves the caller-selected game palette");
 
     SDL_Surface *truecolor = SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_RGBA32);
     require(truecolor, "true-color PNG fixture allocation");
@@ -83,9 +83,22 @@ int main() {
     require(SDL_SavePNG(truecolor, (root / "TRUE.PNG").string().c_str()),
             "true-color PNG fixture save");
     SDL_DestroySurface(truecolor);
+    int expectedRedIndex = 0;
+    unsigned int bestRedDistance = ~0U;
+    for (int i = 0; i < activePalette->ncolors; ++i) {
+        const int dr = 255 - activePalette->colors[i].r;
+        const int dg = activePalette->colors[i].g;
+        const int db = activePalette->colors[i].b;
+        const unsigned int distance =
+            (unsigned int)(dr * dr + dg * dg + db * db);
+        if (distance < bestRedDistance) {
+            bestRedDistance = distance;
+            expectedRedIndex = i;
+        }
+    }
     require(loadReplacementPng("True.Pic", destination),
             "true-color PNG replacement converts to the active game palette");
-    require(((const uint8 *)destination->pixels)[0] == 1,
+    require(((const uint8 *)destination->pixels)[0] == expectedRedIndex,
             "true-color conversion chooses the nearest palette index");
 
     SDL_Surface *wrongDestination =

--- a/tests/png_asset_full_validation_tests.cpp
+++ b/tests/png_asset_full_validation_tests.cpp
@@ -1,0 +1,201 @@
+#include "gfx.h"
+#include "gfx_impl.h"
+#include "headless.h"
+#include "shared/common.h"
+#include "shared/png_asset.h"
+
+#include <SDL3/SDL.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern bool setGamePath(const char *path);
+extern void decodePic(SDL_IOStream *handle, int segment);
+extern void picBlit(SDL_IOStream *handle, int pageIndex);
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::string upper(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return (char)std::toupper(c); });
+    return value;
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+bool isRuntimeImage(const std::filesystem::path &path) {
+    const std::string extension = upper(path.extension().string());
+    const std::string filename = upper(path.filename().string());
+    /*
+     * These four files belong to DEMO.EXE's VGGA path. Calling the regular
+     * game PIC decoder for them would compare against the wrong old loader.
+     */
+    if (filename == "1.PIC" || filename == "2.PIC" ||
+        filename == "3.PIC" || filename == "4.PIC") {
+        return false;
+    }
+    return extension == ".PIC" || extension == ".SPR";
+}
+
+std::vector<unsigned char> surfacePixels(SDL_Surface *surface) {
+    require(surface != nullptr, "missing indexed destination surface");
+    std::vector<unsigned char> pixels(
+        (size_t)surface->w * (size_t)surface->h);
+    if (SDL_MUSTLOCK(surface)) require(SDL_LockSurface(surface), "surface lock");
+    for (int y = 0; y < surface->h; ++y) {
+        const unsigned char *row =
+            (const unsigned char *)surface->pixels + (size_t)y * surface->pitch;
+        std::memcpy(pixels.data() + (size_t)y * surface->w,
+                    row, (size_t)surface->w);
+    }
+    if (SDL_MUSTLOCK(surface)) SDL_UnlockSurface(surface);
+    return pixels;
+}
+
+std::vector<SDL_Color> paletteColors() {
+    SDL_Palette *palette = gfx_getPalette();
+    require(palette && palette->ncolors > 0, "missing active game palette");
+    return std::vector<SDL_Color>(
+        palette->colors, palette->colors + palette->ncolors);
+}
+
+void restorePalette(const std::vector<SDL_Color> &colors) {
+    SDL_Palette *palette = gfx_getPalette();
+    require(palette && palette->ncolors == (int)colors.size(),
+            "active palette size changed");
+    require(SDL_SetPaletteColors(palette, colors.data(), 0, palette->ncolors),
+            "restore active palette");
+}
+
+bool samePalette(const std::vector<SDL_Color> &left,
+                 const std::vector<SDL_Color> &right) {
+    if (left.size() != right.size()) return false;
+    for (size_t i = 0; i < left.size(); ++i) {
+        if (left[i].r != right[i].r || left[i].g != right[i].g ||
+            left[i].b != right[i].b) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void clearSurface(SDL_Surface *surface) {
+    require(surface != nullptr, "missing surface to clear");
+    if (SDL_MUSTLOCK(surface)) require(SDL_LockSurface(surface), "surface lock");
+    std::memset(surface->pixels, 0, (size_t)surface->pitch * surface->h);
+    if (SDL_MUSTLOCK(surface)) SDL_UnlockSurface(surface);
+}
+
+void compareImage(const std::filesystem::path &originalRoot,
+                  const std::filesystem::path &convertedRoot,
+                  const std::filesystem::path &assetPath) {
+    const std::string logicalName =
+        std::filesystem::relative(assetPath, originalRoot).generic_string();
+    const bool sprite = upper(assetPath.extension().string()) == ".SPR";
+    const bool title640 = upper(assetPath.filename().string()) == "TITLE640.PIC";
+    SDL_Surface *surface;
+    int spriteHandle = 0;
+
+    if (title640) {
+        surface = gfx_getHiResSurface();
+    } else if (sprite) {
+        spriteHandle = gfx_allocSpriteBuf();
+        require(spriteHandle != 0,
+                "could not allocate sprite buffer for " + logicalName);
+        surface = gfx_getSpriteSurface(spriteHandle);
+    } else {
+        surface = gfx_getCurPageSurface();
+    }
+
+    const std::vector<SDL_Color> initialPalette = paletteColors();
+    clearSurface(surface);
+    setReplacementRoot(nullptr);
+    SDL_IOStream *legacy = openFile(logicalName.c_str(), 0);
+    require(legacy != nullptr, "cannot open legacy image " + logicalName);
+    if (title640) picBlit(legacy, 0);
+    else if (sprite) decodePic(legacy, spriteHandle);
+    else showPicFile(legacy, 0);
+    fileClose(legacy);
+    const std::vector<unsigned char> legacyPixels = surfacePixels(surface);
+    const std::vector<SDL_Color> legacyPalette = paletteColors();
+
+    restorePalette(initialPalette);
+    clearSurface(surface);
+    setReplacementRoot(&convertedRoot);
+    int loaded;
+    if (title640) {
+        loaded = loadReplacementPngToHiResTitle(logicalName.c_str());
+    } else if (sprite) {
+        loaded = loadReplacementPngToSprite(logicalName.c_str(), spriteHandle);
+    } else {
+        loaded = loadReplacementPngToPage(logicalName.c_str(), 0);
+    }
+    setReplacementRoot(nullptr);
+    require(loaded != 0, "missing PNG replacement for " + logicalName);
+
+    require(surfacePixels(surface) == legacyPixels,
+            "runtime pixel mismatch for " + logicalName);
+    require(samePalette(paletteColors(), legacyPalette),
+            "runtime palette mismatch for " + logicalName);
+
+    restorePalette(initialPalette);
+    if (spriteHandle) gfx_freeSpriteBuf(spriteHandle);
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    require(std::filesystem::is_directory(originalRoot),
+            "F15SE2_ORIGINAL_ASSETS must name an original asset directory");
+    require(std::filesystem::is_directory(convertedRoot),
+            "F15SE2_CONVERTED_ASSETS must name a converted asset directory");
+
+    test_headless_init();
+    gfx_videoInit();
+    require(setGamePath(originalRoot.string().c_str()), "setGamePath failed");
+
+    int compared = 0;
+    for (const auto &entry :
+         std::filesystem::recursive_directory_iterator(originalRoot)) {
+        if (!entry.is_regular_file() || !isRuntimeImage(entry.path())) continue;
+        compareImage(originalRoot, convertedRoot, entry.path());
+        ++compared;
+    }
+
+    setReplacementRoot(nullptr);
+    gfx_videoShutdown();
+    require(compared > 0, "no runtime PIC/SPR assets were compared");
+    std::cout << "png_asset_full_validation_tests compared "
+              << compared << " runtime images\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- loads PNG replacements for legacy PIC/SPR entry points
- scales higher-resolution images into the original logical surface dimensions
- preserves indexed pixels while keeping the caller-selected game DAC authoritative
- quantizes true-color PNGs to the active game palette

## Dependencies

- #29
- companion converter: #28

## Validation

- all runtime PIC/SPR pixels and palettes compared through the real legacy and replacement loaders
- full branch suite passed

Split from #20.
