### PR TITLE
[review: high] 12. [custom] Load optional intro music replacements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(EGAME_SOURCES
 
     # audio: ported ASOUND AdLib driver on SDL3
     ${SRC_DIR}/asound/asound_model.c
+    ${SRC_DIR}/asound/asound_music_replacement.c
     ${SRC_DIR}/asound/asound_replacements.c
     ${SRC_DIR}/asound/asopl.c
     ${SRC_DIR}/asound/asound_sdl.c
@@ -480,6 +481,7 @@ else()
         "Skipping sound full validation: set F15SE2_ORIGINAL_ASSETS and "
         "F15SE2_CONVERTED_ASSETS to existing directories")
 endif()
+add_behavior_test(asound_music_replacement_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(EGAME_SOURCES
 
     # audio: ported ASOUND AdLib driver on SDL3
     ${SRC_DIR}/asound/asound_model.c
+    ${SRC_DIR}/asound/asound_replacements.c
     ${SRC_DIR}/asound/asopl.c
     ${SRC_DIR}/asound/asound_sdl.c
 )
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(asound_replacements_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,21 @@ else()
         "F15SE2_CONVERTED_ASSETS to existing directories")
 endif()
 add_behavior_test(asound_music_replacement_behavior_tests LINK_CORE)
+if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(asound_asset_full_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(asound_asset_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping sound full validation: set F15SE2_ORIGINAL_ASSETS and "
+        "F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,21 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(asound_replacements_behavior_tests LINK_CORE)
+if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(asound_cue_full_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(asound_cue_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping sound full validation: set F15SE2_ORIGINAL_ASSETS and "
+        "F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,11 +485,11 @@ add_behavior_test(asound_music_replacement_behavior_tests LINK_CORE)
 if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
    AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
    AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
-    add_behavior_test(asound_asset_full_validation_tests LINK_CORE
+    add_behavior_test(asound_music_full_validation_tests LINK_CORE
         DEFS
             F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
             F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
-    set_tests_properties(asound_asset_full_validation_tests PROPERTIES
+    set_tests_properties(asound_music_full_validation_tests PROPERTIES
         LABELS "assets;integration"
         TIMEOUT 120)
 else()

--- a/src/asound/asound_model.c
+++ b/src/asound/asound_model.c
@@ -1068,6 +1068,30 @@ const AsoundU8 asound_release_voice5[] = {
     0x00u,
 };
 
+size_t asound_intro_voice_length(int voice) {
+    switch (voice) {
+    case 0: return sizeof(asound_intro_voice0);
+    case 1: return sizeof(asound_intro_voice1);
+    case 2: return sizeof(asound_intro_voice2);
+    case 3: return sizeof(asound_intro_voice3);
+    case 4: return sizeof(asound_intro_voice4);
+    case 5: return sizeof(asound_intro_voice5);
+    default: return 0;
+    }
+}
+
+size_t asound_release_voice_length(int voice) {
+    switch (voice) {
+    case 0: return sizeof(asound_release_voice0);
+    case 1: return sizeof(asound_release_voice1);
+    case 2: return sizeof(asound_release_voice2);
+    case 3: return sizeof(asound_release_voice3);
+    case 4: return sizeof(asound_release_voice4);
+    case 5: return sizeof(asound_release_voice5);
+    default: return 0;
+    }
+}
+
 void asound_log_init(AsoundEventLog *log, AsoundEvent *events, size_t capacity) {
     log->events = events;
     log->count = 0;

--- a/src/asound/asound_model.c
+++ b/src/asound/asound_model.c
@@ -1068,6 +1068,7 @@ const AsoundU8 asound_release_voice5[] = {
     0x00u,
 };
 
+/* Return the active intro replacement duration, falling back to the legacy model length. */
 size_t asound_intro_voice_length(int voice) {
     switch (voice) {
     case 0: return sizeof(asound_intro_voice0);
@@ -1080,6 +1081,7 @@ size_t asound_intro_voice_length(int voice) {
     }
 }
 
+/* Return the active release replacement duration, falling back to the legacy model length. */
 size_t asound_release_voice_length(int voice) {
     switch (voice) {
     case 0: return sizeof(asound_release_voice0);

--- a/src/asound/asound_model.h
+++ b/src/asound/asound_model.h
@@ -155,6 +155,8 @@ extern const AsoundU8 asound_release_voice2[];
 extern const AsoundU8 asound_release_voice3[];
 extern const AsoundU8 asound_release_voice4[];
 extern const AsoundU8 asound_release_voice5[];
+size_t asound_intro_voice_length(int voice);
+size_t asound_release_voice_length(int voice);
 
 void asound_log_init(AsoundEventLog *log, AsoundEvent *events, size_t capacity);
 int asound_log_push(AsoundEventLog *log, AsoundEventType type, AsoundU8 voice,

--- a/src/asound/asound_music_replacement.c
+++ b/src/asound/asound_music_replacement.c
@@ -25,6 +25,7 @@ typedef struct ReplacementMusic {
 
 static ReplacementMusic g_music;
 
+/* Release all parsed replacement music streams and reset their descriptors. */
 static void freeStreams(void) {
     for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
         SDL_free(g_music.intro[voice]);
@@ -37,6 +38,7 @@ static void freeStreams(void) {
     g_music.loaded = 0;
 }
 
+/* Read a complete replacement metadata file as a NUL-terminated owned string. */
 static char *readTextFile(const char *path) {
     SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
     if (!stream) return NULL;
@@ -56,6 +58,7 @@ static char *readTextFile(const char *path) {
     return text;
 }
 
+/* Locate a named stream object in the constrained converter-generated JSON document. */
 static const char *findStreamObject(const char *json, const char *symbol,
                                     const char **object_end) {
     const char *key = json;
@@ -112,6 +115,7 @@ static const char *findStreamObject(const char *json, const char *symbol,
     return NULL;
 }
 
+/* Parse one timed AdLib register stream from converter-generated JSON. */
 static AsoundU8 *parseStream(const char *json, const char *symbol,
                              size_t *stream_size) {
     const char *object_end = NULL;
@@ -157,6 +161,7 @@ static AsoundU8 *parseStream(const char *json, const char *symbol,
     return bytes;
 }
 
+/* Reload optional intro and release music streams from the replacement root. */
 int asound_reload_replacement_music(void) {
     char path[1024];
     /*
@@ -200,6 +205,7 @@ int asound_reload_replacement_music(void) {
     return 1;
 }
 
+/* Start a replacement music stream when available and report whether it took ownership. */
 int asound_start_replacement_music(AsoundDriver *driver, int release_phase) {
     if (!driver) return 0;
     if (!g_music.tried) asound_reload_replacement_music();
@@ -212,6 +218,7 @@ int asound_start_replacement_music(AsoundDriver *driver, int release_phase) {
     return 1;
 }
 
+/* Return parsed replacement events for one named music stream. */
 int asound_replacement_music_stream(int release_phase, int voice,
                                     const AsoundU8 **data, size_t *size) {
     if (data) *data = NULL;

--- a/src/asound/asound_music_replacement.c
+++ b/src/asound/asound_music_replacement.c
@@ -17,6 +17,8 @@
 typedef struct ReplacementMusic {
     AsoundU8 *intro[ASOUND_STREAM_COUNT];
     AsoundU8 *release[ASOUND_STREAM_COUNT];
+    size_t intro_size[ASOUND_STREAM_COUNT];
+    size_t release_size[ASOUND_STREAM_COUNT];
     int loaded;
     int tried;
 } ReplacementMusic;
@@ -29,6 +31,8 @@ static void freeStreams(void) {
         SDL_free(g_music.release[voice]);
         g_music.intro[voice] = NULL;
         g_music.release[voice] = NULL;
+        g_music.intro_size[voice] = 0;
+        g_music.release_size[voice] = 0;
     }
     g_music.loaded = 0;
 }
@@ -54,39 +58,62 @@ static char *readTextFile(const char *path) {
 
 static const char *findStreamObject(const char *json, const char *symbol,
                                     const char **object_end) {
-    const char *object = json;
+    const char *key = json;
     const size_t symbol_length = strlen(symbol);
 
     /*
-     * Match source_symbol inside one flat stream object. Keeping the search
-     * within its closing brace prevents malformed JSON from borrowing the
-     * stream_bytes array from the following voice.
+     * Converter output includes nested event objects before source_symbol.
+     * Locate the exact symbol first, then recover its nearest still-open
+     * object and matching close. This keeps stream_bytes bounded to one voice
+     * without assuming that voice objects are flat.
      */
-    while ((object = strchr(object, '{')) != NULL) {
-        const char *end = strchr(object, '}');
-        const char *key = strstr(object, "\"source_symbol\"");
-        if (!end) return NULL;
-        if (key && key < end) {
-            const char *value = strchr(key, ':');
-            if (value && value < end) {
-                do {
-                    ++value;
-                } while (value < end && isspace((unsigned char)*value));
-                if (value < end && *value++ == '"'
-                    && (size_t)(end - value) > symbol_length
-                    && memcmp(value, symbol, symbol_length) == 0
-                    && value[symbol_length] == '"') {
+    while ((key = strstr(key, "\"source_symbol\"")) != NULL) {
+        const char *value = strchr(key, ':');
+        if (!value) return NULL;
+        do {
+            ++value;
+        } while (*value && isspace((unsigned char)*value));
+        if (*value++ == '"' && !memcmp(value, symbol, symbol_length)
+            && value[symbol_length] == '"') {
+            const char *object = key;
+            int reverse_depth = 0;
+            while (object > json) {
+                --object;
+                if (*object == '}') {
+                    ++reverse_depth;
+                } else if (*object == '{') {
+                    if (reverse_depth == 0) break;
+                    --reverse_depth;
+                }
+            }
+            if (*object != '{') return NULL;
+
+            int depth = 0;
+            int quoted = 0;
+            int escaped = 0;
+            for (const char *end = object; *end; ++end) {
+                if (quoted) {
+                    if (escaped) escaped = 0;
+                    else if (*end == '\\') escaped = 1;
+                    else if (*end == '"') quoted = 0;
+                    continue;
+                }
+                if (*end == '"') quoted = 1;
+                else if (*end == '{') ++depth;
+                else if (*end == '}' && --depth == 0) {
                     *object_end = end;
                     return object;
                 }
             }
+            return NULL;
         }
-        object = end + 1;
+        ++key;
     }
     return NULL;
 }
 
-static AsoundU8 *parseStream(const char *json, const char *symbol) {
+static AsoundU8 *parseStream(const char *json, const char *symbol,
+                             size_t *stream_size) {
     const char *object_end = NULL;
     const char *position = findStreamObject(json, symbol, &object_end);
     if (!position) return NULL;
@@ -126,6 +153,7 @@ static AsoundU8 *parseStream(const char *json, const char *symbol) {
         SDL_free(bytes);
         return NULL;
     }
+    if (stream_size) *stream_size = count;
     return bytes;
 }
 
@@ -153,9 +181,11 @@ int asound_reload_replacement_music(void) {
     for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
         char symbol[64];
         snprintf(symbol, sizeof(symbol), "asound_intro_voice%d", voice);
-        g_music.intro[voice] = parseStream(json, symbol);
+        g_music.intro[voice] =
+            parseStream(json, symbol, &g_music.intro_size[voice]);
         snprintf(symbol, sizeof(symbol), "asound_release_voice%d", voice);
-        g_music.release[voice] = parseStream(json, symbol);
+        g_music.release[voice] =
+            parseStream(json, symbol, &g_music.release_size[voice]);
         if (!g_music.intro[voice] || !g_music.release[voice]) {
             SDL_free(json);
             freeStreams();
@@ -178,6 +208,21 @@ int asound_start_replacement_music(AsoundDriver *driver, int release_phase) {
     AsoundU8 **streams = release_phase ? g_music.release : g_music.intro;
     for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
         asound_stream_init(&driver->streams[voice], streams[voice]);
+    }
+    return 1;
+}
+
+int asound_replacement_music_stream(int release_phase, int voice,
+                                    const AsoundU8 **data, size_t *size) {
+    if (data) *data = NULL;
+    if (size) *size = 0;
+    if (!g_music.loaded || voice < 0 || voice >= ASOUND_STREAM_COUNT) return 0;
+    if (data) {
+        *data = release_phase ? g_music.release[voice] : g_music.intro[voice];
+    }
+    if (size) {
+        *size = release_phase
+            ? g_music.release_size[voice] : g_music.intro_size[voice];
     }
     return 1;
 }

--- a/src/asound/asound_music_replacement.c
+++ b/src/asound/asound_music_replacement.c
@@ -23,7 +23,7 @@ typedef struct ReplacementMusic {
     int tried;
 } ReplacementMusic;
 
-static ReplacementMusic g_music;
+static ReplacementMusic g_music{};
 
 /* Release all parsed replacement music streams and reset their descriptors. */
 static void freeStreams(void) {
@@ -163,7 +163,7 @@ static AsoundU8 *parseStream(const char *json, const char *symbol,
 
 /* Reload optional intro and release music streams from the replacement root. */
 int asound_reload_replacement_music(void) {
-    char path[1024];
+    char path[1024]{};
     /*
      * Playback stream pointers refer directly to these allocations. Runtime
      * code loads once before playback; explicit reload exists for tests and
@@ -184,7 +184,7 @@ int asound_reload_replacement_music(void) {
     }
 
     for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
-        char symbol[64];
+        char symbol[64]{};
         snprintf(symbol, sizeof(symbol), "asound_intro_voice%d", voice);
         g_music.intro[voice] =
             parseStream(json, symbol, &g_music.intro_size[voice]);

--- a/src/asound/asound_music_replacement.c
+++ b/src/asound/asound_music_replacement.c
@@ -1,0 +1,183 @@
+/*
+ * asound_music_replacement.c - Load ASOUND byte streams from converter JSON.
+ */
+
+#include "asound_music_replacement.h"
+
+#include "../shared/asset_path.h"
+#include "../log.h"
+
+#include <SDL3/SDL.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct ReplacementMusic {
+    AsoundU8 *intro[ASOUND_STREAM_COUNT];
+    AsoundU8 *release[ASOUND_STREAM_COUNT];
+    int loaded;
+    int tried;
+} ReplacementMusic;
+
+static ReplacementMusic g_music;
+
+static void freeStreams(void) {
+    for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+        SDL_free(g_music.intro[voice]);
+        SDL_free(g_music.release[voice]);
+        g_music.intro[voice] = NULL;
+        g_music.release[voice] = NULL;
+    }
+    g_music.loaded = 0;
+}
+
+static char *readTextFile(const char *path) {
+    SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
+    if (!stream) return NULL;
+    const Sint64 length = SDL_GetIOSize(stream);
+    if (length <= 0 || (uint64_t)length >= SIZE_MAX) {
+        SDL_CloseIO(stream);
+        return NULL;
+    }
+    char *text = (char *)SDL_malloc((size_t)length + 1);
+    const size_t read = text ? SDL_ReadIO(stream, text, (size_t)length) : 0;
+    SDL_CloseIO(stream);
+    if (read != (size_t)length) {
+        SDL_free(text);
+        return NULL;
+    }
+    text[length] = '\0';
+    return text;
+}
+
+static const char *findStreamObject(const char *json, const char *symbol,
+                                    const char **object_end) {
+    const char *object = json;
+    const size_t symbol_length = strlen(symbol);
+
+    /*
+     * Match source_symbol inside one flat stream object. Keeping the search
+     * within its closing brace prevents malformed JSON from borrowing the
+     * stream_bytes array from the following voice.
+     */
+    while ((object = strchr(object, '{')) != NULL) {
+        const char *end = strchr(object, '}');
+        const char *key = strstr(object, "\"source_symbol\"");
+        if (!end) return NULL;
+        if (key && key < end) {
+            const char *value = strchr(key, ':');
+            if (value && value < end) {
+                do {
+                    ++value;
+                } while (value < end && isspace((unsigned char)*value));
+                if (value < end && *value++ == '"'
+                    && (size_t)(end - value) > symbol_length
+                    && memcmp(value, symbol, symbol_length) == 0
+                    && value[symbol_length] == '"') {
+                    *object_end = end;
+                    return object;
+                }
+            }
+        }
+        object = end + 1;
+    }
+    return NULL;
+}
+
+static AsoundU8 *parseStream(const char *json, const char *symbol) {
+    const char *object_end = NULL;
+    const char *position = findStreamObject(json, symbol, &object_end);
+    if (!position) return NULL;
+    position = strstr(position, "\"stream_bytes\"");
+    if (!position || position >= object_end) return NULL;
+    position = strchr(position, '[');
+    if (!position || position >= object_end) return NULL;
+    ++position;
+
+    AsoundU8 *bytes = NULL;
+    size_t count = 0;
+    size_t capacity = 0;
+    while (position < object_end && *position != ']') {
+        while (isspace((unsigned char)*position) || *position == ',') ++position;
+        if (position >= object_end || *position == ']') break;
+
+        char *end = NULL;
+        const long value = strtol(position, &end, 10);
+        if (end == position || value < 0 || value > 255) {
+            SDL_free(bytes);
+            return NULL;
+        }
+        if (count == capacity) {
+            const size_t next = capacity ? capacity * 2 : 32;
+            AsoundU8 *grown = (AsoundU8 *)SDL_realloc(bytes, next);
+            if (!grown) {
+                SDL_free(bytes);
+                return NULL;
+            }
+            bytes = grown;
+            capacity = next;
+        }
+        bytes[count++] = (AsoundU8)value;
+        position = end;
+    }
+    if (position >= object_end || *position != ']' || !count) {
+        SDL_free(bytes);
+        return NULL;
+    }
+    return bytes;
+}
+
+int asound_reload_replacement_music(void) {
+    char path[1024];
+    /*
+     * Playback stream pointers refer directly to these allocations. Runtime
+     * code loads once before playback; explicit reload exists for tests and
+     * must only be called while no replacement music is active.
+     */
+    freeStreams();
+    g_music.tried = 1;
+    if (!findAssetReplacement("sounds/intro_music.asound.json",
+                              path, sizeof(path))) {
+        return 0;
+    }
+
+    char *json = readTextFile(path);
+    if (!json) {
+        LogWarn(("asset replacement: cannot read intro music %s; "
+                 "using compiled streams", path));
+        return 0;
+    }
+
+    for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+        char symbol[64];
+        snprintf(symbol, sizeof(symbol), "asound_intro_voice%d", voice);
+        g_music.intro[voice] = parseStream(json, symbol);
+        snprintf(symbol, sizeof(symbol), "asound_release_voice%d", voice);
+        g_music.release[voice] = parseStream(json, symbol);
+        if (!g_music.intro[voice] || !g_music.release[voice]) {
+            SDL_free(json);
+            freeStreams();
+            LogWarn(("asset replacement: incomplete intro music %s; "
+                     "using compiled streams", path));
+            return 0;
+        }
+    }
+    SDL_free(json);
+    g_music.loaded = 1;
+    LogInfo(("asset replacement: loaded intro music %s", path));
+    return 1;
+}
+
+int asound_start_replacement_music(AsoundDriver *driver, int release_phase) {
+    if (!driver) return 0;
+    if (!g_music.tried) asound_reload_replacement_music();
+    if (!g_music.loaded) return 0;
+
+    AsoundU8 **streams = release_phase ? g_music.release : g_music.intro;
+    for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+        asound_stream_init(&driver->streams[voice], streams[voice]);
+    }
+    return 1;
+}

--- a/src/asound/asound_music_replacement.c
+++ b/src/asound/asound_music_replacement.c
@@ -10,6 +10,7 @@
 #include <SDL3/SDL.h>
 
 #include <ctype.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -76,7 +77,7 @@ static const char *findStreamObject(const char *json, const char *symbol,
         do {
             ++value;
         } while (*value && isspace((unsigned char)*value));
-        if (*value++ == '"' && !memcmp(value, symbol, symbol_length)
+        if (*value++ == '"' && !strncmp(value, symbol, symbol_length)
             && value[symbol_length] == '"') {
             const char *object = key;
             int reverse_depth = 0;
@@ -113,6 +114,23 @@ static const char *findStreamObject(const char *json, const char *symbol,
         ++key;
     }
     return NULL;
+}
+
+/* The legacy sequencer has a 16-bit cursor and no buffer length. Validate
+ * instruction boundaries and termination before giving it editable bytes.
+ * Loop targets are either zero or the boundary following a 0xfe opcode. */
+static int validStream(const AsoundU8 *bytes, size_t size) {
+    if (!size || size > USHRT_MAX) return 0;
+    for (size_t offset = 0; offset < size;) {
+        const AsoundU8 op = bytes[offset++];
+        if (op == 0xfd) return 1;
+        if (op == 0xfe) continue;
+        const size_t operands = op == 0xf8 ? 2 : 1;
+        if (operands > size - offset) return 0;
+        if (op == 0 && bytes[offset] == 0) return 1;
+        offset += operands;
+    }
+    return 0;
 }
 
 /* Parse one timed AdLib register stream from converter-generated JSON. */
@@ -153,7 +171,7 @@ static AsoundU8 *parseStream(const char *json, const char *symbol,
         bytes[count++] = (AsoundU8)value;
         position = end;
     }
-    if (position >= object_end || *position != ']' || !count) {
+    if (position >= object_end || *position != ']' || !validStream(bytes, count)) {
         SDL_free(bytes);
         return NULL;
     }

--- a/src/asound/asound_music_replacement.c
+++ b/src/asound/asound_music_replacement.c
@@ -15,6 +15,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+enum {
+    STREAM_VOLUME_FADE = 0xf8,
+    STREAM_END_OR_RESTART = 0xfd,
+    STREAM_LOOP_START = 0xfe
+};
+
 typedef struct ReplacementMusic {
     AsoundU8 *intro[ASOUND_STREAM_COUNT];
     AsoundU8 *release[ASOUND_STREAM_COUNT];
@@ -123,9 +129,9 @@ static int validStream(const AsoundU8 *bytes, size_t size) {
     if (!size || size > USHRT_MAX) return 0;
     for (size_t offset = 0; offset < size;) {
         const AsoundU8 op = bytes[offset++];
-        if (op == 0xfd) return 1;
-        if (op == 0xfe) continue;
-        const size_t operands = op == 0xf8 ? 2 : 1;
+        if (op == STREAM_END_OR_RESTART) return 1;
+        if (op == STREAM_LOOP_START) continue;
+        const size_t operands = op == STREAM_VOLUME_FADE ? 2 : 1;
         if (operands > size - offset) return 0;
         if (op == 0 && bytes[offset] == 0) return 1;
         offset += operands;

--- a/src/asound/asound_music_replacement.h
+++ b/src/asound/asound_music_replacement.h
@@ -23,6 +23,10 @@ int asound_reload_replacement_music(void);
  */
 int asound_start_replacement_music(AsoundDriver *driver, int release_phase);
 
+/* Return one loaded stream and its exact byte length for diagnostics/tools. */
+int asound_replacement_music_stream(int release_phase, int voice,
+                                    const AsoundU8 **data, size_t *size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/asound/asound_music_replacement.h
+++ b/src/asound/asound_music_replacement.h
@@ -1,0 +1,30 @@
+/*
+ * asound_music_replacement.h - Editable ASOUND intro/release stream override.
+ */
+#ifndef ASOUND_MUSIC_REPLACEMENT_H
+#define ASOUND_MUSIC_REPLACEMENT_H
+
+#include "asound_model.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Reload sounds/intro_music.asound.json; all twelve streams are required.
+ * Call only while no replacement stream is playing.
+ */
+int asound_reload_replacement_music(void);
+
+/*
+ * Initialize all driver voices from replacement streams.
+ * release_phase selects intro (zero) or release (nonzero). Returns zero when
+ * the caller should use the original compiled streams.
+ */
+int asound_start_replacement_music(AsoundDriver *driver, int release_phase);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASOUND_MUSIC_REPLACEMENT_H */

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -114,7 +114,7 @@ int asound_load_replacement_cues(void) {
         slot.sample_count = 0;
         slot.sample_rate = 0;
 
-        char path[1024];
+        char path[1024]{};
         if (!findAssetReplacement(slot.filename, path, sizeof(path))) continue;
 
         size_t wav_size = 0;

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -1,0 +1,155 @@
+/*
+ * asound_replacements.c - Load individual unsigned 8-bit mono PCM cue WAVs.
+ */
+
+#include "asound_replacements.h"
+
+#include "../shared/asset_path.h"
+#include "../log.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdint.h>
+#include <string.h>
+
+typedef struct CueSlot {
+    AsoundU16 start;
+    AsoundU16 end_inclusive;
+    const char *filename;
+    AsoundU8 *samples;
+    int sample_count;
+    int sample_rate;
+} CueSlot;
+
+static CueSlot g_cues[] = {
+    {0x0000u, 0x31f3u, "sounds/voice_cue_000_sample0.wav", NULL, 0, 0},
+    {0x31f4u, 0x4796u, "sounds/voice_cue_001_sample4.wav", NULL, 0, 0},
+    {0x4797u, 0x5c92u, "sounds/voice_cue_002_sample2_variant0.wav", NULL, 0, 0},
+    {0x5c93u, 0x6a1au, "sounds/voice_cue_003_sample2_variant1.wav", NULL, 0, 0},
+    {0x6a1bu, 0x7d9du, "sounds/voice_cue_004_sample2_variant2.wav", NULL, 0, 0},
+};
+
+static uint16_t read16le(const AsoundU8 *data) {
+    return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
+}
+
+static uint32_t read32le(const AsoundU8 *data) {
+    return (uint32_t)data[0] | ((uint32_t)data[1] << 8)
+        | ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
+}
+
+static AsoundU8 *readFile(const char *path, size_t *size) {
+    SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
+    if (size) *size = 0;
+    if (!stream) return NULL;
+
+    const Sint64 length = SDL_GetIOSize(stream);
+    if (length <= 0 || (uint64_t)length > SIZE_MAX) {
+        SDL_CloseIO(stream);
+        return NULL;
+    }
+    AsoundU8 *data = (AsoundU8 *)SDL_malloc((size_t)length);
+    const size_t read = data ? SDL_ReadIO(stream, data, (size_t)length) : 0;
+    SDL_CloseIO(stream);
+    if (read != (size_t)length) {
+        SDL_free(data);
+        return NULL;
+    }
+    if (size) *size = read;
+    return data;
+}
+
+static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
+                             AsoundU8 **samples, int *sample_rate) {
+    bool format_valid = false;
+    uint32_t rate = 0;
+    if (samples) *samples = NULL;
+    if (sample_rate) *sample_rate = 0;
+    if (!wav || wav_size < 12 || memcmp(wav, "RIFF", 4)
+        || memcmp(wav + 8, "WAVE", 4)) {
+        return 0;
+    }
+
+    for (size_t offset = 12; offset + 8 <= wav_size;) {
+        const AsoundU8 *chunk = wav + offset;
+        const uint32_t chunk_size = read32le(chunk + 4);
+        const size_t data_offset = offset + 8;
+        if (chunk_size > wav_size - data_offset) return 0;
+
+        if (!memcmp(chunk, "fmt ", 4) && chunk_size >= 16) {
+            const uint16_t format = read16le(wav + data_offset);
+            const uint16_t channels = read16le(wav + data_offset + 2);
+            rate = read32le(wav + data_offset + 4);
+            const uint16_t bits = read16le(wav + data_offset + 14);
+            format_valid = format == 1 && channels == 1 && bits == 8 && rate > 0;
+        } else if (!memcmp(chunk, "data", 4)) {
+            if (!format_valid || !chunk_size || chunk_size > INT32_MAX) return 0;
+            AsoundU8 *decoded = (AsoundU8 *)SDL_malloc(chunk_size);
+            if (!decoded) return 0;
+            memcpy(decoded, wav + data_offset, chunk_size);
+            if (samples) *samples = decoded;
+            if (sample_rate) *sample_rate = (int)rate;
+            return (int)chunk_size;
+        }
+
+        const size_t padded_size = (size_t)chunk_size + (chunk_size & 1u);
+        if (padded_size > wav_size - data_offset) return 0;
+        offset = data_offset + padded_size;
+    }
+    return 0;
+}
+
+int asound_load_replacement_cues(void) {
+    int loaded = 0;
+    for (CueSlot &slot : g_cues) {
+        SDL_free(slot.samples);
+        slot.samples = NULL;
+        slot.sample_count = 0;
+        slot.sample_rate = 0;
+
+        char path[1024];
+        if (!findAssetReplacement(slot.filename, path, sizeof(path))) continue;
+
+        size_t wav_size = 0;
+        AsoundU8 *wav = readFile(path, &wav_size);
+        if (wav) {
+            slot.sample_count =
+                decodePcm8MonoWav(wav, wav_size, &slot.samples, &slot.sample_rate);
+            SDL_free(wav);
+        }
+        if (!slot.samples || slot.sample_count <= 0) {
+            SDL_free(slot.samples);
+            slot.samples = NULL;
+            slot.sample_count = 0;
+            slot.sample_rate = 0;
+            LogWarn(("asset replacement: invalid PCM8 mono cue WAV %s; "
+                     "using legacy cue", path));
+            continue;
+        }
+        ++loaded;
+        LogInfo(("asset replacement: loaded cue WAV %s (%d samples, %d Hz)",
+                 path, slot.sample_count, slot.sample_rate));
+    }
+    return loaded;
+}
+
+int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
+                                AsoundReplacementCue *cue) {
+    if (cue) {
+        cue->samples = NULL;
+        cue->sample_count = 0;
+        cue->sample_rate = 0;
+    }
+    for (const CueSlot &slot : g_cues) {
+        if (slot.start == start && slot.end_inclusive == end_inclusive
+            && slot.samples && slot.sample_count > 0) {
+            if (cue) {
+                cue->samples = slot.samples;
+                cue->sample_count = slot.sample_count;
+                cue->sample_rate = slot.sample_rate;
+            }
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -153,3 +153,23 @@ int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
     }
     return 0;
 }
+
+int asound_replacement_cue_count(void) {
+    return (int)(sizeof(g_cues) / sizeof(g_cues[0]));
+}
+
+int asound_replacement_cue_at(int index, AsoundU16 *start,
+                              AsoundU16 *end_inclusive,
+                              AsoundReplacementCue *cue) {
+    if (index < 0 || index >= asound_replacement_cue_count()) return 0;
+    CueSlot *slot = &g_cues[index];
+    if (!slot->samples || slot->sample_count <= 0) return 0;
+    if (start) *start = slot->start;
+    if (end_inclusive) *end_inclusive = slot->end_inclusive;
+    if (cue) {
+        cue->samples = slot->samples;
+        cue->sample_count = slot->sample_count;
+        cue->sample_rate = slot->sample_rate;
+    }
+    return 1;
+}

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -9,6 +9,7 @@
 
 #include <SDL3/SDL.h>
 
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -81,7 +82,8 @@ static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
             const uint16_t channels = read16le(wav + data_offset + 2);
             rate = read32le(wav + data_offset + 4);
             const uint16_t bits = read16le(wav + data_offset + 14);
-            format_valid = format == 1 && channels == 1 && bits == 8 && rate > 0;
+            format_valid = format == 1 && channels == 1 && bits == 8
+                && rate > 0 && rate <= INT_MAX;
         } else if (!memcmp(chunk, "data", 4)) {
             if (!format_valid || !chunk_size || chunk_size > INT32_MAX) return 0;
             AsoundU8 *decoded = (AsoundU8 *)SDL_malloc(chunk_size);

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -140,6 +140,17 @@ int asound_load_replacement_cues(void) {
     return loaded;
 }
 
+/* Return one past the highest legacy byte offset covered by a loaded cue. */
+int asound_replacement_logical_span(void) {
+    int logicalSpan = 0;
+    for (const CueSlot &slot : g_cues) {
+        if (!slot.samples || slot.sample_count <= 0) continue;
+        const int slotSpan = (int)slot.end_inclusive + 1;
+        if (slotSpan > logicalSpan) logicalSpan = slotSpan;
+    }
+    return logicalSpan;
+}
+
 /* Return the replacement cue for a legacy sample pointer, or NULL when not overridden. */
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue) {

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -30,15 +30,18 @@ static CueSlot g_cues[] = {
     {0x6a1bu, 0x7d9du, "sounds/voice_cue_004_sample2_variant2.wav", NULL, 0, 0},
 };
 
+/* Read an unsigned 16-bit little-endian value from an unaligned byte buffer. */
 static uint16_t read16le(const AsoundU8 *data) {
     return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
 }
 
+/* Read an unsigned 32-bit little-endian value from an unaligned byte buffer. */
 static uint32_t read32le(const AsoundU8 *data) {
     return (uint32_t)data[0] | ((uint32_t)data[1] << 8)
         | ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
 }
 
+/* Read an entire replacement file into an owned heap buffer. */
 static AsoundU8 *readFile(const char *path, size_t *size) {
     SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
     if (size) *size = 0;
@@ -60,6 +63,7 @@ static AsoundU8 *readFile(const char *path, size_t *size) {
     return data;
 }
 
+/* Decode one unsigned 8-bit mono PCM WAV while rejecting unsupported layouts. */
 static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
                              AsoundU8 **samples, int *sample_rate) {
     bool format_valid = false;
@@ -101,6 +105,7 @@ static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
     return 0;
 }
 
+/* Load independently editable WAV cues and replace only slots that are present. */
 int asound_load_replacement_cues(void) {
     int loaded = 0;
     for (CueSlot &slot : g_cues) {
@@ -135,6 +140,7 @@ int asound_load_replacement_cues(void) {
     return loaded;
 }
 
+/* Return the replacement cue for a legacy sample pointer, or NULL when not overridden. */
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue) {
     if (cue) {
@@ -156,10 +162,12 @@ int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
     return 0;
 }
 
+/* Return the number of currently loaded replacement sound cues. */
 int asound_replacement_cue_count(void) {
     return (int)(sizeof(g_cues) / sizeof(g_cues[0]));
 }
 
+/* Return replacement cue metadata by stable enumeration index. */
 int asound_replacement_cue_at(int index, AsoundU16 *start,
                               AsoundU16 *end_inclusive,
                               AsoundReplacementCue *cue) {

--- a/src/asound/asound_replacements.c
+++ b/src/asound/asound_replacements.c
@@ -13,6 +13,15 @@
 #include <stdint.h>
 #include <string.h>
 
+enum {
+    RIFF_HEADER_BYTES = 12,
+    CHUNK_HEADER_BYTES = 8,
+    PCM_FORMAT_BYTES = 16,
+    WAVE_FORMAT_PCM = 1,
+    MONO_CHANNELS = 1,
+    PCM_SAMPLE_BITS = 8
+};
+
 typedef struct CueSlot {
     AsoundU16 start;
     AsoundU16 end_inclusive;
@@ -67,37 +76,39 @@ static AsoundU8 *readFile(const char *path, size_t *size) {
 static int decodePcm8MonoWav(const AsoundU8 *wav, size_t wav_size,
                              AsoundU8 **samples, int *sample_rate) {
     bool format_valid = false;
-    uint32_t rate = 0;
+    uint32_t rate_hz = 0;
     if (samples) *samples = NULL;
     if (sample_rate) *sample_rate = 0;
-    if (!wav || wav_size < 12 || memcmp(wav, "RIFF", 4)
-        || memcmp(wav + 8, "WAVE", 4)) {
-        return 0;
-    }
+    if (!wav || wav_size < RIFF_HEADER_BYTES) return 0;
+    const bool is_wave = !memcmp(wav, "RIFF", 4) && !memcmp(wav + 8, "WAVE", 4);
+    if (!is_wave) return 0;
 
-    for (size_t offset = 12; offset + 8 <= wav_size;) {
+    for (size_t offset = RIFF_HEADER_BYTES; offset + CHUNK_HEADER_BYTES <= wav_size;) {
         const AsoundU8 *chunk = wav + offset;
         const uint32_t chunk_size = read32le(chunk + 4);
-        const size_t data_offset = offset + 8;
+        const size_t data_offset = offset + CHUNK_HEADER_BYTES;
         if (chunk_size > wav_size - data_offset) return 0;
 
-        if (!memcmp(chunk, "fmt ", 4) && chunk_size >= 16) {
+        if (!memcmp(chunk, "fmt ", 4) && chunk_size >= PCM_FORMAT_BYTES) {
             const uint16_t format = read16le(wav + data_offset);
             const uint16_t channels = read16le(wav + data_offset + 2);
-            rate = read32le(wav + data_offset + 4);
+            rate_hz = read32le(wav + data_offset + 4);
             const uint16_t bits = read16le(wav + data_offset + 14);
-            format_valid = format == 1 && channels == 1 && bits == 8
-                && rate > 0 && rate <= INT_MAX;
+            const bool supported_layout = format == WAVE_FORMAT_PCM &&
+                channels == MONO_CHANNELS && bits == PCM_SAMPLE_BITS;
+            const bool valid_rate = rate_hz > 0 && rate_hz <= INT_MAX;
+            format_valid = supported_layout && valid_rate;
         } else if (!memcmp(chunk, "data", 4)) {
             if (!format_valid || !chunk_size || chunk_size > INT32_MAX) return 0;
             AsoundU8 *decoded = (AsoundU8 *)SDL_malloc(chunk_size);
             if (!decoded) return 0;
             memcpy(decoded, wav + data_offset, chunk_size);
             if (samples) *samples = decoded;
-            if (sample_rate) *sample_rate = (int)rate;
+            if (sample_rate) *sample_rate = (int)rate_hz;
             return (int)chunk_size;
         }
 
+        /* RIFF aligns chunks to two bytes; padding is not sample data. */
         const size_t padded_size = (size_t)chunk_size + (chunk_size & 1u);
         if (padded_size > wav_size - data_offset) return 0;
         offset = data_offset + padded_size;
@@ -173,7 +184,7 @@ int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
     return 0;
 }
 
-/* Return the number of currently loaded replacement sound cues. */
+/* Return the number of addressable cue slots, including unloaded slots. */
 int asound_replacement_cue_count(void) {
     return (int)(sizeof(g_cues) / sizeof(g_cues[0]));
 }

--- a/src/asound/asound_replacements.h
+++ b/src/asound/asound_replacements.h
@@ -1,0 +1,30 @@
+/*
+ * asound_replacements.h - Optional editable replacements for ASOUND assets.
+ */
+#ifndef ASOUND_REPLACEMENTS_H
+#define ASOUND_REPLACEMENTS_H
+
+#include "asound_model.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct AsoundReplacementCue {
+    const AsoundU8 *samples;
+    int sample_count;
+    int sample_rate;
+} AsoundReplacementCue;
+
+/* Reload all known cue WAVs. Missing or malformed files remain legacy fallbacks. */
+int asound_load_replacement_cues(void);
+
+/* Return a loaded cue matching the original inclusive sample range. */
+int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
+                                AsoundReplacementCue *cue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASOUND_REPLACEMENTS_H */

--- a/src/asound/asound_replacements.h
+++ b/src/asound/asound_replacements.h
@@ -19,6 +19,9 @@ typedef struct AsoundReplacementCue {
 /* Reload all known cue WAVs. Missing or malformed files remain legacy fallbacks. */
 int asound_load_replacement_cues(void);
 
+/* Return one past the highest legacy byte offset covered by a loaded cue. */
+int asound_replacement_logical_span(void);
+
 /* Return a loaded cue matching the original inclusive sample range. */
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue);

--- a/src/asound/asound_replacements.h
+++ b/src/asound/asound_replacements.h
@@ -23,6 +23,12 @@ int asound_load_replacement_cues(void);
 int asound_find_replacement_cue(AsoundU16 start, AsoundU16 end_inclusive,
                                 AsoundReplacementCue *cue);
 
+/* Read-only enumeration for diagnostics and asset validation tools. */
+int asound_replacement_cue_count(void);
+int asound_replacement_cue_at(int index, AsoundU16 *start,
+                              AsoundU16 *end_inclusive,
+                              AsoundReplacementCue *cue);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -15,6 +15,7 @@
 #include <SDL3/SDL.h>
 
 #include "asound_model.h"
+#include "asound_replacements.h"
 #include "asopl.h"
 /* opl3.h has no extern "C" guard of its own; this TU compiles as C++ but opl3.c
  * is built as C, so the declarations must use C linkage to match. */
@@ -33,7 +34,7 @@ extern "C" {
 
 #define ASND_OUT_RATE 44100 /* SDL output sample rate (Hz) */
 #define ASND_TICK_HZ 60     /* sequencer tick = game tick rate */
-#define ASND_SAMPLE_HZ 7231 /* F15DGTL.BIN playback rate (PIT ch2 1193182/165) */
+#define ASND_SAMPLE_HZ 7850 /* Recovered F15DGTL.BIN cue playback rate. */
 #define ASND_CHUNK 512      /* max frames generated per inner loop pass */
 
 static AsoplState g_opl; /* OPL register shadow (event -> regs) */
@@ -47,9 +48,10 @@ static bool g_ready;                              /* device opened */
 static AsoundU8 *g_blob;
 static int g_blobSize;
 static bool g_smpActive;
+static const AsoundU8 *g_smpData;
 static double g_smpPos; /* fractional read position (bytes) */
-static int g_smpEnd;
-static const double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
+static int g_smpSize;
+static double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
 
 /* Fractional countdown (in output frames) to the next sequencer tick. */
 static double g_tickAccum;
@@ -74,12 +76,23 @@ static void asnd_syncChip(void) {
 /* ---- sequencer tick (audio thread, under g_lock) -------------------------- */
 
 static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
+    AsoundReplacementCue cue;
+    if (asound_find_replacement_cue(start, end, &cue)) {
+        g_smpData = cue.samples;
+        g_smpSize = cue.sample_count;
+        g_smpPos = 0;
+        g_smpStep = (double)cue.sample_rate / (double)ASND_OUT_RATE;
+        g_smpActive = true;
+        return;
+    }
     if (!g_blob || g_blobSize <= 0) return;
-    int s = start, e = end;
+    int s = start, e = (int)end + 1;
     if (e > g_blobSize) e = g_blobSize;
     if (s < 0 || s >= e) return;
-    g_smpPos = s;
-    g_smpEnd = e;
+    g_smpData = g_blob + s;
+    g_smpSize = e - s;
+    g_smpPos = 0;
+    g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
     g_smpActive = true;
 }
 
@@ -108,12 +121,12 @@ static void asnd_mixSample(Sint16 *buf, int frames) {
     if (!g_smpActive) return;
     for (int i = 0; i < frames; i++) {
         int idx = (int)g_smpPos;
-        if (idx >= g_smpEnd) {
+        if (idx >= g_smpSize) {
             g_smpActive = false;
             break;
         }
         /* 8-bit unsigned -> signed, scaled below full-scale to leave OPL headroom */
-        int s = ((int)g_blob[idx] - 128) * 200;
+        int s = ((int)g_smpData[idx] - 128) * 200;
         int l = buf[2 * i] + s;
         int r = buf[2 * i + 1] + s;
         if (l > 32767)
@@ -339,27 +352,30 @@ int FAR CDECL audio_noiseTick(void) { return 0; }
  * the game stores in f15DgtlResult and passes to audio_setup as the sample-
  * variant selector (and uses to gate voice cues). 0 on failure -> cues disabled. */
 int loadF15DgtlBin(void) {
+    const int replacementCount = asound_load_replacement_cues();
+    const int replacementSpan = replacementCount > 0 ? 0x7d9e : 0;
     SDL_IOStream *io = openFile("F15DGTL.BIN", 0);
     if (!io) {
-        LogError(("asound: cannot open F15DGTL.BIN"));
+        if (replacementSpan) return replacementSpan;
+        LogError(("asound: cannot open F15DGTL.BIN or replacement cue WAVs"));
         return 0;
     }
     Sint64 size = SDL_GetIOSize(io);
     if (size <= 0) {
         SDL_CloseIO(io);
-        return 0;
+        return replacementSpan;
     }
 
     AsoundU8 *data = (AsoundU8 *)SDL_malloc((size_t)size);
     if (!data) {
         SDL_CloseIO(io);
-        return 0;
+        return replacementSpan;
     }
     size_t got = SDL_ReadIO(io, data, (size_t)size);
     SDL_CloseIO(io);
     if (got != (size_t)size) {
         SDL_free(data);
-        return 0;
+        return replacementSpan;
     }
 
     if (g_lock) SDL_LockMutex(g_lock);

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -48,9 +48,9 @@ static bool g_ready;                              /* device opened */
 static AsoundU8 *g_blob;
 static int g_blobSize;
 static bool g_smpActive;
-static const AsoundU8 *g_smpData;
+static const AsoundU8 *g_smpData{};
 static double g_smpPos; /* fractional read position (bytes) */
-static int g_smpSize;
+static int g_smpSize{};
 static double g_smpStep = (double)ASND_SAMPLE_HZ / (double)ASND_OUT_RATE;
 
 /* Fractional countdown (in output frames) to the next sequencer tick. */
@@ -76,14 +76,14 @@ static void asnd_syncChip(void) {
 /* ---- sequencer tick (audio thread, under g_lock) -------------------------- */
 
 static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
-    AsoundReplacementCue cue;
+    AsoundReplacementCue cue{};
     if (asound_find_replacement_cue(start, end, &cue)) {
         g_smpData = cue.samples;
         g_smpSize = cue.sample_count;
         g_smpPos = 0;
         g_smpStep = (double)cue.sample_rate / (double)ASND_OUT_RATE;
         g_smpActive = true;
-        return;
+        return{};
     }
     if (!g_blob || g_blobSize <= 0) return;
     int s = start, e = (int)end + 1;

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -83,7 +83,7 @@ static void asnd_startSample(AsoundU16 start, AsoundU16 end) {
         g_smpPos = 0;
         g_smpStep = (double)cue.sample_rate / (double)ASND_OUT_RATE;
         g_smpActive = true;
-        return{};
+        return;
     }
     if (!g_blob || g_blobSize <= 0) return;
     int s = start, e = (int)end + 1;
@@ -352,8 +352,8 @@ int FAR CDECL audio_noiseTick(void) { return 0; }
  * the game stores in f15DgtlResult and passes to audio_setup as the sample-
  * variant selector (and uses to gate voice cues). 0 on failure -> cues disabled. */
 int loadF15DgtlBin(void) {
-    const int replacementCount = asound_load_replacement_cues();
-    const int replacementSpan = replacementCount > 0 ? 0x7d9e : 0;
+    asound_load_replacement_cues();
+    const int replacementSpan = asound_replacement_logical_span();
     SDL_IOStream *io = openFile("F15DGTL.BIN", 0);
     if (!io) {
         if (replacementSpan) return replacementSpan;

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -15,6 +15,7 @@
 #include <SDL3/SDL.h>
 
 #include "asound_model.h"
+#include "asound_music_replacement.h"
 #include "asound_replacements.h"
 #include "asopl.h"
 /* opl3.h has no extern "C" guard of its own; this TU compiles as C++ but opl3.c
@@ -273,7 +274,9 @@ int FAR CDECL audio_playIntro(void) {
     if (!g_ready) return 0;
 
     SDL_LockMutex(g_lock);
-    sound_driver_play_intro();
+    if (!asound_start_replacement_music(sound_driver_state(), 0)) {
+        sound_driver_play_intro();
+    }
     SDL_UnlockMutex(g_lock);
 
     input_setMode(INPUT_MODE_MENU);
@@ -285,7 +288,9 @@ int FAR CDECL audio_playIntro(void) {
 
     /* release tail (adlib_start_intro_release), then let it decay out */
     SDL_LockMutex(g_lock);
-    asound_driver_start_intro_rel(sound_driver_state());
+    if (!asound_start_replacement_music(sound_driver_state(), 1)) {
+        asound_driver_start_intro_rel(sound_driver_state());
+    }
     SDL_UnlockMutex(g_lock);
     deadline = SDL_GetTicksNS() + 2 * SDL_NS_PER_SECOND;
     while (asnd_introVoicesActive() && SDL_GetTicksNS() < deadline) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/tests/asound_asset_full_validation_tests.cpp
+++ b/tests/asound_asset_full_validation_tests.cpp
@@ -1,0 +1,107 @@
+#include "asound/asound_model.h"
+#include "asound/asound_music_replacement.h"
+#include "asound/asound_replacements.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+constexpr int kLegacySampleRate = 7850;
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+std::vector<unsigned char> readFile(const std::filesystem::path &path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::vector<unsigned char>(
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const std::vector<unsigned char> blob =
+        readFile(originalRoot / "F15DGTL.BIN");
+    require(!blob.empty(), "cannot read original F15DGTL.BIN");
+
+    setReplacementRoot(&convertedRoot);
+    const int loadedCues = asound_load_replacement_cues();
+    require(loadedCues == asound_replacement_cue_count(),
+            "not all replacement cue WAVs loaded");
+    for (int index = 0; index < loadedCues; ++index) {
+        AsoundU16 start = 0;
+        AsoundU16 end = 0;
+        AsoundReplacementCue cue = {};
+        require(asound_replacement_cue_at(index, &start, &end, &cue),
+                "cannot enumerate loaded replacement cue");
+        const size_t count = (size_t)end - start + 1u;
+        require(cue.sample_rate == kLegacySampleRate,
+                "replacement cue sample rate differs from legacy");
+        require(cue.sample_count == (int)count && end < blob.size(),
+                "replacement cue range or length differs from legacy");
+        require(std::memcmp(cue.samples, blob.data() + start, count) == 0,
+                "replacement cue PCM differs from legacy");
+    }
+
+    static const AsoundU8 *const intro[ASOUND_STREAM_COUNT] = {
+        asound_intro_voice0, asound_intro_voice1, asound_intro_voice2,
+        asound_intro_voice3, asound_intro_voice4, asound_intro_voice5};
+    static const AsoundU8 *const release[ASOUND_STREAM_COUNT] = {
+        asound_release_voice0, asound_release_voice1, asound_release_voice2,
+        asound_release_voice3, asound_release_voice4, asound_release_voice5};
+    require(asound_reload_replacement_music(),
+            "replacement intro music did not load");
+    for (int phase = 0; phase < 2; ++phase) {
+        for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+            const AsoundU8 *replacement = nullptr;
+            size_t replacementSize = 0;
+            const AsoundU8 *legacy = phase ? release[voice] : intro[voice];
+            const size_t legacySize = phase
+                ? asound_release_voice_length(voice)
+                : asound_intro_voice_length(voice);
+            require(asound_replacement_music_stream(
+                        phase, voice, &replacement, &replacementSize),
+                    "cannot enumerate replacement music stream");
+            require(replacementSize == legacySize,
+                    "replacement music stream length differs from legacy");
+            require(std::memcmp(replacement, legacy, legacySize) == 0,
+                    "replacement music stream bytes differ from legacy");
+        }
+    }
+
+    setReplacementRoot(nullptr);
+    std::cout << "asound_asset_full_validation_tests compared "
+              << loadedCues << " cues and "
+              << ASOUND_STREAM_COUNT * 2 << " music streams\n";
+    return 0;
+}

--- a/tests/asound_cue_full_validation_tests.cpp
+++ b/tests/asound_cue_full_validation_tests.cpp
@@ -1,0 +1,78 @@
+#include "asound/asound_replacements.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+constexpr int kLegacySampleRate = 7850;
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+std::vector<unsigned char> readFile(const std::filesystem::path &path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::vector<unsigned char>(
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>());
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const std::vector<unsigned char> blob =
+        readFile(originalRoot / "F15DGTL.BIN");
+    require(!blob.empty(), "cannot read original F15DGTL.BIN");
+
+    setReplacementRoot(&convertedRoot);
+    const int loaded = asound_load_replacement_cues();
+    require(loaded == asound_replacement_cue_count(),
+            "not all replacement cue WAVs loaded");
+    for (int index = 0; index < loaded; ++index) {
+        AsoundU16 start = 0;
+        AsoundU16 end = 0;
+        AsoundReplacementCue cue = {};
+        require(asound_replacement_cue_at(index, &start, &end, &cue),
+                "cannot enumerate loaded replacement cue");
+        const size_t count = (size_t)end - start + 1u;
+        require(cue.sample_rate == kLegacySampleRate,
+                "replacement cue sample rate differs from legacy");
+        require(cue.sample_count == (int)count && end < blob.size(),
+                "replacement cue range or length differs from legacy");
+        require(std::memcmp(cue.samples, blob.data() + start, count) == 0,
+                "replacement cue PCM differs from legacy");
+    }
+
+    setReplacementRoot(nullptr);
+    std::cout << "asound_cue_full_validation_tests compared "
+              << loaded << " cues\n";
+    return 0;
+}

--- a/tests/asound_music_full_validation_tests.cpp
+++ b/tests/asound_music_full_validation_tests.cpp
@@ -1,26 +1,17 @@
 #include "asound/asound_model.h"
 #include "asound/asound_music_replacement.h"
-#include "asound/asound_replacements.h"
 
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <iterator>
 #include <string>
-#include <vector>
 
-#if !defined(F15_ORIGINAL_ASSETS)
-#define F15_ORIGINAL_ASSETS ""
-#endif
 #if !defined(F15_CONVERTED_ASSETS)
 #define F15_CONVERTED_ASSETS ""
 #endif
 
 namespace {
-
-constexpr int kLegacySampleRate = 7850;
 
 void require(bool condition, const std::string &message) {
     if (!condition) {
@@ -38,47 +29,18 @@ void setReplacementRoot(const std::filesystem::path *root) {
 #endif
 }
 
-std::vector<unsigned char> readFile(const std::filesystem::path &path) {
-    std::ifstream input(path, std::ios::binary);
-    return std::vector<unsigned char>(
-        std::istreambuf_iterator<char>(input),
-        std::istreambuf_iterator<char>());
-}
-
 } // namespace
 
 int main() {
-    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
     const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
-    const std::vector<unsigned char> blob =
-        readFile(originalRoot / "F15DGTL.BIN");
-    require(!blob.empty(), "cannot read original F15DGTL.BIN");
-
-    setReplacementRoot(&convertedRoot);
-    const int loadedCues = asound_load_replacement_cues();
-    require(loadedCues == asound_replacement_cue_count(),
-            "not all replacement cue WAVs loaded");
-    for (int index = 0; index < loadedCues; ++index) {
-        AsoundU16 start = 0;
-        AsoundU16 end = 0;
-        AsoundReplacementCue cue = {};
-        require(asound_replacement_cue_at(index, &start, &end, &cue),
-                "cannot enumerate loaded replacement cue");
-        const size_t count = (size_t)end - start + 1u;
-        require(cue.sample_rate == kLegacySampleRate,
-                "replacement cue sample rate differs from legacy");
-        require(cue.sample_count == (int)count && end < blob.size(),
-                "replacement cue range or length differs from legacy");
-        require(std::memcmp(cue.samples, blob.data() + start, count) == 0,
-                "replacement cue PCM differs from legacy");
-    }
-
     static const AsoundU8 *const intro[ASOUND_STREAM_COUNT] = {
         asound_intro_voice0, asound_intro_voice1, asound_intro_voice2,
         asound_intro_voice3, asound_intro_voice4, asound_intro_voice5};
     static const AsoundU8 *const release[ASOUND_STREAM_COUNT] = {
         asound_release_voice0, asound_release_voice1, asound_release_voice2,
         asound_release_voice3, asound_release_voice4, asound_release_voice5};
+
+    setReplacementRoot(&convertedRoot);
     require(asound_reload_replacement_music(),
             "replacement intro music did not load");
     for (int phase = 0; phase < 2; ++phase) {
@@ -100,8 +62,7 @@ int main() {
     }
 
     setReplacementRoot(nullptr);
-    std::cout << "asound_asset_full_validation_tests compared "
-              << loadedCues << " cues and "
+    std::cout << "asound_music_full_validation_tests compared "
               << ASOUND_STREAM_COUNT * 2 << " music streams\n";
     return 0;
 }

--- a/tests/asound_music_replacement_behavior_tests.cpp
+++ b/tests/asound_music_replacement_behavior_tests.cpp
@@ -1,0 +1,94 @@
+#include "asound/asound_music_replacement.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+void writeMusic(const std::filesystem::path &path, bool complete) {
+    std::ofstream out(path);
+    out << "{\"streams\":[";
+    bool first = true;
+    for (int phase = 0; phase < 2; ++phase) {
+        for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+            if (!complete && phase == 1 && voice == ASOUND_STREAM_COUNT - 1) continue;
+            if (!first) out << ',';
+            first = false;
+            out << "{\"source_symbol\":\"asound_"
+                << (phase ? "release" : "intro") << "_voice" << voice
+                << "\",\"stream_bytes\":[" << (phase ? 200 : 100) + voice
+                << ",0]}";
+        }
+    }
+    out << "]}";
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asound-music-tests";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "sounds");
+    const auto musicPath = root / "sounds" / "intro_music.asound.json";
+    writeMusic(musicPath, true);
+    setReplacementRoot(root.string());
+
+    require(asound_reload_replacement_music(),
+            "complete converter JSON loads atomically");
+    AsoundDriver driver = {};
+    require(asound_start_replacement_music(&driver, 0),
+            "replacement intro initializes all voices");
+    for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+        require(driver.streams[voice].stream_ptr
+                && driver.streams[voice].stream_ptr[0] == 100 + voice,
+                "intro voice points at its replacement byte stream");
+    }
+    require(asound_start_replacement_music(&driver, 1),
+            "replacement release initializes all voices");
+    for (int voice = 0; voice < ASOUND_STREAM_COUNT; ++voice) {
+        require(driver.streams[voice].stream_ptr
+                && driver.streams[voice].stream_ptr[0] == 200 + voice,
+                "release voice points at its replacement byte stream");
+    }
+
+    writeMusic(musicPath, false);
+    require(!asound_reload_replacement_music(),
+            "incomplete music JSON is rejected as a unit");
+    require(!asound_start_replacement_music(&driver, 0),
+            "rejected music leaves compiled streams as fallback");
+
+    {
+        std::ofstream out(musicPath);
+        out << "{\"streams\":["
+               "{\"source_symbol\":\"asound_intro_voice0\"},"
+               "{\"source_symbol\":\"asound_intro_voice1\","
+               "\"stream_bytes\":[101,0]}]}";
+    }
+    require(!asound_reload_replacement_music(),
+            "a missing stream cannot borrow bytes from the next object");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(root);
+    std::cout << "asound_music_replacement_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asound_music_replacement_behavior_tests.cpp
+++ b/tests/asound_music_replacement_behavior_tests.cpp
@@ -24,7 +24,8 @@ void setReplacementRoot(const std::string &value) {
 #endif
 }
 
-void writeMusic(const std::filesystem::path &path, bool complete) {
+void writeMusic(const std::filesystem::path &path, bool complete,
+                const char *firstStream = nullptr) {
     std::ofstream out(path);
     out << "{\"streams\":[";
     bool first = true;
@@ -35,8 +36,10 @@ void writeMusic(const std::filesystem::path &path, bool complete) {
             first = false;
             out << "{\"source_symbol\":\"asound_"
                 << (phase ? "release" : "intro") << "_voice" << voice
-                << "\",\"stream_bytes\":[" << (phase ? 200 : 100) + voice
-                << ",0]}";
+                << "\",\"stream_bytes\":[";
+            if (!phase && !voice && firstStream) out << firstStream;
+            else out << (phase ? 200 : 100) + voice << ",1,0,0";
+            out << "]}";
         }
     }
     out << "]}";
@@ -71,6 +74,23 @@ int main() {
                 "release voice points at its replacement byte stream");
     }
 
+    // Exercise the real sequencer, not just the returned stream pointers.
+    asound_driver_tick(&driver, nullptr);
+    asound_driver_tick(&driver, nullptr);
+    for (const auto &stream : driver.streams) {
+        require(!stream.stream_ptr, "valid replacement streams terminate");
+    }
+
+    for (const char *invalid : {"100", "100,1", "248,1", "249", "255"}) {
+        writeMusic(musicPath, true, invalid);
+        require(!asound_reload_replacement_music(),
+                "truncated or unterminated bytecode is rejected before playback");
+    }
+    writeMusic(musicPath, true, "253");
+    require(asound_reload_replacement_music(), "stream-end opcode is accepted");
+    writeMusic(musicPath, true, "254,100,1,255,2,0,0");
+    require(asound_reload_replacement_music(), "bounded loop bytecode is accepted");
+
     writeMusic(musicPath, false);
     require(!asound_reload_replacement_music(),
             "incomplete music JSON is rejected as a unit");
@@ -86,6 +106,13 @@ int main() {
     }
     require(!asound_reload_replacement_music(),
             "a missing stream cannot borrow bytes from the next object");
+
+    {
+        std::ofstream out(musicPath);
+        out << "{\"source_symbol\":\"a";
+    }
+    require(!asound_reload_replacement_music(),
+            "truncated symbol string is rejected without an out-of-bounds read");
 
     setReplacementRoot("");
     std::filesystem::remove_all(root);

--- a/tests/asound_replacements_behavior_tests.cpp
+++ b/tests/asound_replacements_behavior_tests.cpp
@@ -29,7 +29,7 @@ void append32(std::vector<unsigned char> &out, unsigned int value) {
     append16(out, value >> 16);
 }
 
-void writePcm8MonoWav(const std::filesystem::path &path, int rate,
+void writePcm8MonoWav(const std::filesystem::path &path, unsigned int rate,
                       const std::vector<unsigned char> &samples) {
     std::vector<unsigned char> wav;
     wav.insert(wav.end(), {'R', 'I', 'F', 'F'});
@@ -67,7 +67,8 @@ int main() {
     std::filesystem::create_directories(root / "sounds");
     writePcm8MonoWav(root / "sounds" / "voice_cue_000_sample0.wav",
                      11025, {0, 64, 128, 255});
-    std::ofstream(root / "sounds" / "voice_cue_001_sample4.wav") << "not a WAV";
+    writePcm8MonoWav(root / "sounds" / "voice_cue_001_sample4.wav",
+                     0x80000000u, {128});
 
     setReplacementRoot(root.string());
     require(asound_load_replacement_cues() == 1,
@@ -81,7 +82,7 @@ int main() {
     require(cue.samples[0] == 0 && cue.samples[2] == 128 && cue.samples[3] == 255,
             "cue preserves unsigned PCM bytes");
     require(!asound_find_replacement_cue(0x31f4u, 0x4796u, &cue),
-            "malformed cue remains a legacy fallback");
+            "out-of-range sample rate remains a legacy fallback");
     require(!asound_find_replacement_cue(1, 2, &cue),
             "unknown sample range remains a legacy fallback");
 

--- a/tests/asound_replacements_behavior_tests.cpp
+++ b/tests/asound_replacements_behavior_tests.cpp
@@ -87,7 +87,7 @@ int main() {
             "unknown sample range remains a legacy fallback");
 
     require(setGamePath(root.string().c_str()), "modern-only game path is valid");
-    require(loadF15DgtlBin() == 0x7d9e,
+    require(loadF15DgtlBin() == 0x31f4,
             "replacement cues enable digitized sound without F15DGTL.BIN");
 
     setReplacementRoot("");

--- a/tests/asound_replacements_behavior_tests.cpp
+++ b/tests/asound_replacements_behavior_tests.cpp
@@ -1,0 +1,101 @@
+#include "asound/asound_replacements.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern bool setGamePath(const char *path);
+extern int loadF15DgtlBin(void);
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void append16(std::vector<unsigned char> &out, unsigned int value) {
+    out.push_back((unsigned char)value);
+    out.push_back((unsigned char)(value >> 8));
+}
+
+void append32(std::vector<unsigned char> &out, unsigned int value) {
+    append16(out, value);
+    append16(out, value >> 16);
+}
+
+void writePcm8MonoWav(const std::filesystem::path &path, int rate,
+                      const std::vector<unsigned char> &samples) {
+    std::vector<unsigned char> wav;
+    wav.insert(wav.end(), {'R', 'I', 'F', 'F'});
+    append32(wav, 36u + (unsigned int)samples.size());
+    wav.insert(wav.end(), {'W', 'A', 'V', 'E', 'f', 'm', 't', ' '});
+    append32(wav, 16);
+    append16(wav, 1);
+    append16(wav, 1);
+    append32(wav, (unsigned int)rate);
+    append32(wav, (unsigned int)rate);
+    append16(wav, 1);
+    append16(wav, 8);
+    wav.insert(wav.end(), {'d', 'a', 't', 'a'});
+    append32(wav, (unsigned int)samples.size());
+    wav.insert(wav.end(), samples.begin(), samples.end());
+    std::ofstream(path, std::ios::binary)
+        .write((const char *)wav.data(), (std::streamsize)wav.size());
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asound-replacement-tests";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "sounds");
+    writePcm8MonoWav(root / "sounds" / "voice_cue_000_sample0.wav",
+                     11025, {0, 64, 128, 255});
+    std::ofstream(root / "sounds" / "voice_cue_001_sample4.wav") << "not a WAV";
+
+    setReplacementRoot(root.string());
+    require(asound_load_replacement_cues() == 1,
+            "loader accepts valid cues and ignores malformed optional cues");
+
+    AsoundReplacementCue cue = {};
+    require(asound_find_replacement_cue(0x0000u, 0x31f3u, &cue),
+            "cue lookup uses the original inclusive sample range");
+    require(cue.sample_count == 4 && cue.sample_rate == 11025,
+            "cue preserves editable WAV length and sample rate");
+    require(cue.samples[0] == 0 && cue.samples[2] == 128 && cue.samples[3] == 255,
+            "cue preserves unsigned PCM bytes");
+    require(!asound_find_replacement_cue(0x31f4u, 0x4796u, &cue),
+            "malformed cue remains a legacy fallback");
+    require(!asound_find_replacement_cue(1, 2, &cue),
+            "unknown sample range remains a legacy fallback");
+
+    require(setGamePath(root.string().c_str()), "modern-only game path is valid");
+    require(loadF15DgtlBin() == 0x7d9e,
+            "replacement cues enable digitized sound without F15DGTL.BIN");
+
+    setReplacementRoot("");
+    require(asound_load_replacement_cues() == 0,
+            "reload without a replacement root clears prior cue data");
+    require(!asound_find_replacement_cue(0x0000u, 0x31f3u, &cue),
+            "cleared replacement no longer overrides the legacy cue");
+
+    std::filesystem::remove_all(root);
+    std::cout << "asound_replacements_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";


### PR DESCRIPTION
## Summary

- loads the twelve editable ASOUND intro/release streams
- requires a complete set and falls back atomically to compiled streams
- keeps music parsing separate from digitized sound cues

## Dependencies

- #31
- companion converter: #28

## Validation

- all twelve streams compared byte-for-byte with compiled legacy data
- full branch suite: 35/35 passed

Split from #20.
