### PR TITLE
[review: medium] 13. [custom] Load optional editable bitmap fonts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,18 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(bitmap_font_replacement_behavior_tests LINK_CORE)
+if(F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(bitmap_font_full_validation_tests LINK_CORE
+        DEFS F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(bitmap_font_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping bitmap-font full validation: set "
+        "F15SE2_CONVERTED_ASSETS to an existing directory")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/bitmap_font_replacement.c
     ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(bitmap_font_replacement_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -603,7 +603,7 @@ static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     BitmapFontReplacement replacement{};
     if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]
         || !g_fontBitmapPtrs[fontIdx]) {
-        return{};
+        return;
     }
     if (bitmapFontReplacementGet(fontIdx, g_fontMaxWidths[fontIdx],
                                  g_fontHeightsArr[fontIdx],

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -598,6 +598,7 @@ static uint8 *g_fontBitmapPtrs[8] = {
     (uint8 *)g_font0_bitmaps, (uint8 *)g_font1_bitmaps, NULL, (uint8 *)g_font3_bitmaps,
     (uint8 *)g_font4_bitmaps, (uint8 *)g_font5_bitmaps, NULL, NULL};
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+/* Override one legacy bitmap font slot from editable BDF or PNG media when available. */
 static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     BitmapFontReplacement replacement;
     if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -600,10 +600,10 @@ static uint8 *g_fontBitmapPtrs[8] = {
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
 /* Override one legacy bitmap font slot from editable BDF or PNG media when available. */
 static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
-    BitmapFontReplacement replacement;
+    BitmapFontReplacement replacement{};
     if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]
         || !g_fontBitmapPtrs[fontIdx]) {
-        return;
+        return{};
     }
     if (bitmapFontReplacementGet(fontIdx, g_fontMaxWidths[fontIdx],
                                  g_fontHeightsArr[fontIdx],

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -612,6 +612,57 @@ static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     }
 }
 
+#ifdef DEBUG
+static int copyFontTables(const uint8 *bitmap, const uint8 *widths,
+                          int height, int maxWidth,
+                          uint8 *bitmapOut, size_t bitmapOutSize,
+                          uint8 *widthsOut, size_t widthsOutSize,
+                          int *heightOut, int *maxWidthOut) {
+    const size_t bitmapSize = (size_t)96 * (size_t)height;
+    if (!bitmap || !widths || height <= 0 || maxWidth <= 0) return 0;
+    if (bitmapOut && bitmapOutSize < bitmapSize) return 0;
+    if (widthsOut && widthsOutSize < 96u) return 0;
+    if (bitmapOut) memcpy(bitmapOut, bitmap, bitmapSize);
+    if (widthsOut) memcpy(widthsOut, widths, 96u);
+    if (heightOut) *heightOut = height;
+    if (maxWidthOut) *maxWidthOut = maxWidth;
+    return 1;
+}
+
+int gfx_testCopyEffectiveFont(uint16 fontIdx, uint8 *bitmapOut,
+                              size_t bitmapOutSize, uint8 *widthsOut,
+                              size_t widthsOutSize, int *heightOut,
+                              int *maxWidthOut) {
+    if (fontIdx >= 8) return 0;
+    tryLoadBitmapFontReplacement(fontIdx);
+    return copyFontTables(
+        g_fontBitmapPtrs[fontIdx], g_fontWidthTables[fontIdx],
+        g_fontBitmapRowSize[fontIdx], g_fontMaxWidths[fontIdx],
+        bitmapOut, bitmapOutSize, widthsOut, widthsOutSize,
+        heightOut, maxWidthOut);
+}
+
+int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut,
+                            size_t bitmapOutSize, uint8 *widthsOut,
+                            size_t widthsOutSize, int *heightOut,
+                            int *maxWidthOut) {
+    const uint8 *bitmap = NULL;
+    const uint8 *widths = NULL;
+    switch (fontIdx) {
+    case 0: bitmap = &g_font0_bitmaps[0][0]; widths = g_font0_widths; break;
+    case 1: bitmap = &g_font1_bitmaps[0][0]; widths = g_font1_widths; break;
+    case 3: bitmap = &g_font3_bitmaps[0][0]; widths = g_font3_widths; break;
+    case 4: bitmap = &g_font4_bitmaps[0][0]; widths = g_font4_widths; break;
+    case 5: bitmap = &g_font5_bitmaps[0][0]; widths = g_font5_widths; break;
+    default: return 0;
+    }
+    return copyFontTables(
+        bitmap, widths, g_fontBitmapRowSize[fontIdx],
+        g_fontMaxWidths[fontIdx], bitmapOut, bitmapOutSize,
+        widthsOut, widthsOutSize, heightOut, maxWidthOut);
+}
+#endif
+
 /* ---- Shared glyph engine (slots 0x01-0x06) ----
  * MGRAPHIC has one core blitter (0x04 @0x4ab) that the string slots fall into
  * after running 0-3 clip stages. The clip stages cut partial glyphs at the

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 
 #include "fontdata.h"
+#include "shared/bitmap_font_replacement.h"
 
 /* The SDL window and renderer are owned here: the graphics layer brings up the
  * video output and every gfx_* function presents through it. The original game
@@ -136,6 +137,7 @@ void gfx_videoShutdown(void) {
         SDL_DestroyPalette(gfxPalette);
         gfxPalette = NULL;
     }
+    bitmapFontReplacementShutdown();
     if (sdlRenderer) SDL_DestroyRenderer(sdlRenderer);
     if (sdlWindow) SDL_DestroyWindow(sdlWindow);
     SDL_Quit();
@@ -585,7 +587,7 @@ static const uint8 g_font0_widths[96] = {
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-static const uint8 *const g_fontWidthTables[8] = {
+static const uint8 *g_fontWidthTables[8] = {
     g_font0_widths, g_font1_widths, NULL, g_font3_widths,
     g_font4_widths, g_font5_widths, NULL, NULL};
 static const uint8 g_fontHeightsArr[8] = {5, 8, 7, 6, 7, 6, 4, 0};
@@ -596,6 +598,19 @@ static uint8 *g_fontBitmapPtrs[8] = {
     (uint8 *)g_font0_bitmaps, (uint8 *)g_font1_bitmaps, NULL, (uint8 *)g_font3_bitmaps,
     (uint8 *)g_font4_bitmaps, (uint8 *)g_font5_bitmaps, NULL, NULL};
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
+    BitmapFontReplacement replacement;
+    if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]
+        || !g_fontBitmapPtrs[fontIdx]) {
+        return;
+    }
+    if (bitmapFontReplacementGet(fontIdx, g_fontMaxWidths[fontIdx],
+                                 g_fontHeightsArr[fontIdx],
+                                 g_fontWidthTables[fontIdx], &replacement)) {
+        g_fontBitmapPtrs[fontIdx] = (uint8 *)replacement.bitmaps;
+        g_fontWidthTables[fontIdx] = (const uint8 *)replacement.widths;
+    }
+}
 
 /* ---- Shared glyph engine (slots 0x01-0x06) ----
  * MGRAPHIC has one core blitter (0x04 @0x4ab) that the string slots fall into
@@ -634,6 +649,7 @@ static void drawStringCore(int16 *params, const char *string,
     y = (int)params[5];
     color = (int)params[2];
     fontIdx = (uint16)params[6] & 7;
+    tryLoadBitmapFontReplacement(fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -715,6 +731,7 @@ void FAR gfx_drawGlyphStrRot(const char *string, int fontIdx, int color,
     float penX = 0.0f; /* running text-column offset (in glyph texels) */
     if (!string) return;
     fontIdx &= 7;
+    tryLoadBitmapFontReplacement((uint16)fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -1209,6 +1226,7 @@ int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
      * pointers, exactly as drawStringCore reads them. */
     const uint8 *wt;
     if (fontIdx >= 8) return 8;
+    tryLoadBitmapFontReplacement(fontIdx);
     /* Chars >= 0x80 are inline color escapes - no glyph, no width */
     if (ch >= 0x80) return 0;
     wt = g_fontWidthTables[fontIdx];

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -61,6 +61,17 @@ struct SDL_Palette *gfx_getPalette(void);
 void gfx_paletteRGB(int idx, uint8 *r, uint8 *g, uint8 *b);
 int gfx_paletteGeneration(void);
 
+#ifdef DEBUG
+int gfx_testCopyEffectiveFont(uint16 fontIdx, uint8 *bitmapOut,
+                              size_t bitmapOutSize, uint8 *widthsOut,
+                              size_t widthsOutSize, int *heightOut,
+                              int *maxWidthOut);
+int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut,
+                            size_t bitmapOutSize, uint8 *widthsOut,
+                            size_t widthsOutSize, int *heightOut,
+                            int *maxWidthOut);
+#endif
+
 /* Current explosion screen-shake (0-3 virtual px, set by gfx_dacCycle). The GL
  * backend reads it mid-frame to offset the immediate 2D overlay, matching the
  * software present's shake shift. */

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -24,12 +24,12 @@ typedef struct CachedFont {
     int tried;
 } CachedFont;
 
-static CachedFont g_fonts[FONT_SLOT_COUNT];
+static CachedFont g_fonts[FONT_SLOT_COUNT]{};
 
 /* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
 static int replacementPath(unsigned font_id, const char *extension,
                            char *path, size_t path_size) {
-    char relative[64];
+    char relative[64]{};
     snprintf(relative, sizeof(relative), "fonts/font_%u.%s",
              font_id, extension);
     return findAssetReplacement(relative, path, path_size);
@@ -54,7 +54,7 @@ static int parseBdf(const char *path, unsigned height,
     int advance = -1;
     unsigned row = 0;
     int in_bitmap = 0;
-    char line[512];
+    char line[512]{};
 
     if (!file) return 0;
     bitmaps = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, height);
@@ -181,8 +181,8 @@ fail:
 int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
                              unsigned height, const uint8_t *original_widths,
                              BitmapFontReplacement *result) {
-    CachedFont *font;
-    char path[1024];
+    CachedFont *font{};
+    char path[1024]{};
 
     if (!result || !original_widths || font_id >= FONT_SLOT_COUNT
         || cell_width == 0 || cell_width > 8 || height == 0) {

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -1,0 +1,222 @@
+/*
+ * bitmap_font_replacement.c - BDF/PNG font replacement loader.
+ */
+
+#include "bitmap_font_replacement.h"
+
+#include "asset_path.h"
+#include "../log.h"
+
+#include <SDL3/SDL.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FONT_SLOT_COUNT 8
+#define FONT_FIRST_CODEPOINT 0x20
+#define FONT_GLYPH_COUNT 96
+
+typedef struct CachedFont {
+    uint8_t *bitmaps;
+    uint8_t *widths;
+    int tried;
+} CachedFont;
+
+static CachedFont g_fonts[FONT_SLOT_COUNT];
+
+static int replacementPath(unsigned font_id, const char *extension,
+                           char *path, size_t path_size) {
+    char relative[64];
+    snprintf(relative, sizeof(relative), "fonts/font_%u.%s",
+             font_id, extension);
+    return findAssetReplacement(relative, path, path_size);
+}
+
+static void discardFont(CachedFont *font) {
+    SDL_free(font->bitmaps);
+    SDL_free(font->widths);
+    font->bitmaps = NULL;
+    font->widths = NULL;
+}
+
+static int parseBdf(const char *path, unsigned height,
+                    uint8_t **bitmaps_out, uint8_t **widths_out) {
+    FILE *file = fopen(path, "rb");
+    uint8_t *bitmaps = NULL;
+    uint8_t *widths = NULL;
+    unsigned char complete[FONT_GLYPH_COUNT] = {0};
+    int encoding = -1;
+    int advance = -1;
+    unsigned row = 0;
+    int in_bitmap = 0;
+    char line[512];
+
+    if (!file) return 0;
+    bitmaps = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, height);
+    widths = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, 1);
+    if (!bitmaps || !widths) goto fail;
+
+    while (fgets(line, sizeof(line), file)) {
+        char *text = line;
+        while (isspace((unsigned char)*text)) ++text;
+        if (strncmp(text, "STARTCHAR ", 10) == 0) {
+            encoding = -1;
+            advance = -1;
+            row = 0;
+            in_bitmap = 0;
+        } else if (sscanf(text, "ENCODING %d", &encoding) == 1) {
+            continue;
+        } else if (sscanf(text, "DWIDTH %d", &advance) == 1) {
+            continue;
+        } else if (strncmp(text, "BITMAP", 6) == 0) {
+            in_bitmap = 1;
+            row = 0;
+        } else if (strncmp(text, "ENDCHAR", 7) == 0) {
+            if (encoding >= FONT_FIRST_CODEPOINT
+                && encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT
+                && advance > 0 && advance <= 255 && row == height) {
+                const unsigned index =
+                    (unsigned)(encoding - FONT_FIRST_CODEPOINT);
+                widths[index] = (uint8_t)advance;
+                complete[index] = 1;
+            }
+            in_bitmap = 0;
+        } else if (in_bitmap) {
+            char *end = NULL;
+            if (row >= height) goto fail;
+            const unsigned long value = strtoul(text, &end, 16);
+            if (end == text || value > 255) goto fail;
+            while (isspace((unsigned char)*end)) ++end;
+            if (*end != '\0') goto fail;
+            if (encoding >= FONT_FIRST_CODEPOINT
+                && encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT) {
+                const unsigned index =
+                    (unsigned)(encoding - FONT_FIRST_CODEPOINT);
+                bitmaps[index * height + row] = (uint8_t)value;
+            }
+            ++row;
+        }
+    }
+    fclose(file);
+
+    for (unsigned index = 0; index < FONT_GLYPH_COUNT; ++index) {
+        if (!complete[index]) goto invalid;
+    }
+    *bitmaps_out = bitmaps;
+    *widths_out = widths;
+    return 1;
+
+invalid:
+    SDL_free(bitmaps);
+    SDL_free(widths);
+    return 0;
+fail:
+    fclose(file);
+    SDL_free(bitmaps);
+    SDL_free(widths);
+    return 0;
+}
+
+static int pixelIsLit(SDL_Surface *surface, int x, int y) {
+    Uint8 r, g, b, a;
+    if (!SDL_ReadSurfacePixel(surface, x, y, &r, &g, &b, &a)) return 0;
+    return a != 0 && (r != 0 || g != 0 || b != 0);
+}
+
+static int parsePng(const char *path, unsigned cell_width, unsigned height,
+                    const uint8_t *original_widths,
+                    uint8_t **bitmaps_out, uint8_t **widths_out) {
+    SDL_Surface *surface = SDL_LoadPNG(path);
+    uint8_t *bitmaps = NULL;
+    uint8_t *widths = NULL;
+    const unsigned expected_width = 16 * (cell_width + 1) - 1;
+    const unsigned expected_height = 6 * (height + 1) - 1;
+
+    if (!surface) return 0;
+    if (cell_width == 0 || cell_width > 8 || height == 0
+        || surface->w < (int)expected_width
+        || surface->h < (int)expected_height) {
+        SDL_DestroySurface(surface);
+        return 0;
+    }
+
+    bitmaps = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, height);
+    widths = (uint8_t *)SDL_malloc(FONT_GLYPH_COUNT);
+    if (!bitmaps || !widths) goto fail;
+    memcpy(widths, original_widths, FONT_GLYPH_COUNT);
+
+    for (unsigned index = 0; index < FONT_GLYPH_COUNT; ++index) {
+        const unsigned x0 = (index % 16) * (cell_width + 1);
+        const unsigned y0 = (index / 16) * (height + 1);
+        for (unsigned y = 0; y < height; ++y) {
+            uint8_t bits = 0;
+            for (unsigned x = 0; x < cell_width; ++x) {
+                if (pixelIsLit(surface, (int)(x0 + x), (int)(y0 + y))) {
+                    bits |= (uint8_t)(0x80u >> x);
+                }
+            }
+            bitmaps[index * height + y] = bits;
+        }
+    }
+    SDL_DestroySurface(surface);
+    *bitmaps_out = bitmaps;
+    *widths_out = widths;
+    return 1;
+
+fail:
+    SDL_DestroySurface(surface);
+    SDL_free(bitmaps);
+    SDL_free(widths);
+    return 0;
+}
+
+int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
+                             unsigned height, const uint8_t *original_widths,
+                             BitmapFontReplacement *result) {
+    CachedFont *font;
+    char path[1024];
+
+    if (!result || !original_widths || font_id >= FONT_SLOT_COUNT
+        || cell_width == 0 || cell_width > 8 || height == 0) {
+        return 0;
+    }
+    result->bitmaps = NULL;
+    result->widths = NULL;
+    font = &g_fonts[font_id];
+    if (!font->tried) {
+        font->tried = 1;
+        if (replacementPath(font_id, "bdf", path, sizeof(path))) {
+            if (parseBdf(path, height, &font->bitmaps, &font->widths)) {
+                LogInfo(("asset replacement: loaded bitmap font %u from %s",
+                         font_id, path));
+            } else {
+                LogWarn(("asset replacement: rejected BDF font %u at %s",
+                         font_id, path));
+            }
+        }
+        if (!font->bitmaps
+            && replacementPath(font_id, "png", path, sizeof(path))) {
+            if (parsePng(path, cell_width, height, original_widths,
+                         &font->bitmaps, &font->widths)) {
+                LogInfo(("asset replacement: loaded bitmap font %u from %s",
+                         font_id, path));
+            } else {
+                LogWarn(("asset replacement: rejected PNG font %u at %s",
+                         font_id, path));
+            }
+        }
+    }
+    if (!font->bitmaps) return 0;
+    result->bitmaps = font->bitmaps;
+    result->widths = font->widths;
+    return 1;
+}
+
+void bitmapFontReplacementShutdown(void) {
+    for (unsigned index = 0; index < FONT_SLOT_COUNT; ++index) {
+        discardFont(&g_fonts[index]);
+        g_fonts[index].tried = 0;
+    }
+}

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -26,6 +26,7 @@ typedef struct CachedFont {
 
 static CachedFont g_fonts[FONT_SLOT_COUNT];
 
+/* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
 static int replacementPath(unsigned font_id, const char *extension,
                            char *path, size_t path_size) {
     char relative[64];
@@ -34,6 +35,7 @@ static int replacementPath(unsigned font_id, const char *extension,
     return findAssetReplacement(relative, path, path_size);
 }
 
+/* Release one decoded bitmap font replacement and clear its cached state. */
 static void discardFont(CachedFont *font) {
     SDL_free(font->bitmaps);
     SDL_free(font->widths);
@@ -41,6 +43,7 @@ static void discardFont(CachedFont *font) {
     font->widths = NULL;
 }
 
+/* Parse editable BDF glyph bitmaps and advances into the legacy font slot representation. */
 static int parseBdf(const char *path, unsigned height,
                     uint8_t **bitmaps_out, uint8_t **widths_out) {
     FILE *file = fopen(path, "rb");
@@ -119,12 +122,14 @@ fail:
     return 0;
 }
 
+/* Interpret one atlas pixel as foreground using alpha and luminance. */
 static int pixelIsLit(SDL_Surface *surface, int x, int y) {
     Uint8 r, g, b, a;
     if (!SDL_ReadSurfacePixel(surface, x, y, &r, &g, &b, &a)) return 0;
     return a != 0 && (r != 0 || g != 0 || b != 0);
 }
 
+/* Parse a replacement font atlas while preserving the established glyph-cell layout. */
 static int parsePng(const char *path, unsigned cell_width, unsigned height,
                     const uint8_t *original_widths,
                     uint8_t **bitmaps_out, uint8_t **widths_out) {
@@ -172,6 +177,7 @@ fail:
     return 0;
 }
 
+/* Load and cache the first available BDF or PNG replacement for a font slot. */
 int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
                              unsigned height, const uint8_t *original_widths,
                              BitmapFontReplacement *result) {
@@ -197,6 +203,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
             }
         }
         if (!font->bitmaps
+/* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
             && replacementPath(font_id, "png", path, sizeof(path))) {
             if (parsePng(path, cell_width, height, original_widths,
                          &font->bitmaps, &font->widths)) {
@@ -214,6 +221,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
     return 1;
 }
 
+/* Release all cached bitmap font replacements at renderer shutdown. */
 void bitmapFontReplacementShutdown(void) {
     for (unsigned index = 0; index < FONT_SLOT_COUNT; ++index) {
         discardFont(&g_fonts[index]);

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -193,6 +193,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
     font = &g_fonts[font_id];
     if (!font->tried) {
         font->tried = 1;
+        /* Prefer the editable BDF. Try the PNG font sheet only if no BDF loads. */
         if (replacementPath(font_id, "bdf", path, sizeof(path))) {
             if (parseBdf(path, height, &font->bitmaps, &font->widths)) {
                 LogInfo(("asset replacement: loaded bitmap font %u from %s",
@@ -202,9 +203,8 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
                          font_id, path));
             }
         }
-        if (!font->bitmaps
-/* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
-            && replacementPath(font_id, "png", path, sizeof(path))) {
+        if (!font->bitmaps &&
+            replacementPath(font_id, "png", path, sizeof(path))) {
             if (parsePng(path, cell_width, height, original_widths,
                          &font->bitmaps, &font->widths)) {
                 LogInfo(("asset replacement: loaded bitmap font %u from %s",

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -14,9 +14,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define FONT_SLOT_COUNT 8
-#define FONT_FIRST_CODEPOINT 0x20
-#define FONT_GLYPH_COUNT 96
+enum {
+    FONT_SLOT_COUNT = 8,
+    FONT_FIRST_CODEPOINT = 0x20,
+    FONT_GLYPH_COUNT = 96,
+    FONT_ROW_BITS = 8,
+    ATLAS_COLUMNS = 16,
+    ATLAS_ROWS = FONT_GLYPH_COUNT / ATLAS_COLUMNS,
+    ATLAS_GAP_PIXELS = 1
+};
 
 typedef struct CachedFont {
     uint8_t *bitmaps;
@@ -77,9 +83,10 @@ static int parseBdf(const char *path, unsigned height,
             in_bitmap = 1;
             row = 0;
         } else if (strncmp(text, "ENDCHAR", 7) == 0) {
-            if (encoding >= FONT_FIRST_CODEPOINT
-                && encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT
-                && advance > 0 && advance <= 255 && row == height) {
+            const bool supportedCodepoint = encoding >= FONT_FIRST_CODEPOINT &&
+                encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT;
+            const bool completeGlyph = advance > 0 && advance <= UINT8_MAX && row == height;
+            if (supportedCodepoint && completeGlyph) {
                 const unsigned index =
                     (unsigned)(encoding - FONT_FIRST_CODEPOINT);
                 widths[index] = (uint8_t)advance;
@@ -90,7 +97,7 @@ static int parseBdf(const char *path, unsigned height,
             char *end = NULL;
             if (row >= height) goto fail;
             const unsigned long value = strtoul(text, &end, 16);
-            if (end == text || value > 255) goto fail;
+            if (end == text || value > UINT8_MAX) goto fail;
             while (isspace((unsigned char)*end)) ++end;
             if (*end != '\0') goto fail;
             if (encoding >= FONT_FIRST_CODEPOINT
@@ -124,7 +131,7 @@ fail:
 
 /* Interpret one atlas pixel as foreground using alpha and luminance. */
 static int pixelIsLit(SDL_Surface *surface, int x, int y) {
-    Uint8 r, g, b, a;
+    Uint8 r = 0, g = 0, b = 0, a = 0;
     if (!SDL_ReadSurfacePixel(surface, x, y, &r, &g, &b, &a)) return 0;
     return a != 0 && (r != 0 || g != 0 || b != 0);
 }
@@ -136,11 +143,11 @@ static int parsePng(const char *path, unsigned cell_width, unsigned height,
     SDL_Surface *surface = SDL_LoadPNG(path);
     uint8_t *bitmaps = NULL;
     uint8_t *widths = NULL;
-    const unsigned expected_width = 16 * (cell_width + 1) - 1;
-    const unsigned expected_height = 6 * (height + 1) - 1;
+    const unsigned expected_width = ATLAS_COLUMNS * (cell_width + ATLAS_GAP_PIXELS) - ATLAS_GAP_PIXELS;
+    const unsigned expected_height = ATLAS_ROWS * (height + ATLAS_GAP_PIXELS) - ATLAS_GAP_PIXELS;
 
     if (!surface) return 0;
-    if (cell_width == 0 || cell_width > 8 || height == 0
+    if (cell_width == 0 || cell_width > FONT_ROW_BITS || height == 0
         || surface->w < (int)expected_width
         || surface->h < (int)expected_height) {
         SDL_DestroySurface(surface);
@@ -153,8 +160,8 @@ static int parsePng(const char *path, unsigned cell_width, unsigned height,
     memcpy(widths, original_widths, FONT_GLYPH_COUNT);
 
     for (unsigned index = 0; index < FONT_GLYPH_COUNT; ++index) {
-        const unsigned x0 = (index % 16) * (cell_width + 1);
-        const unsigned y0 = (index / 16) * (height + 1);
+        const unsigned x0 = (index % ATLAS_COLUMNS) * (cell_width + ATLAS_GAP_PIXELS);
+        const unsigned y0 = (index / ATLAS_COLUMNS) * (height + ATLAS_GAP_PIXELS);
         for (unsigned y = 0; y < height; ++y) {
             uint8_t bits = 0;
             for (unsigned x = 0; x < cell_width; ++x) {
@@ -185,7 +192,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
     char path[1024]{};
 
     if (!result || !original_widths || font_id >= FONT_SLOT_COUNT
-        || cell_width == 0 || cell_width > 8 || height == 0) {
+        || cell_width == 0 || cell_width > FONT_ROW_BITS || height == 0) {
         return 0;
     }
     result->bitmaps = NULL;

--- a/src/shared/bitmap_font_replacement.h
+++ b/src/shared/bitmap_font_replacement.h
@@ -1,0 +1,31 @@
+/*
+ * bitmap_font_replacement.h - Optional editable bitmap-font media.
+ */
+#ifndef BITMAP_FONT_REPLACEMENT_H
+#define BITMAP_FONT_REPLACEMENT_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct BitmapFontReplacement {
+    const uint8_t *bitmaps;
+    const uint8_t *widths;
+} BitmapFontReplacement;
+
+/*
+ * Load fonts/font_<id>.bdf, falling back to fonts/font_<id>.png.
+ * Replacement data retains the legacy 96-glyph, one-byte-per-row layout.
+ */
+int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
+                             unsigned height, const uint8_t *original_widths,
+                             BitmapFontReplacement *result);
+void bitmapFontReplacementShutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";

--- a/tests/bitmap_font_full_validation_tests.cpp
+++ b/tests/bitmap_font_full_validation_tests.cpp
@@ -1,0 +1,74 @@
+#include "gfx_impl.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const int fontIds[] = {0, 1, 3, 4, 5};
+
+    setReplacementRoot(&convertedRoot);
+    for (int fontId : fontIds) {
+        uint8 legacyBitmap[96 * 32] = {};
+        uint8 replacementBitmap[96 * 32] = {};
+        uint8 legacyWidths[96] = {};
+        uint8 replacementWidths[96] = {};
+        int legacyHeight = 0;
+        int legacyMaxWidth = 0;
+        int replacementHeight = 0;
+        int replacementMaxWidth = 0;
+
+        require(gfx_testCopyBuiltinFont(
+                    (uint16)fontId, legacyBitmap, sizeof(legacyBitmap),
+                    legacyWidths, sizeof(legacyWidths),
+                    &legacyHeight, &legacyMaxWidth),
+                "cannot read built-in font_" + std::to_string(fontId));
+        require(gfx_testCopyEffectiveFont(
+                    (uint16)fontId, replacementBitmap,
+                    sizeof(replacementBitmap), replacementWidths,
+                    sizeof(replacementWidths), &replacementHeight,
+                    &replacementMaxWidth),
+                "cannot load replacement font_" + std::to_string(fontId));
+        require(replacementHeight == legacyHeight &&
+                    replacementMaxWidth == legacyMaxWidth,
+                "font metrics differ for font_" + std::to_string(fontId));
+        require(std::memcmp(
+                    replacementWidths, legacyWidths, sizeof(legacyWidths)) == 0,
+                "glyph widths differ for font_" + std::to_string(fontId));
+        require(std::memcmp(replacementBitmap, legacyBitmap,
+                            (size_t)legacyHeight * 96u) == 0,
+                "glyph rows differ for font_" + std::to_string(fontId));
+    }
+
+    setReplacementRoot(nullptr);
+    std::cout << "bitmap_font_full_validation_tests compared "
+              << sizeof(fontIds) / sizeof(fontIds[0]) << " font slots\n";
+    return 0;
+}

--- a/tests/bitmap_font_replacement_behavior_tests.cpp
+++ b/tests/bitmap_font_replacement_behavior_tests.cpp
@@ -1,0 +1,95 @@
+#include "shared/bitmap_font_replacement.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+void writeBdf(const std::filesystem::path &path, bool complete) {
+    std::ofstream out(path);
+    out << "STARTFONT 2.1\n";
+    const int glyph_count = complete ? 96 : 95;
+    for (int index = 0; index < glyph_count; ++index) {
+        out << "STARTCHAR glyph\nENCODING " << 32 + index
+            << "\nDWIDTH " << 1 + index % 8
+            << " 0\nBBX 8 2 0 0\nBITMAP\n"
+            << (index == 0 ? "80\n40\n" : "00\n00\n")
+            << "ENDCHAR\n";
+    }
+    out << "ENDFONT\n";
+}
+
+void writePng(const std::filesystem::path &path) {
+    SDL_Surface *surface =
+        SDL_CreateSurface(16 * 9 - 1, 6 * 3 - 1, SDL_PIXELFORMAT_RGBA32);
+    require(surface != nullptr, "font PNG test surface is created");
+    SDL_FillSurfaceRect(surface, nullptr, 0);
+    require(SDL_WriteSurfacePixel(surface, 0, 0, 255, 255, 255, 255),
+            "font PNG test pixel is written");
+    require(SDL_SavePNG(surface, path.string().c_str()),
+            "font PNG test atlas is saved");
+    SDL_DestroySurface(surface);
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-font-tests";
+    const auto fonts = root / "fonts";
+    const auto bdf = fonts / "font_1.bdf";
+    const auto png = fonts / "font_1.png";
+    const uint8_t original_widths[96] = {4};
+    BitmapFontReplacement replacement = {};
+
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(fonts);
+    setReplacementRoot(root.string());
+    writeBdf(bdf, true);
+
+    require(bitmapFontReplacementGet(1, 8, 2, original_widths, &replacement),
+            "complete BDF loads");
+    require(replacement.bitmaps[0] == 0x80
+            && replacement.bitmaps[1] == 0x40,
+            "BDF bitmap rows retain their legacy byte layout");
+    require(replacement.widths[0] == 1 && replacement.widths[7] == 8,
+            "BDF advance widths replace the legacy table");
+
+    bitmapFontReplacementShutdown();
+    writeBdf(bdf, false);
+    writePng(png);
+    replacement = {};
+    require(bitmapFontReplacementGet(1, 8, 2, original_widths, &replacement),
+            "valid PNG is used when BDF is incomplete");
+    require(replacement.bitmaps[0] == 0x80,
+            "PNG atlas is converted to the legacy glyph-row layout");
+    require(replacement.widths[0] == original_widths[0],
+            "PNG atlas preserves original advance widths");
+
+    bitmapFontReplacementShutdown();
+    setReplacementRoot("");
+    std::filesystem::remove_all(root);
+    std::cout << "bitmap_font_replacement_behavior_tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- loads BDF fonts with PNG atlas fallback
- preserves the original 96-glyph bitmap layout and metrics
- leaves built-in fonts active when replacements are absent or invalid

## Dependencies

- #29
- companion converter: #28

## Validation

- all glyph rows and advance widths compared for font slots 0, 1, 3, 4, and 5

Split from #20.
