### PR TITLE
[review: medium] 11. [custom] Load optional WAV sound cue replacements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(EGAME_SOURCES
 
     # audio: ported ASOUND AdLib driver on SDL3
     ${SRC_DIR}/asound/asound_model.c
+    ${SRC_DIR}/asound/asound_replacements.c
     ${SRC_DIR}/asound/asopl.c
     ${SRC_DIR}/asound/asound_sdl.c
 )
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(asound_replacements_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,21 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(asound_replacements_behavior_tests LINK_CORE)
+if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(asound_cue_full_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(asound_cue_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping sound full validation: set F15SE2_ORIGINAL_ASSETS and "
+        "F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -114,7 +114,7 @@ int asound_load_replacement_cues(void) {
         slot.sample_count = 0;
         slot.sample_rate = 0;
 
-        char path[1024];
+        char path[1024]{};
         if (!findAssetReplacement(slot.filename, path, sizeof(path))) continue;
 
         size_t wav_size = 0;

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -1,0 +1,155 @@
+/*
+ * asound_replacements.c - Load individual unsigned 8-bit mono PCM cue WAVs.
+ */
+
+#include "asound_replacements.h"
+
+#include "../shared/asset_path.h"
+#include "../log.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdint.h>
+#include <string.h>
+
+typedef struct CueSlot {
+    AsoundU16 start;
+    AsoundU16 end_inclusive;
+    const char *filename;
+    AsoundU8 *samples;
+    int sample_count;
+    int sample_rate;
+} CueSlot;
+
+static CueSlot g_cues[] = {
+    {0x0000u, 0x31f3u, "sounds/voice_cue_000_sample0.wav", NULL, 0, 0},
+    {0x31f4u, 0x4796u, "sounds/voice_cue_001_sample4.wav", NULL, 0, 0},
+    {0x4797u, 0x5c92u, "sounds/voice_cue_002_sample2_variant0.wav", NULL, 0, 0},
+    {0x5c93u, 0x6a1au, "sounds/voice_cue_003_sample2_variant1.wav", NULL, 0, 0},
+    {0x6a1bu, 0x7d9du, "sounds/voice_cue_004_sample2_variant2.wav", NULL, 0, 0},
+};
+
+static uint16_t read16le(const AsoundU8 *data) {
+    return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
+}
+
+static uint32_t read32le(const AsoundU8 *data) {
+    return (uint32_t)data[0] | ((uint32_t)data[1] << 8)
+        | ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
+}
+
+static AsoundU8 *readFile(const char *path, size_t *size) {
+    SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
+    if (size) *size = 0;
+    if (!stream) return NULL;
+
+    const Sint64 length = SDL_GetIOSize(stream);
+    if (length <= 0 || (uint64_t)length > SIZE_MAX) {
+        SDL_CloseIO(stream);
+        return NULL;
+    }
+    AsoundU8 *data = (AsoundU8 *)SDL_malloc((size_t)length);
+    const size_t read = data ? SDL_ReadIO(stream, data, (size_t)length) : 0;
+    SDL_CloseIO(stream);
+    if (read != (size_t)length) {
+        SDL_free(data);
+        return NULL;
+    }
+    if (size) *size = read;
+    return data;
+}
+
+static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
+                             AsoundU8 **samples, int *sample_rate) {
+    bool format_valid = false;
+    uint32_t rate = 0;
+    if (samples) *samples = NULL;
+    if (sample_rate) *sample_rate = 0;
+    if (!wav || wav_size < 12 || memcmp(wav, "RIFF", 4)
+        || memcmp(wav + 8, "WAVE", 4)) {
+        return 0;
+    }
+
+    for (size_t offset = 12; offset + 8 <= wav_size;) {
+        const AsoundU8 *chunk = wav + offset;
+        const uint32_t chunk_size = read32le(chunk + 4);
+        const size_t data_offset = offset + 8;
+        if (chunk_size > wav_size - data_offset) return 0;
+
+        if (!memcmp(chunk, "fmt ", 4) && chunk_size >= 16) {
+            const uint16_t format = read16le(wav + data_offset);
+            const uint16_t channels = read16le(wav + data_offset + 2);
+            rate = read32le(wav + data_offset + 4);
+            const uint16_t bits = read16le(wav + data_offset + 14);
+            format_valid = format == 1 && channels == 1 && bits == 8 && rate > 0;
+        } else if (!memcmp(chunk, "data", 4)) {
+            if (!format_valid || !chunk_size || chunk_size > INT32_MAX) return 0;
+            AsoundU8 *decoded = (AsoundU8 *)SDL_malloc(chunk_size);
+            if (!decoded) return 0;
+            memcpy(decoded, wav + data_offset, chunk_size);
+            if (samples) *samples = decoded;
+            if (sample_rate) *sample_rate = (int)rate;
+            return (int)chunk_size;
+        }
+
+        const size_t padded_size = (size_t)chunk_size + (chunk_size & 1u);
+        if (padded_size > wav_size - data_offset) return 0;
+        offset = data_offset + padded_size;
+    }
+    return 0;
+}
+
+int asound_load_replacement_cues(void) {
+    int loaded = 0;
+    for (CueSlot &slot : g_cues) {
+        SDL_free(slot.samples);
+        slot.samples = NULL;
+        slot.sample_count = 0;
+        slot.sample_rate = 0;
+
+        char path[1024];
+        if (!findAssetReplacement(slot.filename, path, sizeof(path))) continue;
+
+        size_t wav_size = 0;
+        AsoundU8 *wav = readFile(path, &wav_size);
+        if (wav) {
+            slot.sample_count =
+                decodePcm8MonoWav(wav, wav_size, &slot.samples, &slot.sample_rate);
+            SDL_free(wav);
+        }
+        if (!slot.samples || slot.sample_count <= 0) {
+            SDL_free(slot.samples);
+            slot.samples = NULL;
+            slot.sample_count = 0;
+            slot.sample_rate = 0;
+            LogWarn(("asset replacement: invalid PCM8 mono cue WAV %s; "
+                     "using legacy cue", path));
+            continue;
+        }
+        ++loaded;
+        LogInfo(("asset replacement: loaded cue WAV %s (%d samples, %d Hz)",
+                 path, slot.sample_count, slot.sample_rate));
+    }
+    return loaded;
+}
+
+int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
+                                AsoundReplacementCue *cue) {
+    if (cue) {
+        cue->samples = NULL;
+        cue->sample_count = 0;
+        cue->sample_rate = 0;
+    }
+    for (const CueSlot &slot : g_cues) {
+        if (slot.start == start && slot.end_inclusive == end_inclusive
+            && slot.samples && slot.sample_count > 0) {
+            if (cue) {
+                cue->samples = slot.samples;
+                cue->sample_count = slot.sample_count;
+                cue->sample_rate = slot.sample_rate;
+            }
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -153,3 +153,23 @@ int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
     }
     return 0;
 }
+
+int asound_replacement_cue_count(void) {
+    return (int)(sizeof(g_cues) / sizeof(g_cues[0]));
+}
+
+int asound_replacement_cue_at(int index, AsoundU16 *start,
+                              AsoundU16 *end_inclusive,
+                              AsoundReplacementCue *cue) {
+    if (index < 0 || index >= asound_replacement_cue_count()) return 0;
+    CueSlot *slot = &g_cues[index];
+    if (!slot->samples || slot->sample_count <= 0) return 0;
+    if (start) *start = slot->start;
+    if (end_inclusive) *end_inclusive = slot->end_inclusive;
+    if (cue) {
+        cue->samples = slot->samples;
+        cue->sample_count = slot->sample_count;
+        cue->sample_rate = slot->sample_rate;
+    }
+    return 1;
+}

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -9,6 +9,7 @@
 
 #include <SDL3/SDL.h>
 
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -81,7 +82,8 @@ static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
             const uint16_t channels = read16le(wav + data_offset + 2);
             rate = read32le(wav + data_offset + 4);
             const uint16_t bits = read16le(wav + data_offset + 14);
-            format_valid = format == 1 && channels == 1 && bits == 8 && rate > 0;
+            format_valid = format == 1 && channels == 1 && bits == 8
+                && rate > 0 && rate <= INT_MAX;
         } else if (!memcmp(chunk, "data", 4)) {
             if (!format_valid || !chunk_size || chunk_size > INT32_MAX) return 0;
             AsoundU8 *decoded = (AsoundU8 *)SDL_malloc(chunk_size);

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -140,6 +140,17 @@ int asound_load_replacement_cues(void) {
     return loaded;
 }
 
+/* Return one past the highest legacy byte offset covered by a loaded cue. */
+int asound_replacement_logical_span(void) {
+    int logicalSpan = 0;
+    for (const CueSlot &slot : g_cues) {
+        if (!slot.samples || slot.sample_count <= 0) continue;
+        const int slotSpan = (int)slot.end_inclusive + 1;
+        if (slotSpan > logicalSpan) logicalSpan = slotSpan;
+    }
+    return logicalSpan;
+}
+
 /* Return the replacement cue for a legacy sample pointer, or NULL when not overridden. */
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue) {

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -30,15 +30,18 @@ static CueSlot g_cues[] = {
     {0x6a1bu, 0x7d9du, "sounds/voice_cue_004_sample2_variant2.wav", NULL, 0, 0},
 };
 
+/* Read an unsigned 16-bit little-endian value from an unaligned byte buffer. */
 static uint16_t read16le(const AsoundU8 *data) {
     return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
 }
 
+/* Read an unsigned 32-bit little-endian value from an unaligned byte buffer. */
 static uint32_t read32le(const AsoundU8 *data) {
     return (uint32_t)data[0] | ((uint32_t)data[1] << 8)
         | ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
 }
 
+/* Read an entire replacement file into an owned heap buffer. */
 static AsoundU8 *readFile(const char *path, size_t *size) {
     SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
     if (size) *size = 0;
@@ -60,6 +63,7 @@ static AsoundU8 *readFile(const char *path, size_t *size) {
     return data;
 }
 
+/* Decode one unsigned 8-bit mono PCM WAV while rejecting unsupported layouts. */
 static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
                              AsoundU8 **samples, int *sample_rate) {
     bool format_valid = false;
@@ -101,6 +105,7 @@ static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
     return 0;
 }
 
+/* Load independently editable WAV cues and replace only slots that are present. */
 int asound_load_replacement_cues(void) {
     int loaded = 0;
     for (CueSlot &slot : g_cues) {
@@ -135,6 +140,7 @@ int asound_load_replacement_cues(void) {
     return loaded;
 }
 
+/* Return the replacement cue for a legacy sample pointer, or NULL when not overridden. */
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue) {
     if (cue) {
@@ -156,10 +162,12 @@ int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
     return 0;
 }
 
+/* Return the number of currently loaded replacement sound cues. */
 int asound_replacement_cue_count(void) {
     return (int)(sizeof(g_cues) / sizeof(g_cues[0]));
 }
 
+/* Return replacement cue metadata by stable enumeration index. */
 int asound_replacement_cue_at(int index, AsoundU16 *start,
                               AsoundU16 *end_inclusive,
                               AsoundReplacementCue *cue) {

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -13,6 +13,15 @@
 #include <stdint.h>
 #include <string.h>
 
+enum {
+    RIFF_HEADER_BYTES = 12,
+    CHUNK_HEADER_BYTES = 8,
+    PCM_FORMAT_BYTES = 16,
+    WAVE_FORMAT_PCM = 1,
+    MONO_CHANNELS = 1,
+    PCM_SAMPLE_BITS = 8
+};
+
 typedef struct CueSlot {
     AsoundU16 start;
     AsoundU16 end_inclusive;
@@ -67,37 +76,39 @@ static AsoundU8 *readFile(const char *path, size_t *size) {
 static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
                              AsoundU8 **samples, int *sample_rate) {
     bool format_valid = false;
-    uint32_t rate = 0;
+    uint32_t rate_hz = 0;
     if (samples) *samples = NULL;
     if (sample_rate) *sample_rate = 0;
-    if (!wav || wav_size < 12 || memcmp(wav, "RIFF", 4)
-        || memcmp(wav + 8, "WAVE", 4)) {
-        return 0;
-    }
+    if (!wav || wav_size < RIFF_HEADER_BYTES) return 0;
+    const bool is_wave = !memcmp(wav, "RIFF", 4) && !memcmp(wav + 8, "WAVE", 4);
+    if (!is_wave) return 0;
 
-    for (size_t offset = 12; offset + 8 <= wav_size;) {
+    for (size_t offset = RIFF_HEADER_BYTES; offset + CHUNK_HEADER_BYTES <= wav_size;) {
         const AsoundU8 *chunk = wav + offset;
         const uint32_t chunk_size = read32le(chunk + 4);
-        const size_t data_offset = offset + 8;
+        const size_t data_offset = offset + CHUNK_HEADER_BYTES;
         if (chunk_size > wav_size - data_offset) return 0;
 
-        if (!memcmp(chunk, "fmt ", 4) && chunk_size >= 16) {
+        if (!memcmp(chunk, "fmt ", 4) && chunk_size >= PCM_FORMAT_BYTES) {
             const uint16_t format = read16le(wav + data_offset);
             const uint16_t channels = read16le(wav + data_offset + 2);
-            rate = read32le(wav + data_offset + 4);
+            rate_hz = read32le(wav + data_offset + 4);
             const uint16_t bits = read16le(wav + data_offset + 14);
-            format_valid = format == 1 && channels == 1 && bits == 8
-                && rate > 0 && rate <= INT_MAX;
+            const bool supported_layout = format == WAVE_FORMAT_PCM &&
+                channels == MONO_CHANNELS && bits == PCM_SAMPLE_BITS;
+            const bool valid_rate = rate_hz > 0 && rate_hz <= INT_MAX;
+            format_valid = supported_layout && valid_rate;
         } else if (!memcmp(chunk, "data", 4)) {
             if (!format_valid || !chunk_size || chunk_size > INT32_MAX) return 0;
             AsoundU8 *decoded = (AsoundU8 *)SDL_malloc(chunk_size);
             if (!decoded) return 0;
             memcpy(decoded, wav + data_offset, chunk_size);
             if (samples) *samples = decoded;
-            if (sample_rate) *sample_rate = (int)rate;
+            if (sample_rate) *sample_rate = (int)rate_hz;
             return (int)chunk_size;
         }
 
+        /* RIFF aligns chunks to two bytes; padding is not sample data. */
         const size_t padded_size = (size_t)chunk_size + (chunk_size & 1u);
         if (padded_size > wav_size - data_offset) return 0;
         offset = data_offset + padded_size;
@@ -173,7 +184,7 @@ int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
     return 0;
 }
 
-/* Return the number of currently loaded replacement sound cues. */
+/* Return the number of addressable cue slots, including unloaded slots. */
 int asound_replacement_cue_count(void) {
     return (int)(sizeof(g_cues) / sizeof(g_cues[0]));
 }

--- a/src/asound/asound_replacements.h
+++ b/src/asound/asound_replacements.h
@@ -1,0 +1,30 @@
+/*
+ * asound_replacements.h - Optional editable replacements for ASOUND assets.
+ */
+#ifndef ASOUND_REPLACEMENTS_H
+#define ASOUND_REPLACEMENTS_H
+
+#include "asound_model.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct AsoundReplacementCue {
+    const AsoundU8 *samples;
+    int sample_count;
+    int sample_rate;
+} AsoundReplacementCue;
+
+/* Reload all known cue WAVs. Missing or malformed files remain legacy fallbacks. */
+int asound_load_replacement_cues(void);
+
+/* Return a loaded cue matching the original inclusive sample range. */
+int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
+                                AsoundReplacementCue *cue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASOUND_REPLACEMENTS_H */

--- a/src/asound/asound_replacements.h
+++ b/src/asound/asound_replacements.h
@@ -19,6 +19,9 @@ typedef struct AsoundReplacementCue {
 /* Reload all known cue WAVs. Missing or malformed files remain legacy fallbacks. */
 int asound_load_replacement_cues(void);
 
+/* Return one past the highest legacy byte offset covered by a loaded cue. */
+int asound_replacement_logical_span(void);
+
 /* Return a loaded cue matching the original inclusive sample range. */
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue);

--- a/src/asound/asound_replacements.h
+++ b/src/asound/asound_replacements.h
@@ -23,6 +23,12 @@ int asound_load_replacement_cues(void);
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue);
 
+/* Read-only enumeration for diagnostics and asset validation tools. */
+int asound_replacement_cue_count(void);
+int asound_replacement_cue_at(int index, AsoundU16 *start,
+                              AsoundU16 *end_inclusive,
+                              AsoundReplacementCue *cue);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -15,6 +15,7 @@
 #include <SDL3/SDL.h>
 
 #include "asound_model.h"
+#include "asound_replacements.h"
 #include "asopl.h"
 /* opl3.h has no extern "C" guard of its own; this TU compiles as C++ but opl3.c
  * is built as C, so the declarations must use C linkage to match. */
@@ -33,7 +34,7 @@ extern "C" {
 
 #define ASND_OUT_RATE 44100 /* SDL output sample rate (Hz) */
 #define ASND_TICK_HZ 60     /* sequencer tick = game tick rate */
-#define ASND_SAMPLE_HZ 7231 /* F15DGTL.BIN playback rate (PIT ch2 1193182/165) */
+#define ASND_SAMPLE_HZ 7850 /* Recovered F15DGTL.BIN cue playback rate. */
 #define ASND_CHUNK 512      /* max frames generated per inner loop pass */
 
 static AsoplState g_opl; /* OPL register shadow (event -> regs) */
@@ -47,9 +48,10 @@ static bool g_ready;                              /* device opened */
 static AsoundU8 *g_blob;
 static int g_blobSize;
 static bool g_smpActive;
+static const AsoundU8 *g_smpData;
 static double g_smpPos; /* fractional read position (bytes) */
-static int g_smpEnd;
-static const double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
+static int g_smpSize;
+static double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
 
 /* Fractional countdown (in output frames) to the next sequencer tick. */
 static double g_tickAccum;
@@ -74,12 +76,23 @@ static void asnd_syncChip(void) {
 /* ---- sequencer tick (audio thread, under g_lock) -------------------------- */
 
 static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
+    AsoundReplacementCue cue;
+    if (asound_find_replacement_cue(start, end, &cue)) {
+        g_smpData = cue.samples;
+        g_smpSize = cue.sample_count;
+        g_smpPos = 0;
+        g_smpStep = (double)cue.sample_rate / (double)ASND_OUT_RATE;
+        g_smpActive = true;
+        return;
+    }
     if (!g_blob || g_blobSize <= 0) return;
-    int s = start, e = end;
+    int s = start, e = (int)end + 1;
     if (e > g_blobSize) e = g_blobSize;
     if (s < 0 || s >= e) return;
-    g_smpPos = s;
-    g_smpEnd = e;
+    g_smpData = g_blob + s;
+    g_smpSize = e - s;
+    g_smpPos = 0;
+    g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
     g_smpActive = true;
 }
 
@@ -108,12 +121,12 @@ static void asnd_mixSample(Sint16 *buf, int frames) {
     if (!g_smpActive) return;
     for (int i = 0; i < frames; i++) {
         int idx = (int)g_smpPos;
-        if (idx >= g_smpEnd) {
+        if (idx >= g_smpSize) {
             g_smpActive = false;
             break;
         }
         /* 8-bit unsigned -> signed, scaled below full-scale to leave OPL headroom */
-        int s = ((int)g_blob[idx] - 128) * 200;
+        int s = ((int)g_smpData[idx] - 128) * 200;
         int l = buf[2 * i] + s;
         int r = buf[2 * i + 1] + s;
         if (l > 32767)
@@ -339,27 +352,30 @@ int FAR CDECL audio_noiseTick(void) { return 0; }
  * the game stores in f15DgtlResult and passes to audio_setup as the sample-
  * variant selector (and uses to gate voice cues). 0 on failure -> cues disabled. */
 int loadF15DgtlBin(void) {
+    const int replacementCount = asound_load_replacement_cues();
+    const int replacementSpan = replacementCount > 0 ? 0x7d9e : 0;
     SDL_IOStream *io = openFile("F15DGTL.BIN", 0);
     if (!io) {
-        LogError(("asound: cannot open F15DGTL.BIN"));
+        if (replacementSpan) return replacementSpan;
+        LogError(("asound: cannot open F15DGTL.BIN or replacement cue WAVs"));
         return 0;
     }
     Sint64 size = SDL_GetIOSize(io);
     if (size <= 0) {
         SDL_CloseIO(io);
-        return 0;
+        return replacementSpan;
     }
 
     AsoundU8 *data = (AsoundU8 *)SDL_malloc((size_t)size);
     if (!data) {
         SDL_CloseIO(io);
-        return 0;
+        return replacementSpan;
     }
     size_t got = SDL_ReadIO(io, data, (size_t)size);
     SDL_CloseIO(io);
     if (got != (size_t)size) {
         SDL_free(data);
-        return 0;
+        return replacementSpan;
     }
 
     if (g_lock) SDL_LockMutex(g_lock);

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -48,9 +48,9 @@ static bool g_ready;                              /* device opened */
 static AsoundU8 *g_blob;
 static int g_blobSize;
 static bool g_smpActive;
-static const AsoundU8 *g_smpData;
+static const AsoundU8 *g_smpData{};
 static double g_smpPos; /* fractional read position (bytes) */
-static int g_smpSize;
+static int g_smpSize{};
 static double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
 
 /* Fractional countdown (in output frames) to the next sequencer tick. */
@@ -76,14 +76,14 @@ static void asnd_syncChip(void) {
 /* ---- sequencer tick (audio thread, under g_lock) -------------------------- */
 
 static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
-    AsoundReplacementCue cue;
+    AsoundReplacementCue cue{};
     if (asound_find_replacement_cue(start, end, &cue)) {
         g_smpData = cue.samples;
         g_smpSize = cue.sample_count;
         g_smpPos = 0;
         g_smpStep = (double)cue.sample_rate / (double)ASND_OUT_RATE;
         g_smpActive = true;
-        return;
+        return{};
     }
     if (!g_blob || g_blobSize <= 0) return;
     int s = start, e = (int)end + 1;

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -83,7 +83,7 @@ static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
         g_smpPos = 0;
         g_smpStep = (double)cue.sample_rate / (double)ASND_OUT_RATE;
         g_smpActive = true;
-        return{};
+        return;
     }
     if (!g_blob || g_blobSize <= 0) return;
     int s = start, e = (int)end + 1;
@@ -352,8 +352,8 @@ int FAR CDECL audio_noiseTick(void) { return 0; }
  * the game stores in f15DgtlResult and passes to audio_setup as the sample-
  * variant selector (and uses to gate voice cues). 0 on failure -> cues disabled. */
 int loadF15DgtlBin(void) {
-    const int replacementCount = asound_load_replacement_cues();
-    const int replacementSpan = replacementCount > 0 ? 0x7d9e : 0;
+    asound_load_replacement_cues();
+    const int replacementSpan = asound_replacement_logical_span();
     SDL_IOStream *io = openFile("F15DGTL.BIN", 0);
     if (!io) {
         if (replacementSpan) return replacementSpan;

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/tests/asound_cue_full_validation_tests.cpp
+++ b/tests/asound_cue_full_validation_tests.cpp
@@ -1,0 +1,78 @@
+#include "asound/asound_replacements.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+constexpr int kLegacySampleRate = 7850;
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+std::vector<unsigned char> readFile(const std::filesystem::path &path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::vector<unsigned char>(
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const std::vector<unsigned char> blob =
+        readFile(originalRoot / "F15DGTL.BIN");
+    require(!blob.empty(), "cannot read original F15DGTL.BIN");
+
+    setReplacementRoot(&convertedRoot);
+    const int loaded = asound_load_replacement_cues();
+    require(loaded == asound_replacement_cue_count(),
+            "not all replacement cue WAVs loaded");
+    for (int index = 0; index < loaded; ++index) {
+        AsoundU16 start = 0;
+        AsoundU16 end = 0;
+        AsoundReplacementCue cue = {};
+        require(asound_replacement_cue_at(index, &start, &end, &cue),
+                "cannot enumerate loaded replacement cue");
+        const size_t count = (size_t)end - start + 1u;
+        require(cue.sample_rate == kLegacySampleRate,
+                "replacement cue sample rate differs from legacy");
+        require(cue.sample_count == (int)count && end < blob.size(),
+                "replacement cue range or length differs from legacy");
+        require(std::memcmp(cue.samples, blob.data() + start, count) == 0,
+                "replacement cue PCM differs from legacy");
+    }
+
+    setReplacementRoot(nullptr);
+    std::cout << "asound_cue_full_validation_tests compared "
+              << loaded << " cues\n";
+    return 0;
+}

--- a/tests/asound_replacements_behavior_tests.cpp
+++ b/tests/asound_replacements_behavior_tests.cpp
@@ -29,7 +29,7 @@ void append32(std::vector<unsigned char> &out, unsigned int value) {
     append16(out, value >> 16);
 }
 
-void writePcm8MonoWav(const std::filesystem::path &path, int rate,
+void writePcm8MonoWav(const std::filesystem::path &path, unsigned int rate,
                       const std::vector<unsigned char> &samples) {
     std::vector<unsigned char> wav;
     wav.insert(wav.end(), {'R', 'I', 'F', 'F'});
@@ -67,7 +67,8 @@ int main() {
     std::filesystem::create_directories(root / "sounds");
     writePcm8MonoWav(root / "sounds" / "voice_cue_000_sample0.wav",
                      11025, {0, 64, 128, 255});
-    std::ofstream(root / "sounds" / "voice_cue_001_sample4.wav") << "not a WAV";
+    writePcm8MonoWav(root / "sounds" / "voice_cue_001_sample4.wav",
+                     0x80000000u, {128});
 
     setReplacementRoot(root.string());
     require(asound_load_replacement_cues() == 1,
@@ -81,7 +82,7 @@ int main() {
     require(cue.samples[0] == 0 && cue.samples[2] == 128 && cue.samples[3] == 255,
             "cue preserves unsigned PCM bytes");
     require(!asound_find_replacement_cue(0x31f4u, 0x4796u, &cue),
-            "malformed cue remains a legacy fallback");
+            "out-of-range sample rate remains a legacy fallback");
     require(!asound_find_replacement_cue(1, 2, &cue),
             "unknown sample range remains a legacy fallback");
 

--- a/tests/asound_replacements_behavior_tests.cpp
+++ b/tests/asound_replacements_behavior_tests.cpp
@@ -87,7 +87,7 @@ int main() {
             "unknown sample range remains a legacy fallback");
 
     require(setGamePath(root.string().c_str()), "modern-only game path is valid");
-    require(loadF15DgtlBin() == 0x7d9e,
+    require(loadF15DgtlBin() == 0x31f4,
             "replacement cues enable digitized sound without F15DGTL.BIN");
 
     setReplacementRoot("");

--- a/tests/asound_replacements_behavior_tests.cpp
+++ b/tests/asound_replacements_behavior_tests.cpp
@@ -1,0 +1,101 @@
+#include "asound/asound_replacements.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern bool setGamePath(const char *path);
+extern int loadF15DgtlBin(void);
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void append16(std::vector<unsigned char> &out, unsigned int value) {
+    out.push_back((unsigned char)value);
+    out.push_back((unsigned char)(value >> 8));
+}
+
+void append32(std::vector<unsigned char> &out, unsigned int value) {
+    append16(out, value);
+    append16(out, value >> 16);
+}
+
+void writePcm8MonoWav(const std::filesystem::path &path, int rate,
+                      const std::vector<unsigned char> &samples) {
+    std::vector<unsigned char> wav;
+    wav.insert(wav.end(), {'R', 'I', 'F', 'F'});
+    append32(wav, 36u + (unsigned int)samples.size());
+    wav.insert(wav.end(), {'W', 'A', 'V', 'E', 'f', 'm', 't', ' '});
+    append32(wav, 16);
+    append16(wav, 1);
+    append16(wav, 1);
+    append32(wav, (unsigned int)rate);
+    append32(wav, (unsigned int)rate);
+    append16(wav, 1);
+    append16(wav, 8);
+    wav.insert(wav.end(), {'d', 'a', 't', 'a'});
+    append32(wav, (unsigned int)samples.size());
+    wav.insert(wav.end(), samples.begin(), samples.end());
+    std::ofstream(path, std::ios::binary)
+        .write((const char *)wav.data(), (std::streamsize)wav.size());
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asound-replacement-tests";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "sounds");
+    writePcm8MonoWav(root / "sounds" / "voice_cue_000_sample0.wav",
+                     11025, {0, 64, 128, 255});
+    std::ofstream(root / "sounds" / "voice_cue_001_sample4.wav") << "not a WAV";
+
+    setReplacementRoot(root.string());
+    require(asound_load_replacement_cues() == 1,
+            "loader accepts valid cues and ignores malformed optional cues");
+
+    AsoundReplacementCue cue = {};
+    require(asound_find_replacement_cue(0x0000u, 0x31f3u, &cue),
+            "cue lookup uses the original inclusive sample range");
+    require(cue.sample_count == 4 && cue.sample_rate == 11025,
+            "cue preserves editable WAV length and sample rate");
+    require(cue.samples[0] == 0 && cue.samples[2] == 128 && cue.samples[3] == 255,
+            "cue preserves unsigned PCM bytes");
+    require(!asound_find_replacement_cue(0x31f4u, 0x4796u, &cue),
+            "malformed cue remains a legacy fallback");
+    require(!asound_find_replacement_cue(1, 2, &cue),
+            "unknown sample range remains a legacy fallback");
+
+    require(setGamePath(root.string().c_str()), "modern-only game path is valid");
+    require(loadF15DgtlBin() == 0x7d9e,
+            "replacement cues enable digitized sound without F15DGTL.BIN");
+
+    setReplacementRoot("");
+    require(asound_load_replacement_cues() == 0,
+            "reload without a replacement root clears prior cue data");
+    require(!asound_find_replacement_cue(0x0000u, 0x31f3u, &cue),
+            "cleared replacement no longer overrides the legacy cue");
+
+    std::filesystem::remove_all(root);
+    std::cout << "asound_replacements_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";


### PR DESCRIPTION
## Summary

- loads each digitized cue from an individual unsigned 8-bit mono WAV
- preserves editable sample rates, including the original 7850 Hz files
- falls back per cue when a replacement is absent or malformed
- rejects sample rates that overflow the runtime representation

## Dependencies

- #29
- companion converter: #28

## Validation

- every cue compared byte-for-byte with `F15DGTL.BIN`
- malformed and overflowing-rate behavior tests

Split from #20.
