### PR TITLE
[review: high] 15. [custom] Load optional per-shape GLB models in OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ set(EGAME_SOURCES
     ${SRC_DIR}/eghudr.c
     ${SRC_DIR}/eg3drast.c
     ${SRC_DIR}/r3d.c
+    ${SRC_DIR}/r3d_replacement.c
     ${SRC_DIR}/r3d_sw.c
     ${SRC_DIR}/r3d_gl.c
     ${SRC_DIR}/r3dmesh.c
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(r3d_replacement_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,21 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(r3d_replacement_behavior_tests LINK_CORE)
+if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(r3d_replacement_full_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(r3d_replacement_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping 3D full validation: set F15SE2_ORIGINAL_ASSETS and "
+        "F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/src/eg3dproj.c
+++ b/src/eg3dproj.c
@@ -107,7 +107,7 @@ static void renderGridTile(int lod, int tileX, int tileY, int gridX, int gridY, 
             g_modelStreamPtr = g_world3dData + buf3d3[g_curTileEntry->shape];
         }
         {
-            R3DSubmit obj = {g_modelStreamPtr, 0, 0, 0,
+            R3DSubmit obj = {g_modelStreamPtr, -1, NULL, 0, 0, 0,
                              g_curTileEntry->x, g_curTileEntry->y, g_curTileEntry->z};
             r3d_submit(&obj);
         }
@@ -219,7 +219,7 @@ void projectObjects(int16 heading, int16 rangeGate, int32 worldX, int32 worldY, 
                             g_modelStreamPtr = g_world3dData + buf3d3[g_curTileEntry->shape];
                         }
                         {
-                            R3DSubmit obj = {g_modelStreamPtr, 0, 0, 0,
+                            R3DSubmit obj = {g_modelStreamPtr, -1, NULL, 0, 0, 0,
                                              g_curTileEntry->x, g_curTileEntry->y, g_curTileEntry->z};
                             r3d_submit(&obj);
                         }
@@ -232,7 +232,7 @@ void projectObjects(int16 heading, int16 rangeGate, int32 worldX, int32 worldY, 
                         g_modelStreamPtr = g_world3dData + buf3d3[g_curTileEntry->shape];
                         g_objColorBase = 0x400;
                         {
-                            R3DSubmit obj = {g_modelStreamPtr, 0, 0, 0,
+                            R3DSubmit obj = {g_modelStreamPtr, -1, NULL, 0, 0, 0,
                                              g_curTileEntry->x, g_curTileEntry->y, g_curTileEntry->z};
                             r3d_submit(&obj);
                         }

--- a/src/egmath.c
+++ b/src/egmath.c
@@ -21,15 +21,18 @@
 
 // ==== seg000:0xc8de ====
 
+/* Return whether a requested slot belongs to the separately loaded PHOTO shape table. */
 static int isPhotoShapeSlot(int shapeId) {
     return (shapeId & 0x100) && (shapeId & 0x7f) >= (int)size3d3;
 }
 
+/* Translate a legacy shape pointer into its stable replacement slot index. */
 static int replacementShapeSlot(int shapeId) {
     const int slot = shapeId & 0x7f;
     return isPhotoShapeSlot(shapeId) ? slot - (int)size3d3 : slot;
 }
 
+/* Return the legacy container name that owns a replacement shape pointer. */
 static const char *replacementShapeContainer(int shapeId) {
     if (isPhotoShapeSlot(shapeId)) return "PHOTO.3D3";
     return (shapeId & 0x100) ? regnStr : a15flt_xxx;

--- a/src/egmath.c
+++ b/src/egmath.c
@@ -21,6 +21,20 @@
 
 // ==== seg000:0xc8de ====
 
+static int isPhotoShapeSlot(int shapeId) {
+    return (shapeId & 0x100) && (shapeId & 0x7f) >= (int)size3d3;
+}
+
+static int replacementShapeSlot(int shapeId) {
+    const int slot = shapeId & 0x7f;
+    return isPhotoShapeSlot(shapeId) ? slot - (int)size3d3 : slot;
+}
+
+static const char *replacementShapeContainer(int shapeId) {
+    if (isPhotoShapeSlot(shapeId)) return "PHOTO.3D3";
+    return (shapeId & 0x100) ? regnStr : a15flt_xxx;
+}
+
 void load15Flt3d3() {
     int16 bytesLeft, chunkSize;
     struct SREGS segs;
@@ -109,7 +123,10 @@ static void drawWorldObjectCore(int16 shapeId, int isShadow,
             setViewPositionFrac(vfx, vfy, vfz);
             g_curLod = 1;
             {
-                R3DSubmit obj = {g_world3dData + dataOff, -objYaw, objPitch, objRoll,
+                R3DSubmit obj = {g_world3dData + dataOff,
+                                 replacementShapeSlot(shapeId),
+                                 replacementShapeContainer(shapeId),
+                                 -objYaw, objPitch, objRoll,
                                  (int16)relX, -(int16)relY, altitude != 0, isShadow};
                 r3d_submit(&obj);
             }
@@ -344,7 +361,10 @@ void drawTargetView(int shapeId, int32 worldX, int32 worldY, int altitude, int o
     g_offscreenRender = 1;
     {
         R3DScene scene = {g_targetViewParams, -g_trkBearing, g_trkPitch, g_trkRoll, 0, 0, 0, 0};
-        R3DSubmit obj = {g_world3dData + dataOff, -objYaw, objPitch, objRoll, relX, -relY, relZ};
+        R3DSubmit obj = {g_world3dData + dataOff,
+                         replacementShapeSlot(shapeId),
+                         replacementShapeContainer(shapeId),
+                         -objYaw, objPitch, objRoll, relX, -relY, relZ};
         r3d_beginScene(&scene);
         /* after beginScene: setup3DTransform's setViewPosition cleared the frac */
         setViewPositionFrac(fracX, fracY, fracZ);

--- a/src/r3d.h
+++ b/src/r3d.h
@@ -47,6 +47,8 @@ typedef struct {
  * normal object. */
 typedef struct {
     R3DMesh mesh;
+    int shapeId;
+    const char *containerLegacyName;
     int yaw, pitch, roll;
     int posX, posY, posZ;
     int shadow;

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -139,6 +139,79 @@ static void fillPools(MeshVtxPools *pools) {
     pools->nZ = (int)size3d3_6;
 }
 
+#ifdef DEBUG
+int r3dgl_testLegacyShapeStats(const unsigned char *legacyModel,
+                               size_t legacyModelSize,
+                               R3DLegacyShapeStats *stats) {
+    MeshVtxPools pools;
+    Mesh decoded;
+    MeshLod *lod;
+
+    if (!legacyModel || !stats || legacyModelSize == 0 ||
+        legacyModelSize > WORLD3D_DATA_SIZE) {
+        return 0;
+    }
+    memset(stats, 0, sizeof(*stats));
+    memset(g_world3dData, 0, WORLD3D_DATA_SIZE);
+    memcpy(g_world3dData, legacyModel, legacyModelSize);
+    fillPools(&pools);
+    if (r3dmesh_decode((const uint8 *)g_world3dData,
+                       (const uint8 *)g_world3dData + legacyModelSize,
+                       &pools, colorLut, &decoded) < 0) {
+        return 0;
+    }
+    lod = &decoded.lods[0];
+    stats->form = lod->form;
+    if (lod->form == MESH_FORM_POINT) {
+        stats->renderable = 1;
+        stats->points = 1;
+        stats->pointColors[lod->pointColor] = 1;
+        return 1;
+    }
+    if (lod->form == MESH_FORM_EDGERUN) {
+        stats->renderable = lod->nRunRefs > 0;
+        stats->points = lod->nRunRefs;
+        stats->pointColors[lod->pointColor] = lod->nRunRefs;
+        return 1;
+    }
+    if (lod->form != MESH_FORM_MODEL) return 1;
+
+    for (int i = 0; i < lod->nFaces; ++i) {
+        MeshFace *face = &lod->faces[i];
+        if (face->nEdges < 3 || face->colorByte == 0xff) continue;
+        const int triangleCount = (int)face->nEdges - 2;
+        stats->renderable = 1;
+        stats->triangles += triangleCount;
+        stats->faceColors[face->colorByte] += triangleCount;
+        for (int edgeIndex = 0; edgeIndex < face->nEdges; ++edgeIndex) {
+            MeshEdge *edge = &lod->edges[face->edge[edgeIndex]];
+            if (edge->va == edge->vb) {
+                ++stats->points;
+                ++stats->pointColors[face->colorByte];
+            } else {
+                ++stats->maximumLines;
+                ++stats->maximumLineColors[face->colorByte];
+            }
+        }
+    }
+    for (int i = 0; i < lod->nLines; ++i) {
+        MeshLine *line = &lod->lines[i];
+        MeshEdge *edge = &lod->edges[line->edge];
+        stats->renderable = 1;
+        if (edge->va == edge->vb) {
+            ++stats->points;
+            ++stats->pointColors[line->colorByte];
+        } else {
+            ++stats->minimumLines;
+            ++stats->maximumLines;
+            ++stats->minimumLineColors[line->colorByte];
+            ++stats->maximumLineColors[line->colorByte];
+        }
+    }
+    return 1;
+}
+#endif
+
 /* ---- scene state -------------------------------------------------------- */
 
 static int s_sceneRendered;  /* a GL 3D view was drawn this frame (live under the present) */

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -1181,7 +1181,7 @@ static void drawSub(const GlSub *r) {
 
     if (replacement) {
         drawReplacementSub(r, replacement);
-        return{};
+        return;
     }
 
     fillPools(&pools);

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -30,6 +30,7 @@
 #include "r3d_gl.h"
 #include "r2d.h"
 #include "r3dmesh.h"
+#include "r3d_replacement.h"
 #include "gfx_impl.h"
 #include "eg3dmap.h"
 #include "egcode.h"
@@ -195,6 +196,8 @@ static float s_vpW, s_vpH;   /* active 3D viewport size in window pixels (screen
  * original look, the later draw winning at equal depth. */
 typedef struct {
     char *model;
+    int shapeId;
+    const char *containerLegacyName;
     int16 combined[9];
     long camBase, camX, camY; /* camera-space origin axes (screen-X, screen-Y, depth) */
     int shade, colorBase, curLod;
@@ -387,7 +390,7 @@ static void fogVertex(float x, float y, float z) {
 static const char *gl_name(void) { return "opengl1"; }
 
 static int gl_init(void) { return s_active; } /* claims iff the context came up */
-static void gl_shutdown(void) {}
+static void gl_shutdown(void) { r3dReplacementShutdown(); }
 
 static R3DMesh gl_registerMesh(R3DMesh raw) { return raw; } /* decoded per submit */
 static void gl_releaseMesh(R3DMesh mesh) { (void)mesh; }
@@ -853,6 +856,8 @@ static void gl_submit(const R3DSubmit *o) {
 
     r = &s_subs[s_nSub];
     r->model = (char *)o->mesh;
+    r->shapeId = o->shapeId;
+    r->containerLegacyName = o->containerLegacyName;
     for (i = 0; i < 9; i++) r->combined[i] = combined[i];
     r->camBase = camBase;
     r->camX = camTransX;
@@ -965,20 +970,125 @@ static void drawDepthPoint(float x, float y, long depth32, int colorIdx) {
     glEnd();
 }
 
+/* Replacement and legacy shadows use the same opacity and ground-plane lift. */
+static const float GL_SHADOW_ALPHA = 0.4f;
+static const float GL_SHADOW_RAISE_FRAC = 0.25f;
+
+static void drawReplacementSub(const GlSub *submission,
+                               const R3DReplacementMesh *mesh) {
+    const int lod_shift = 8 - 2 * submission->curLod;
+    const int shift = lod_shift > 0 ? lod_shift : 0;
+    const float scale = (float)(1 << shift);
+    float matrix[9];
+    float shadow_nx = 0.0f, shadow_ny = 0.0f, shadow_nz = 0.0f;
+    float shadow_ox = 0.0f, shadow_oy = 0.0f, shadow_oz = 0.0f;
+    float shadow_lift_x = 0.0f, shadow_lift_y = 0.0f;
+    float shadow_lift_z = 0.0f;
+    for (int index = 0; index < 9; ++index) {
+        matrix[index] = (float)submission->combined[index];
+    }
+
+    if (submission->shadow) {
+        shadow_nx = (float)g_viewRotMatrix[3];
+        shadow_ny = (float)g_viewRotMatrix[4];
+        shadow_nz = (float)g_viewRotMatrix[5];
+        const float normal_length = SDL_sqrtf(
+            shadow_nx * shadow_nx + shadow_ny * shadow_ny
+            + shadow_nz * shadow_nz);
+        if (normal_length > 1e-3f) {
+            shadow_nx /= normal_length;
+            shadow_ny /= normal_length;
+            shadow_nz /= normal_length;
+        }
+        shadow_ox = (float)submission->camBase / scale;
+        shadow_oy = (float)submission->camX / scale;
+        shadow_oz = (float)submission->camY / scale;
+        float maximum_height = 0.0f;
+        for (int primitive_index = 0;
+             primitive_index < mesh->nPrims; ++primitive_index) {
+            const R3DReplacementPrim *primitive =
+                &mesh->prims[primitive_index];
+            for (int vertex = 0; vertex < primitive->nVerts; ++vertex) {
+                const float x = primitive->xyz[vertex * 3];
+                const float y = primitive->xyz[vertex * 3 + 1];
+                const float z = primitive->xyz[vertex * 3 + 2];
+                const float camera_x =
+                    (2.0f * (matrix[0] * x + matrix[3] * z
+                             + matrix[6] * y)
+                     + (float)submission->camBase) / scale;
+                const float camera_y =
+                    (2.0f * (matrix[1] * x + matrix[4] * z
+                             + matrix[7] * y)
+                     + (float)submission->camX) / scale;
+                const float depth =
+                    (2.0f * (matrix[2] * x + matrix[5] * z
+                             + matrix[8] * y)
+                     + (float)submission->camY) / scale;
+                float height =
+                    (camera_x - shadow_ox) * shadow_nx
+                    + (camera_y - shadow_oy) * shadow_ny
+                    + (depth - shadow_oz) * shadow_nz;
+                if (height < 0.0f) height = -height;
+                if (height > maximum_height) maximum_height = height;
+            }
+        }
+        const float raise =
+            (shadow_nz > 0.0f ? -GL_SHADOW_RAISE_FRAC
+                              : GL_SHADOW_RAISE_FRAC)
+            * maximum_height;
+        shadow_lift_x = raise * shadow_nx;
+        shadow_lift_y = raise * shadow_ny;
+        shadow_lift_z = raise * shadow_nz;
+    }
+
+    for (int primitive_index = 0;
+         primitive_index < mesh->nPrims; ++primitive_index) {
+        const R3DReplacementPrim *primitive =
+            &mesh->prims[primitive_index];
+        if (submission->shadow && primitive->mode != 4) continue;
+        const GLenum mode = primitive->mode == 4 ? GL_TRIANGLES
+                          : primitive->mode == 1 ? GL_LINES : GL_POINTS;
+        if (submission->shadow) {
+            glColor4f(0.0f, 0.0f, 0.0f, GL_SHADOW_ALPHA);
+        } else {
+            paintBias();
+            glColor4fv(primitive->rgba);
+        }
+        if (mode == GL_POINTS) {
+            glPointSize(s_pixelScale > 1.0f ? s_pixelScale : 1.0f);
+        }
+        glBegin(mode);
+        for (int vertex = 0; vertex < primitive->nVerts; ++vertex) {
+            const float x = primitive->xyz[vertex * 3];
+            const float y = primitive->xyz[vertex * 3 + 1];
+            const float z = primitive->xyz[vertex * 3 + 2];
+            float camera_x =
+                (2.0f * (matrix[0] * x + matrix[3] * z + matrix[6] * y)
+                 + (float)submission->camBase) / scale;
+            float camera_y =
+                (2.0f * (matrix[1] * x + matrix[4] * z + matrix[7] * y)
+                 + (float)submission->camX) / scale;
+            float depth =
+                (2.0f * (matrix[2] * x + matrix[5] * z + matrix[8] * y)
+                 + (float)submission->camY) / scale;
+            if (submission->shadow) {
+                const float distance =
+                    (camera_x - shadow_ox) * shadow_nx
+                    + (camera_y - shadow_oy) * shadow_ny
+                    + (depth - shadow_oz) * shadow_nz;
+                camera_x += shadow_lift_x - distance * shadow_nx;
+                camera_y += shadow_lift_y - distance * shadow_ny;
+                depth += shadow_lift_z - distance * shadow_nz;
+            }
+            fogVertex(camera_x, camera_y, depth / 65536.0f);
+        }
+        glEnd();
+    }
+}
+
 /* Decode + transform + draw one object (painter's order; z-buffer on, GL_LEQUAL,
  * per-draw polygon offset set by the caller). Re-decodes the mesh (cheap; avoids
  * caching across region reloads). */
-/* Aircraft ground-shadow opacity (translucent black, GL_SRC_ALPHA blend). Lower =
- * fainter. A silhouette flattened from a real 3D model self-overlaps slightly (tail
- * over fuselage), so keep it below 0.5 or the overlaps read as a darker core. */
-static const float GL_SHADOW_ALPHA = 0.4f;
-
-/* Lift the flattened shadow toward the camera by this fraction of the model's own
- * camera-space height, so it clears the ground surface it lies on instead of
- * z-fighting it. Self-scaling (a far, small shadow lifts less) and small enough that
- * the float above the ground is imperceptible from a cockpit view. */
-static const float GL_SHADOW_RAISE_FRAC = 0.25f;
-
 static void drawSub(const GlSub *r) {
     MeshVtxPools pools;
     MeshLod *l;
@@ -992,6 +1102,13 @@ static void drawSub(const GlSub *r) {
     float snx = 0, sny = 0, snz = 0, sox = 0, soy = 0, soz = 0;
     float srvx = 0, srvy = 0, srvz = 0;
     static float vx_[R3DMESH_MAX_VERTS], vy_[R3DMESH_MAX_VERTS], vd_[R3DMESH_MAX_VERTS];
+    R3DReplacementMesh *replacement =
+        r3dReplacementMesh(r->containerLegacyName, r->shapeId);
+
+    if (replacement) {
+        drawReplacementSub(r, replacement);
+        return;
+    }
 
     fillPools(&pools);
     if (r3dmesh_decode((const uint8 *)r->model,

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -1047,6 +1047,7 @@ static void drawDepthPoint(float x, float y, long depth32, int colorIdx) {
 static const float GL_SHADOW_ALPHA = 0.4f;
 static const float GL_SHADOW_RAISE_FRAC = 0.25f;
 
+/* Submit one replacement mesh with the same transform and primitive order as the legacy shape. */
 static void drawReplacementSub(const GlSub *submission,
                                const R3DReplacementMesh *mesh) {
     const int lod_shift = 8 - 2 * submission->curLod;

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -143,9 +143,9 @@ static void fillPools(MeshVtxPools *pools) {
 int r3dgl_testLegacyShapeStats(const unsigned char *legacyModel,
                                size_t legacyModelSize,
                                R3DLegacyShapeStats *stats) {
-    MeshVtxPools pools;
-    Mesh decoded;
-    MeshLod *lod;
+    MeshVtxPools pools{};
+    Mesh decoded{};
+    MeshLod *lod{};
 
     if (!legacyModel || !stats || legacyModelSize == 0 ||
         legacyModelSize > WORLD3D_DATA_SIZE) {
@@ -1053,7 +1053,7 @@ static void drawReplacementSub(const GlSub *submission,
     const int lod_shift = 8 - 2 * submission->curLod;
     const int shift = lod_shift > 0 ? lod_shift : 0;
     const float scale = (float)(1 << shift);
-    float matrix[9];
+    float matrix[9]{};
     float shadow_nx = 0.0f, shadow_ny = 0.0f, shadow_nz = 0.0f;
     float shadow_ox = 0.0f, shadow_oy = 0.0f, shadow_oz = 0.0f;
     float shadow_lift_x = 0.0f, shadow_lift_y = 0.0f;
@@ -1181,7 +1181,7 @@ static void drawSub(const GlSub *r) {
 
     if (replacement) {
         drawReplacementSub(r, replacement);
-        return;
+        return{};
     }
 
     fillPools(&pools);

--- a/src/r3d_gl.h
+++ b/src/r3d_gl.h
@@ -1,6 +1,8 @@
 #ifndef R3D_GL_H
 #define R3D_GL_H
 
+#include <stddef.h>
+
 /*
  * OpenGL 1.x backend support hooks consumed by the graphics layer (gfx_impl.c).
  *
@@ -15,6 +17,25 @@
 struct SDL_Window;
 struct SDL_Surface;
 typedef struct R2DImage R2DImage;
+
+#ifdef DEBUG
+typedef struct R3DLegacyShapeStats {
+    int form;
+    int renderable;
+    int triangles;
+    int minimumLines;
+    int maximumLines;
+    int points;
+    int faceColors[256];
+    int minimumLineColors[256];
+    int maximumLineColors[256];
+    int pointColors[256];
+} R3DLegacyShapeStats;
+
+int r3dgl_testLegacyShapeStats(const unsigned char *legacyModel,
+                               size_t legacyModelSize,
+                               R3DLegacyShapeStats *stats);
+#endif
 
 /* Whether to bring a GL window/context up (GL is the auto preference, or forced
  * via F15_RENDER=gl). Checked by gfx_impl.c before window creation so it can

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -32,12 +32,14 @@ typedef struct CachedMesh {
 
 static std::vector<CachedMesh *> g_cache;
 
+/* Fold one ASCII byte for DOS-compatible case-insensitive filename comparison. */
 static std::string lower(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(),
                    [](unsigned char c) { return (char)std::tolower(c); });
     return value;
 }
 
+/* Find one child entry case-insensitively beneath a replacement directory. */
 static fs::path findChildCaseInsensitive(const fs::path &parent,
                                          const std::string &name) {
     std::error_code error;
@@ -52,6 +54,7 @@ static fs::path findChildCaseInsensitive(const fs::path &parent,
     return {};
 }
 
+/* Return the configured replacement root, or NULL when replacements are disabled. */
 static fs::path replacementRoot(void) {
     const char *root = std::getenv("F15_REPLACEMENT_ROOT");
     if (!root || !root[0]) return {};
@@ -60,6 +63,7 @@ static fs::path replacementRoot(void) {
     return fs::is_directory(path, error) ? path : fs::path();
 }
 
+/* Resolve the self-contained directory that owns a legacy 3D shape table. */
 static fs::path shapeDirectory(const char *container_name) {
     fs::path root = replacementRoot();
     if (root.empty() || !container_name || !container_name[0]) return {};
@@ -79,6 +83,7 @@ static fs::path shapeDirectory(const char *container_name) {
     return {};
 }
 
+/* Find a per-shape GLB replacement by stable slot prefix and optional descriptive suffix. */
 static fs::path findShapeFile(const fs::path &directory, int shape_id,
                               const char *extension) {
     char exact[64];
@@ -98,6 +103,7 @@ static fs::path findShapeFile(const fs::path &directory, int shape_id,
         const std::string filename = lower(entry.path().filename().string());
         if (filename == exact_lower) return entry.path();
         if (filename.rfind(prefix_lower, 0) == 0
+/* Fold one ASCII byte for DOS-compatible case-insensitive filename comparison. */
             && lower(entry.path().extension().string()) == extension_lower) {
             matches.push_back(entry.path());
         }
@@ -111,21 +117,25 @@ static fs::path findShapeFile(const fs::path &directory, int shape_id,
     return matches.empty() ? fs::path() : matches.front();
 }
 
+/* Read an unsigned 32-bit little-endian cache value. */
 static uint32 readU32(const uint8 *bytes) {
     return (uint32)bytes[0] | ((uint32)bytes[1] << 8)
          | ((uint32)bytes[2] << 16) | ((uint32)bytes[3] << 24);
 }
 
+/* Read a signed 32-bit little-endian cache value. */
 static int32 readS32(const uint8 *bytes) {
     return (int32)readU32(bytes);
 }
 
+/* Read a little-endian IEEE-754 cache value. */
 static float readF32(const uint8 *bytes) {
     float value;
     std::memcpy(&value, bytes, sizeof(value));
     return value;
 }
 
+/* Release all allocations owned by one decoded replacement mesh. */
 static void freeMesh(R3DReplacementMesh *mesh) {
     if (!mesh) return;
     for (int index = 0; index < mesh->nPrims; ++index) {
@@ -136,6 +146,7 @@ static void freeMesh(R3DReplacementMesh *mesh) {
     mesh->nPrims = 0;
 }
 
+/* Decode a validated runtime mesh cache while preserving primitive order and colors. */
 static int parseGlmesh(R3DReplacementMesh *mesh, const uint8 *data,
                        size_t size) {
     size_t position = 44;
@@ -192,6 +203,7 @@ fail:
     return 0;
 }
 
+/* Read a complete file into an owned byte buffer. */
 static std::vector<uint8> readBytes(const fs::path &path) {
     std::vector<uint8> bytes;
     std::error_code error;
@@ -207,6 +219,7 @@ static std::vector<uint8> readBytes(const fs::path &path) {
     return bytes;
 }
 
+/* Write a complete byte buffer atomically enough for the disposable cache contract. */
 static int writeBytes(const fs::path &path, const std::vector<uint8> &bytes) {
     std::error_code error;
     fs::create_directories(path.parent_path(), error);
@@ -217,6 +230,7 @@ static int writeBytes(const fs::path &path, const std::vector<uint8> &bytes) {
     return std::fclose(file) == 0 && written;
 }
 
+/* Quote one path safely for the explicitly configured external asset-tool command. */
 static std::string shellQuote(const std::string &value) {
 #if defined(_WIN32)
     std::string quoted = "\"";
@@ -229,6 +243,7 @@ static std::string shellQuote(const std::string &value) {
 #endif
 }
 
+/* Return the configured converter command used to compile GLB cache files. */
 static std::string assetTool(void) {
     const char *configured = std::getenv("F15_ASSET_TOOL");
     if (configured && configured[0]) return configured;
@@ -245,6 +260,7 @@ static std::string assetTool(void) {
     return {};
 }
 
+/* Compile an edited GLB into a disposable runtime mesh cache. */
 static std::vector<uint8> buildCache(const fs::path &glb_path) {
     std::vector<uint8> bytes;
     bool too_large = false;
@@ -283,6 +299,7 @@ static std::vector<uint8> buildCache(const fs::path &glb_path) {
     return bytes;
 }
 
+/* Verify that cache identity metadata matches the current editable GLB. */
 static int cacheMatchesGlb(const std::vector<uint8> &bytes,
                            const fs::path &glb) {
     if (bytes.size() < 44 || std::memcmp(bytes.data(), "F15GLM3", 7) != 0) {
@@ -292,6 +309,7 @@ static int cacheMatchesGlb(const std::vector<uint8> &bytes,
     return expected == QuickDigest5::fileToHash(glb.string());
 }
 
+/* Return whether an existing runtime cache is current and structurally loadable. */
 static int cacheIsUsable(const std::vector<uint8> &bytes,
                          const fs::path &glb) {
     R3DReplacementMesh parsed = {};
@@ -302,6 +320,7 @@ static int cacheIsUsable(const std::vector<uint8> &bytes,
     return usable;
 }
 
+/* Load one per-shape replacement, rebuilding its cache only when required. */
 static R3DReplacementMesh *loadShape(const char *container_name,
                                      int shape_id,
                                      const std::string &request_key) {
@@ -353,6 +372,7 @@ static R3DReplacementMesh *loadShape(const char *container_name,
     return &entry->mesh;
 }
 
+/* Return the lazily loaded replacement mesh for a legacy container and slot. */
 R3DReplacementMesh *r3dReplacementMesh(const char *container_name,
                                        int shape_id) {
     if (!container_name || shape_id < 0 || shape_id > 999) return NULL;
@@ -374,6 +394,7 @@ R3DReplacementMesh *r3dReplacementMesh(const char *container_name,
     return NULL;
 }
 
+/* Release every cached replacement mesh at renderer shutdown. */
 void r3dReplacementShutdown(void) {
     for (CachedMesh *entry : g_cache) {
         freeMesh(&entry->mesh);

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -247,6 +247,7 @@ static std::string assetTool(void) {
 
 static std::vector<uint8> buildCache(const fs::path &glb_path) {
     std::vector<uint8> bytes;
+    bool too_large = false;
     const std::string tool = assetTool();
     if (tool.empty()) return bytes;
     const std::string command =
@@ -260,18 +261,25 @@ static std::vector<uint8> buildCache(const fs::path &glb_path) {
     uint8 chunk[4096];
     size_t count;
     while ((count = std::fread(chunk, 1, sizeof(chunk), pipe)) != 0) {
-        if (bytes.size() + count > 16 * 1024 * 1024) {
+        if (!too_large && count > 16 * 1024 * 1024 - bytes.size()) {
+            /*
+             * Keep draining the child after crossing the limit. Calling pclose
+             * with unread pipe data can deadlock while the converter is blocked
+             * writing the remainder.
+             */
+            too_large = true;
             bytes.clear();
-            break;
+        } else if (!too_large) {
+            bytes.insert(bytes.end(), chunk, chunk + count);
         }
-        bytes.insert(bytes.end(), chunk, chunk + count);
     }
+    const int read_failed = std::ferror(pipe) != 0;
 #if defined(_WIN32)
     const int status = _pclose(pipe);
 #else
     const int status = pclose(pipe);
 #endif
-    if (status != 0) bytes.clear();
+    if (status != 0 || read_failed || too_large) bytes.clear();
     return bytes;
 }
 

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -63,7 +63,17 @@ static fs::path replacementRoot(void) {
 static fs::path shapeDirectory(const char *container_name) {
     fs::path root = replacementRoot();
     if (root.empty() || !container_name || !container_name[0]) return {};
-    const std::string stem = fs::path(container_name).stem().string();
+    std::string stem = fs::path(container_name).stem().string();
+    const std::string normalized = lower(stem);
+
+    /* The original runtime uses short theater filenames, while the converter
+     * gives their replacement directories descriptive campaign names. */
+    if (normalized == "lb") {
+        stem = "LIBYA";
+    } else if (normalized == "pg") {
+        stem = "GULF";
+    }
+
     fs::path directory = findChildCaseInsensitive(root, stem);
     if (!directory.empty() && fs::is_directory(directory)) return directory;
     return {};

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -1,0 +1,365 @@
+/*
+ * r3d_replacement.c - Per-shape GLB discovery and GLMESH cache loading.
+ *
+ * GLB remains the editable source. The converter reduces it to a deliberately
+ * small binary cache so the game does not need a general JSON/glTF stack.
+ */
+
+#include "r3d_replacement.h"
+
+#include "log.h"
+
+#include <SDL3/SDL.h>
+#include <quickdigest5.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+typedef struct CachedMesh {
+    std::string key;
+    R3DReplacementMesh mesh;
+    int loaded;
+} CachedMesh;
+
+static std::vector<CachedMesh *> g_cache;
+
+static std::string lower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return (char)std::tolower(c); });
+    return value;
+}
+
+static fs::path findChildCaseInsensitive(const fs::path &parent,
+                                         const std::string &name) {
+    std::error_code error;
+    if (!fs::is_directory(parent, error)) return {};
+    const std::string wanted = lower(name);
+    for (const fs::directory_entry &entry : fs::directory_iterator(parent, error)) {
+        if (error) break;
+        if (lower(entry.path().filename().string()) == wanted) {
+            return entry.path();
+        }
+    }
+    return {};
+}
+
+static fs::path replacementRoot(void) {
+    const char *root = std::getenv("F15_REPLACEMENT_ROOT");
+    if (!root || !root[0]) return {};
+    std::error_code error;
+    fs::path path(root);
+    return fs::is_directory(path, error) ? path : fs::path();
+}
+
+static fs::path shapeDirectory(const char *container_name) {
+    fs::path root = replacementRoot();
+    if (root.empty() || !container_name || !container_name[0]) return {};
+    const std::string stem = fs::path(container_name).stem().string();
+    fs::path directory = findChildCaseInsensitive(root, stem);
+    if (!directory.empty() && fs::is_directory(directory)) return directory;
+    return {};
+}
+
+static fs::path findShapeFile(const fs::path &directory, int shape_id,
+                              const char *extension) {
+    char exact[64];
+    char prefix[64];
+    std::vector<fs::path> matches;
+    std::error_code error;
+    std::snprintf(exact, sizeof(exact), "shape_%03d%s", shape_id, extension);
+    std::snprintf(prefix, sizeof(prefix), "shape_%03d_", shape_id);
+    const std::string exact_lower = lower(exact);
+    const std::string prefix_lower = lower(prefix);
+    const std::string extension_lower = lower(extension);
+
+    if (!fs::is_directory(directory, error)) return {};
+    for (const fs::directory_entry &entry :
+         fs::directory_iterator(directory, error)) {
+        if (error || !entry.is_regular_file()) continue;
+        const std::string filename = lower(entry.path().filename().string());
+        if (filename == exact_lower) return entry.path();
+        if (filename.rfind(prefix_lower, 0) == 0
+            && lower(entry.path().extension().string()) == extension_lower) {
+            matches.push_back(entry.path());
+        }
+    }
+    std::sort(matches.begin(), matches.end());
+    if (matches.size() > 1) {
+        LogWarn(("asset replacement: ambiguous shape %d (%zu matching %s files)",
+                 shape_id, matches.size(), extension));
+        return {};
+    }
+    return matches.empty() ? fs::path() : matches.front();
+}
+
+static uint32 readU32(const uint8 *bytes) {
+    return (uint32)bytes[0] | ((uint32)bytes[1] << 8)
+         | ((uint32)bytes[2] << 16) | ((uint32)bytes[3] << 24);
+}
+
+static int32 readS32(const uint8 *bytes) {
+    return (int32)readU32(bytes);
+}
+
+static float readF32(const uint8 *bytes) {
+    float value;
+    std::memcpy(&value, bytes, sizeof(value));
+    return value;
+}
+
+static void freeMesh(R3DReplacementMesh *mesh) {
+    if (!mesh) return;
+    for (int index = 0; index < mesh->nPrims; ++index) {
+        SDL_free(mesh->prims[index].xyz);
+    }
+    SDL_free(mesh->prims);
+    mesh->prims = NULL;
+    mesh->nPrims = 0;
+}
+
+static int parseGlmesh(R3DReplacementMesh *mesh, const uint8 *data,
+                       size_t size) {
+    size_t position = 44;
+    if (!mesh || !data || size < position
+        || std::memcmp(data, "F15GLM3", 7) != 0) {
+        return 0;
+    }
+    const uint32 primitive_count = readU32(data + 40);
+    if (primitive_count == 0 || primitive_count > 4096) return 0;
+    mesh->prims = (R3DReplacementPrim *)SDL_calloc(
+        primitive_count, sizeof(*mesh->prims));
+    if (!mesh->prims) return 0;
+    mesh->nPrims = (int)primitive_count;
+
+    for (uint32 index = 0; index < primitive_count; ++index) {
+        R3DReplacementPrim *primitive = &mesh->prims[index];
+        if (position > size || size - position < 40) goto fail;
+        primitive->mode = (int)readU32(data + position);
+        primitive->nVerts = (int)readU32(data + position + 4);
+        primitive->sourceKind = (int)readU32(data + position + 8);
+        primitive->sourceIndex = (int)readS32(data + position + 12);
+        primitive->sourceColor = (int)readS32(data + position + 16);
+        primitive->sourceFlags = readU32(data + position + 20);
+        for (int channel = 0; channel < 4; ++channel) {
+            primitive->rgba[channel] =
+                readF32(data + position + 24 + channel * 4);
+            if (!std::isfinite(primitive->rgba[channel])) goto fail;
+        }
+        position += 40;
+
+        if (primitive->nVerts <= 0 || primitive->nVerts > 65536
+            || (primitive->mode != 4 && primitive->mode != 1
+                && primitive->mode != 0)
+            || (primitive->mode == 4 && primitive->nVerts % 3 != 0)
+            || (primitive->mode == 1 && primitive->nVerts % 2 != 0)) {
+            goto fail;
+        }
+        const size_t float_count = (size_t)primitive->nVerts * 3;
+        if (position > size || float_count > (size - position) / 4) goto fail;
+        primitive->xyz =
+            (float *)SDL_malloc(float_count * sizeof(float));
+        if (!primitive->xyz) goto fail;
+        for (size_t value_index = 0; value_index < float_count; ++value_index) {
+            primitive->xyz[value_index] = readF32(data + position);
+            if (!std::isfinite(primitive->xyz[value_index])) goto fail;
+            position += 4;
+        }
+    }
+    if (position != size) goto fail;
+    return 1;
+
+fail:
+    freeMesh(mesh);
+    return 0;
+}
+
+static std::vector<uint8> readBytes(const fs::path &path) {
+    std::vector<uint8> bytes;
+    std::error_code error;
+    const uintmax_t length = fs::file_size(path, error);
+    if (error || length == 0 || length > 16 * 1024 * 1024) return bytes;
+    FILE *file = std::fopen(path.string().c_str(), "rb");
+    if (!file) return bytes;
+    bytes.resize((size_t)length);
+    if (std::fread(bytes.data(), 1, bytes.size(), file) != bytes.size()) {
+        bytes.clear();
+    }
+    std::fclose(file);
+    return bytes;
+}
+
+static int writeBytes(const fs::path &path, const std::vector<uint8> &bytes) {
+    std::error_code error;
+    fs::create_directories(path.parent_path(), error);
+    FILE *file = std::fopen(path.string().c_str(), "wb");
+    if (!file) return 0;
+    const int written =
+        std::fwrite(bytes.data(), 1, bytes.size(), file) == bytes.size();
+    return std::fclose(file) == 0 && written;
+}
+
+static std::string shellQuote(const std::string &value) {
+#if defined(_WIN32)
+    std::string quoted = "\"";
+    for (char c : value) quoted += c == '"' ? "\\\"" : std::string(1, c);
+    return quoted + '"';
+#else
+    std::string quoted = "'";
+    for (char c : value) quoted += c == '\'' ? "'\\''" : std::string(1, c);
+    return quoted + '\'';
+#endif
+}
+
+static std::string assetTool(void) {
+    const char *configured = std::getenv("F15_ASSET_TOOL");
+    if (configured && configured[0]) return configured;
+    const fs::path candidates[] = {
+        "tools/f15assets/cli.py",
+        "../tools/f15assets/cli.py",
+        "../../tools/f15assets/cli.py"
+    };
+    for (const fs::path &candidate : candidates) {
+        if (fs::is_regular_file(candidate)) {
+            return "python3 " + shellQuote(candidate.string());
+        }
+    }
+    return {};
+}
+
+static std::vector<uint8> buildCache(const fs::path &glb_path) {
+    std::vector<uint8> bytes;
+    const std::string tool = assetTool();
+    if (tool.empty()) return bytes;
+    const std::string command =
+        tool + " build-glmesh " + shellQuote(glb_path.string());
+#if defined(_WIN32)
+    FILE *pipe = _popen(command.c_str(), "rb");
+#else
+    FILE *pipe = popen(command.c_str(), "r");
+#endif
+    if (!pipe) return bytes;
+    uint8 chunk[4096];
+    size_t count;
+    while ((count = std::fread(chunk, 1, sizeof(chunk), pipe)) != 0) {
+        if (bytes.size() + count > 16 * 1024 * 1024) {
+            bytes.clear();
+            break;
+        }
+        bytes.insert(bytes.end(), chunk, chunk + count);
+    }
+#if defined(_WIN32)
+    const int status = _pclose(pipe);
+#else
+    const int status = pclose(pipe);
+#endif
+    if (status != 0) bytes.clear();
+    return bytes;
+}
+
+static int cacheMatchesGlb(const std::vector<uint8> &bytes,
+                           const fs::path &glb) {
+    if (bytes.size() < 44 || std::memcmp(bytes.data(), "F15GLM3", 7) != 0) {
+        return 0;
+    }
+    const std::string expected((const char *)bytes.data() + 8, 32);
+    return expected == QuickDigest5::fileToHash(glb.string());
+}
+
+static int cacheIsUsable(const std::vector<uint8> &bytes,
+                         const fs::path &glb) {
+    R3DReplacementMesh parsed = {};
+    const int usable =
+        cacheMatchesGlb(bytes, glb) &&
+        parseGlmesh(&parsed, bytes.data(), bytes.size());
+    freeMesh(&parsed);
+    return usable;
+}
+
+static R3DReplacementMesh *loadShape(const char *container_name,
+                                     int shape_id,
+                                     const std::string &request_key) {
+    const fs::path directory = shapeDirectory(container_name);
+    if (directory.empty()) return NULL;
+    const fs::path glb = findShapeFile(directory, shape_id, ".glb");
+    fs::path cache;
+    if (!glb.empty()) {
+        cache = glb.parent_path() / "cache" / glb.filename();
+        cache.replace_extension(".glmesh");
+    } else {
+        cache = findShapeFile(directory, shape_id, ".glmesh");
+        if (cache.empty()) {
+            cache = findShapeFile(directory / "cache", shape_id, ".glmesh");
+        }
+    }
+    if (cache.empty()) return NULL;
+    std::vector<uint8> bytes;
+    if (!glb.empty()) {
+        bytes = readBytes(cache);
+        if (!cacheIsUsable(bytes, glb)) {
+            bytes = buildCache(glb);
+            if (!cacheIsUsable(bytes, glb)) {
+                LogWarn(("asset replacement: cannot build GLMESH for %s",
+                         glb.string().c_str()));
+                return NULL;
+            }
+            if (!writeBytes(cache, bytes)) {
+                LogWarn(("asset replacement: cannot write model cache %s",
+                         cache.string().c_str()));
+            }
+        }
+    } else {
+        bytes = readBytes(cache);
+    }
+
+    CachedMesh *entry = new CachedMesh{};
+    entry->key = request_key;
+    entry->loaded = parseGlmesh(&entry->mesh, bytes.data(), bytes.size());
+    if (!entry->loaded) {
+        LogWarn(("asset replacement: rejected model cache %s",
+                 cache.string().c_str()));
+        delete entry;
+        return NULL;
+    }
+    g_cache.push_back(entry);
+    LogInfo(("asset replacement: loaded shape %d for %s from %s",
+             shape_id, container_name, cache.string().c_str()));
+    return &entry->mesh;
+}
+
+R3DReplacementMesh *r3dReplacementMesh(const char *container_name,
+                                       int shape_id) {
+    if (!container_name || shape_id < 0 || shape_id > 999) return NULL;
+    const std::string key =
+        lower(fs::path(container_name).stem().string())
+        + ":" + std::to_string(shape_id);
+    for (CachedMesh *entry : g_cache) {
+        if (entry->key == key) return entry->loaded ? &entry->mesh : NULL;
+    }
+    R3DReplacementMesh *mesh = loadShape(container_name, shape_id, key);
+    if (mesh) return mesh;
+
+    /* Negative entries prevent terrain objects without replacements from
+     * rescanning the asset directory every rendered frame. */
+    CachedMesh *missing = new CachedMesh{};
+    missing->key = key;
+    missing->loaded = 0;
+    g_cache.push_back(missing);
+    return NULL;
+}
+
+void r3dReplacementShutdown(void) {
+    for (CachedMesh *entry : g_cache) {
+        freeMesh(&entry->mesh);
+        delete entry;
+    }
+    g_cache.clear();
+}

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -30,7 +30,7 @@ typedef struct CachedMesh {
     int loaded;
 } CachedMesh;
 
-static std::vector<CachedMesh *> g_cache;
+static std::vector<CachedMesh *> g_cache{};
 
 /* Fold one ASCII byte for DOS-compatible case-insensitive filename comparison. */
 static std::string lower(std::string value) {
@@ -42,7 +42,7 @@ static std::string lower(std::string value) {
 /* Find one child entry case-insensitively beneath a replacement directory. */
 static fs::path findChildCaseInsensitive(const fs::path &parent,
                                          const std::string &name) {
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(parent, error)) return {};
     const std::string wanted = lower(name);
     for (const fs::directory_entry &entry : fs::directory_iterator(parent, error)) {
@@ -58,7 +58,7 @@ static fs::path findChildCaseInsensitive(const fs::path &parent,
 static fs::path replacementRoot(void) {
     const char *root = std::getenv("F15_REPLACEMENT_ROOT");
     if (!root || !root[0]) return {};
-    std::error_code error;
+    std::error_code error{};
     fs::path path(root);
     return fs::is_directory(path, error) ? path : fs::path();
 }
@@ -86,10 +86,10 @@ static fs::path shapeDirectory(const char *container_name) {
 /* Find a per-shape GLB replacement by stable slot prefix and optional descriptive suffix. */
 static fs::path findShapeFile(const fs::path &directory, int shape_id,
                               const char *extension) {
-    char exact[64];
-    char prefix[64];
-    std::vector<fs::path> matches;
-    std::error_code error;
+    char exact[64]{};
+    char prefix[64]{};
+    std::vector<fs::path> matches{};
+    std::error_code error{};
     std::snprintf(exact, sizeof(exact), "shape_%03d%s", shape_id, extension);
     std::snprintf(prefix, sizeof(prefix), "shape_%03d_", shape_id);
     const std::string exact_lower = lower(exact);
@@ -130,7 +130,7 @@ static int32 readS32(const uint8 *bytes) {
 
 /* Read a little-endian IEEE-754 cache value. */
 static float readF32(const uint8 *bytes) {
-    float value;
+    float value{};
     std::memcpy(&value, bytes, sizeof(value));
     return value;
 }
@@ -205,8 +205,8 @@ fail:
 
 /* Read a complete file into an owned byte buffer. */
 static std::vector<uint8> readBytes(const fs::path &path) {
-    std::vector<uint8> bytes;
-    std::error_code error;
+    std::vector<uint8> bytes{};
+    std::error_code error{};
     const uintmax_t length = fs::file_size(path, error);
     if (error || length == 0 || length > 16 * 1024 * 1024) return bytes;
     FILE *file = std::fopen(path.string().c_str(), "rb");
@@ -221,7 +221,7 @@ static std::vector<uint8> readBytes(const fs::path &path) {
 
 /* Write a complete byte buffer atomically enough for the disposable cache contract. */
 static int writeBytes(const fs::path &path, const std::vector<uint8> &bytes) {
-    std::error_code error;
+    std::error_code error{};
     fs::create_directories(path.parent_path(), error);
     FILE *file = std::fopen(path.string().c_str(), "wb");
     if (!file) return 0;
@@ -262,7 +262,7 @@ static std::string assetTool(void) {
 
 /* Compile an edited GLB into a disposable runtime mesh cache. */
 static std::vector<uint8> buildCache(const fs::path &glb_path) {
-    std::vector<uint8> bytes;
+    std::vector<uint8> bytes{};
     bool too_large = false;
     const std::string tool = assetTool();
     if (tool.empty()) return bytes;
@@ -274,8 +274,8 @@ static std::vector<uint8> buildCache(const fs::path &glb_path) {
     FILE *pipe = popen(command.c_str(), "r");
 #endif
     if (!pipe) return bytes;
-    uint8 chunk[4096];
-    size_t count;
+    uint8 chunk[4096]{};
+    size_t count{};
     while ((count = std::fread(chunk, 1, sizeof(chunk), pipe)) != 0) {
         if (!too_large && count > 16 * 1024 * 1024 - bytes.size()) {
             /*
@@ -327,7 +327,7 @@ static R3DReplacementMesh *loadShape(const char *container_name,
     const fs::path directory = shapeDirectory(container_name);
     if (directory.empty()) return NULL;
     const fs::path glb = findShapeFile(directory, shape_id, ".glb");
-    fs::path cache;
+    fs::path cache{};
     if (!glb.empty()) {
         cache = glb.parent_path() / "cache" / glb.filename();
         cache.replace_extension(".glmesh");
@@ -338,7 +338,7 @@ static R3DReplacementMesh *loadShape(const char *container_name,
         }
     }
     if (cache.empty()) return NULL;
-    std::vector<uint8> bytes;
+    std::vector<uint8> bytes{};
     if (!glb.empty()) {
         bytes = readBytes(cache);
         if (!cacheIsUsable(bytes, glb)) {

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -88,6 +88,7 @@ static fs::path findShapeFile(const fs::path &directory, int shape_id,
                               const char *extension) {
     char exact[64]{};
     char prefix[64]{};
+    fs::path exact_match{};
     std::vector<fs::path> matches{};
     std::error_code error{};
     std::snprintf(exact, sizeof(exact), "shape_%03d%s", shape_id, extension);
@@ -101,14 +102,18 @@ static fs::path findShapeFile(const fs::path &directory, int shape_id,
          fs::directory_iterator(directory, error)) {
         if (error || !entry.is_regular_file()) continue;
         const std::string filename = lower(entry.path().filename().string());
-        if (filename == exact_lower) return entry.path();
+        if (filename == exact_lower) {
+            /* Case-sensitive hosts can contain two spellings of the same
+             * DOS filename. Neither is a portable choice. */
+            if (!exact_match.empty()) return {};
+            exact_match = entry.path();
+        }
         if (filename.rfind(prefix_lower, 0) == 0
-/* Fold one ASCII byte for DOS-compatible case-insensitive filename comparison. */
             && lower(entry.path().extension().string()) == extension_lower) {
             matches.push_back(entry.path());
         }
     }
-    std::sort(matches.begin(), matches.end());
+    if (!exact_match.empty()) return exact_match;
     if (matches.size() > 1) {
         LogWarn(("asset replacement: ambiguous shape %d (%zu matching %s files)",
                  shape_id, matches.size(), extension));
@@ -130,8 +135,10 @@ static int32 readS32(const uint8 *bytes) {
 
 /* Read a little-endian IEEE-754 cache value. */
 static float readF32(const uint8 *bytes) {
+    const uint32 bits = readU32(bytes);
     float value{};
-    std::memcpy(&value, bytes, sizeof(value));
+    /* The cache is little-endian even when the host is not. */
+    std::memcpy(&value, &bits, sizeof(value));
     return value;
 }
 

--- a/src/r3d_replacement.c
+++ b/src/r3d_replacement.c
@@ -24,6 +24,19 @@
 
 namespace fs = std::filesystem;
 
+enum {
+    GLMESH_HEADER_BYTES = 44,
+    GLMESH_PRIMITIVE_BYTES = 40,
+    GLMESH_FLOAT_BYTES = 4,
+    MAX_MESH_PRIMITIVES = 4096,
+    MAX_PRIMITIVE_VERTICES = 65536,
+    MAX_SHAPE_ID = 999,
+    PRIMITIVE_POINTS = 0,
+    PRIMITIVE_LINES = 1,
+    PRIMITIVE_TRIANGLES = 4
+};
+static constexpr size_t MAX_CACHE_BYTES = 16 * 1024 * 1024;
+
 typedef struct CachedMesh {
     std::string key;
     R3DReplacementMesh mesh;
@@ -156,13 +169,13 @@ static void freeMesh(R3DReplacementMesh *mesh) {
 /* Decode a validated runtime mesh cache while preserving primitive order and colors. */
 static int parseGlmesh(R3DReplacementMesh *mesh, const uint8 *data,
                        size_t size) {
-    size_t position = 44;
+    size_t position = GLMESH_HEADER_BYTES;
     if (!mesh || !data || size < position
         || std::memcmp(data, "F15GLM3", 7) != 0) {
         return 0;
     }
     const uint32 primitive_count = readU32(data + 40);
-    if (primitive_count == 0 || primitive_count > 4096) return 0;
+    if (primitive_count == 0 || primitive_count > MAX_MESH_PRIMITIVES) return 0;
     mesh->prims = (R3DReplacementPrim *)SDL_calloc(
         primitive_count, sizeof(*mesh->prims));
     if (!mesh->prims) return 0;
@@ -170,7 +183,7 @@ static int parseGlmesh(R3DReplacementMesh *mesh, const uint8 *data,
 
     for (uint32 index = 0; index < primitive_count; ++index) {
         R3DReplacementPrim *primitive = &mesh->prims[index];
-        if (position > size || size - position < 40) goto fail;
+        if (position > size || size - position < GLMESH_PRIMITIVE_BYTES) goto fail;
         primitive->mode = (int)readU32(data + position);
         primitive->nVerts = (int)readU32(data + position + 4);
         primitive->sourceKind = (int)readU32(data + position + 8);
@@ -182,24 +195,26 @@ static int parseGlmesh(R3DReplacementMesh *mesh, const uint8 *data,
                 readF32(data + position + 24 + channel * 4);
             if (!std::isfinite(primitive->rgba[channel])) goto fail;
         }
-        position += 40;
+        position += GLMESH_PRIMITIVE_BYTES;
 
-        if (primitive->nVerts <= 0 || primitive->nVerts > 65536
-            || (primitive->mode != 4 && primitive->mode != 1
-                && primitive->mode != 0)
-            || (primitive->mode == 4 && primitive->nVerts % 3 != 0)
-            || (primitive->mode == 1 && primitive->nVerts % 2 != 0)) {
-            goto fail;
-        }
+        const bool validVertexCount = primitive->nVerts > 0 &&
+            primitive->nVerts <= MAX_PRIMITIVE_VERTICES;
+        const bool supportedMode = primitive->mode == PRIMITIVE_TRIANGLES ||
+            primitive->mode == PRIMITIVE_LINES || primitive->mode == PRIMITIVE_POINTS;
+        const bool incompleteTriangle = primitive->mode == PRIMITIVE_TRIANGLES &&
+            primitive->nVerts % 3 != 0;
+        const bool incompleteLine = primitive->mode == PRIMITIVE_LINES &&
+            primitive->nVerts % 2 != 0;
+        if (!validVertexCount || !supportedMode || incompleteTriangle || incompleteLine) goto fail;
         const size_t float_count = (size_t)primitive->nVerts * 3;
-        if (position > size || float_count > (size - position) / 4) goto fail;
+        if (position > size || float_count > (size - position) / GLMESH_FLOAT_BYTES) goto fail;
         primitive->xyz =
             (float *)SDL_malloc(float_count * sizeof(float));
         if (!primitive->xyz) goto fail;
         for (size_t value_index = 0; value_index < float_count; ++value_index) {
             primitive->xyz[value_index] = readF32(data + position);
             if (!std::isfinite(primitive->xyz[value_index])) goto fail;
-            position += 4;
+            position += GLMESH_FLOAT_BYTES;
         }
     }
     if (position != size) goto fail;
@@ -215,7 +230,7 @@ static std::vector<uint8> readBytes(const fs::path &path) {
     std::vector<uint8> bytes{};
     std::error_code error{};
     const uintmax_t length = fs::file_size(path, error);
-    if (error || length == 0 || length > 16 * 1024 * 1024) return bytes;
+    if (error || length == 0 || length > MAX_CACHE_BYTES) return bytes;
     FILE *file = std::fopen(path.string().c_str(), "rb");
     if (!file) return bytes;
     bytes.resize((size_t)length);
@@ -226,7 +241,7 @@ static std::vector<uint8> readBytes(const fs::path &path) {
     return bytes;
 }
 
-/* Write a complete byte buffer atomically enough for the disposable cache contract. */
+/* Write the disposable cache; incomplete writes are rejected by its reader. */
 static int writeBytes(const fs::path &path, const std::vector<uint8> &bytes) {
     std::error_code error{};
     fs::create_directories(path.parent_path(), error);
@@ -284,7 +299,7 @@ static std::vector<uint8> buildCache(const fs::path &glb_path) {
     uint8 chunk[4096]{};
     size_t count{};
     while ((count = std::fread(chunk, 1, sizeof(chunk), pipe)) != 0) {
-        if (!too_large && count > 16 * 1024 * 1024 - bytes.size()) {
+        if (!too_large && count > MAX_CACHE_BYTES - bytes.size()) {
             /*
              * Keep draining the child after crossing the limit. Calling pclose
              * with unread pipe data can deadlock while the converter is blocked
@@ -309,7 +324,7 @@ static std::vector<uint8> buildCache(const fs::path &glb_path) {
 /* Verify that cache identity metadata matches the current editable GLB. */
 static int cacheMatchesGlb(const std::vector<uint8> &bytes,
                            const fs::path &glb) {
-    if (bytes.size() < 44 || std::memcmp(bytes.data(), "F15GLM3", 7) != 0) {
+    if (bytes.size() < GLMESH_HEADER_BYTES || std::memcmp(bytes.data(), "F15GLM3", 7) != 0) {
         return 0;
     }
     const std::string expected((const char *)bytes.data() + 8, 32);
@@ -382,7 +397,7 @@ static R3DReplacementMesh *loadShape(const char *container_name,
 /* Return the lazily loaded replacement mesh for a legacy container and slot. */
 R3DReplacementMesh *r3dReplacementMesh(const char *container_name,
                                        int shape_id) {
-    if (!container_name || shape_id < 0 || shape_id > 999) return NULL;
+    if (!container_name || shape_id < 0 || shape_id > MAX_SHAPE_ID) return NULL;
     const std::string key =
         lower(fs::path(container_name).stem().string())
         + ":" + std::to_string(shape_id);

--- a/src/r3d_replacement.h
+++ b/src/r3d_replacement.h
@@ -1,0 +1,34 @@
+/*
+ * r3d_replacement.h - Runtime representation of an editable per-shape model.
+ */
+#ifndef R3D_REPLACEMENT_H
+#define R3D_REPLACEMENT_H
+
+#include "inttype.h"
+
+typedef struct R3DReplacementPrim {
+    int mode; /* OpenGL primitive mode: 4 triangles, 1 lines, 0 points. */
+    int nVerts;
+    int sourceKind;
+    int sourceIndex;
+    int sourceColor;
+    uint32 sourceFlags;
+    float rgba[4];
+    float *xyz;
+} R3DReplacementPrim;
+
+typedef struct R3DReplacementMesh {
+    int nPrims;
+    R3DReplacementPrim *prims;
+} R3DReplacementMesh;
+
+/*
+ * Return a cached replacement for one legacy shape slot, or NULL to use the
+ * original model. GLB extras are optional; drawing consumes only mode, RGBA,
+ * and vertex positions from the generated cache.
+ */
+R3DReplacementMesh *r3dReplacementMesh(const char *container_name,
+                                       int shape_id);
+void r3dReplacementShutdown(void);
+
+#endif

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";

--- a/tests/r3d_replacement_behavior_tests.cpp
+++ b/tests/r3d_replacement_behavior_tests.cpp
@@ -1,0 +1,91 @@
+#include "r3d_replacement.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void appendU32(std::vector<unsigned char> &bytes, unsigned value) {
+    for (int shift = 0; shift < 32; shift += 8) {
+        bytes.push_back((unsigned char)(value >> shift));
+    }
+}
+
+void appendF32(std::vector<unsigned char> &bytes, float value) {
+    unsigned bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    appendU32(bytes, bits);
+}
+
+void writeMesh(const std::filesystem::path &path, bool valid) {
+    std::vector<unsigned char> bytes(40, 0);
+    std::memcpy(bytes.data(), "F15GLM3", 7);
+    appendU32(bytes, 1);
+    appendU32(bytes, 4);
+    appendU32(bytes, valid ? 3 : 2);
+    appendU32(bytes, 1);
+    appendU32(bytes, 0);
+    appendU32(bytes, 7);
+    appendU32(bytes, 1);
+    appendF32(bytes, 1.0f);
+    appendF32(bytes, 0.5f);
+    appendF32(bytes, 0.25f);
+    appendF32(bytes, 1.0f);
+    for (int vertex = 0; vertex < (valid ? 3 : 2); ++vertex) {
+        appendF32(bytes, (float)vertex);
+        appendF32(bytes, 0.0f);
+        appendF32(bytes, 0.0f);
+    }
+    std::ofstream out(path, std::ios::binary);
+    out.write((const char *)bytes.data(), (std::streamsize)bytes.size());
+}
+
+void setRoot(const std::string &root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root.c_str());
+#else
+    if (root.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", root.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-r3d-tests";
+    const auto models = root / "TEST";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(models);
+    setRoot(root.string());
+
+    writeMesh(models / "shape_005_Fighter.glmesh", true);
+    R3DReplacementMesh *mesh = r3dReplacementMesh("test.3d3", 5);
+    require(mesh && mesh->nPrims == 1, "standalone GLMESH loads by shape slot");
+    require(mesh->prims[0].mode == 4 && mesh->prims[0].nVerts == 3,
+            "triangle primitive is preserved");
+    require(mesh->prims[0].rgba[1] == 0.5f
+            && mesh->prims[0].xyz[3] == 1.0f,
+            "material and vertex data are preserved");
+
+    writeMesh(models / "shape_006_Broken.glmesh", false);
+    require(!r3dReplacementMesh("TEST.3D3", 6),
+            "invalid primitive cardinality falls back atomically");
+
+    r3dReplacementShutdown();
+    setRoot("");
+    std::filesystem::remove_all(root);
+    std::cout << "r3d_replacement_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/r3d_replacement_behavior_tests.cpp
+++ b/tests/r3d_replacement_behavior_tests.cpp
@@ -60,6 +60,15 @@ void setRoot(const std::string &root) {
 #endif
 }
 
+void setTool(const std::string &tool) {
+#if defined(_WIN32)
+    _putenv_s("F15_ASSET_TOOL", tool.c_str());
+#else
+    if (tool.empty()) unsetenv("F15_ASSET_TOOL");
+    else setenv("F15_ASSET_TOOL", tool.c_str(), 1);
+#endif
+}
+
 } // namespace
 
 int main() {
@@ -82,6 +91,23 @@ int main() {
     writeMesh(models / "shape_006_Broken.glmesh", false);
     require(!r3dReplacementMesh("TEST.3D3", 6),
             "invalid primitive cardinality falls back atomically");
+
+#if !defined(_WIN32)
+    const auto oversized = root / "oversized.glmesh";
+    {
+        std::ofstream output(oversized, std::ios::binary);
+        std::vector<char> block(1024 * 1024, '\0');
+        for (int i = 0; i < 17; ++i) {
+            output.write(block.data(), (std::streamsize)block.size());
+        }
+    }
+    std::ofstream(models / "shape_007_Oversized.glb", std::ios::binary)
+        << "not a GLB";
+    setTool("cat '" + oversized.string() + "' #");
+    require(!r3dReplacementMesh("TEST.3D3", 7),
+            "oversized converter output is drained and rejected");
+    setTool("");
+#endif
 
     r3dReplacementShutdown();
     setRoot("");

--- a/tests/r3d_replacement_behavior_tests.cpp
+++ b/tests/r3d_replacement_behavior_tests.cpp
@@ -92,6 +92,37 @@ int main() {
     require(!r3dReplacementMesh("TEST.3D3", 6),
             "invalid primitive cardinality falls back atomically");
 
+    writeMesh(models / "shape_008.glmesh", true);
+    if (!std::filesystem::exists(models / "SHAPE_008.GLMESH")) {
+        writeMesh(models / "SHAPE_008.GLMESH", true);
+        require(!r3dReplacementMesh("TEST.3D3", 8),
+                "duplicate case-insensitive slot names are ambiguous");
+    }
+
+    writeMesh(models / "shape_009_First.glmesh", true);
+    writeMesh(models / "shape_009_Second.glmesh", true);
+    require(!r3dReplacementMesh("TEST.3D3", 9),
+            "two descriptive names for one slot are ambiguous");
+
+    writeMesh(models / "shape_010.glmesh", true);
+    {
+        std::ofstream out(models / "shape_010.glmesh", std::ios::binary | std::ios::app);
+        out.put('x');
+    }
+    require(!r3dReplacementMesh("TEST.3D3", 10),
+            "trailing bytes invalidate the entire cache");
+
+    writeMesh(models / "shape_011.glmesh", true);
+    {
+        std::fstream out(models / "shape_011.glmesh", std::ios::binary | std::ios::in | std::ios::out);
+        // First vertex starts after the 44-byte header and 40-byte primitive.
+        const unsigned char infinity[] = {0, 0, 0x80, 0x7f};
+        out.seekp(84);
+        out.write(reinterpret_cast<const char *>(infinity), sizeof(infinity));
+    }
+    require(!r3dReplacementMesh("TEST.3D3", 11),
+            "non-finite coordinates invalidate the entire cache");
+
 #if !defined(_WIN32)
     const auto oversized = root / "oversized.glmesh";
     {

--- a/tests/r3d_replacement_full_validation_tests.cpp
+++ b/tests/r3d_replacement_full_validation_tests.cpp
@@ -1,0 +1,176 @@
+#include "r3d_gl.h"
+#include "r3d_replacement.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+std::vector<unsigned char> readFile(const std::filesystem::path &path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::vector<unsigned char>(
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>());
+}
+
+unsigned read16(const std::vector<unsigned char> &bytes, size_t offset) {
+    require(offset + 2 <= bytes.size(), "truncated 3D3 word");
+    return bytes[offset] | ((unsigned)bytes[offset + 1] << 8);
+}
+
+bool is3d3(const std::filesystem::path &path) {
+    std::string extension = path.extension().string();
+    for (char &c : extension) c = (char)std::toupper((unsigned char)c);
+    return extension == ".3D3";
+}
+
+void compareMesh(const std::string &logicalName, int shapeId,
+                 const unsigned char *legacy, size_t legacySize) {
+    R3DLegacyShapeStats source = {};
+    require(r3dgl_testLegacyShapeStats(legacy, legacySize, &source),
+            "legacy shape decode failed: " + logicalName);
+    R3DReplacementMesh *mesh =
+        r3dReplacementMesh(logicalName.c_str(), shapeId);
+    if (!source.renderable) {
+        require(mesh == nullptr,
+                "non-renderable shape unexpectedly has replacement: " +
+                    logicalName + " shape " + std::to_string(shapeId));
+        return;
+    }
+    require(mesh != nullptr,
+            "missing replacement: " + logicalName +
+                " shape " + std::to_string(shapeId));
+
+    int previousSourceIndex[4] = {-1, -1, -1, -1};
+    int triangles = 0;
+    int lines = 0;
+    int points = 0;
+    int faceColors[256] = {};
+    int lineColors[256] = {};
+    int pointColors[256] = {};
+    for (int i = 0; i < mesh->nPrims; ++i) {
+        const R3DReplacementPrim &primitive = mesh->prims[i];
+        require((primitive.sourceFlags & 1u) != 0u &&
+                    primitive.sourceKind >= 1 &&
+                    primitive.sourceKind <= 3 &&
+                    primitive.sourceColor >= 0 &&
+                    primitive.sourceColor < 256,
+                "replacement lacks source proof metadata");
+        require(primitive.sourceIndex >=
+                    previousSourceIndex[primitive.sourceKind],
+                "replacement source primitive order changed");
+        previousSourceIndex[primitive.sourceKind] = primitive.sourceIndex;
+        require((primitive.sourceKind == 1 && primitive.mode == 4) ||
+                    (primitive.sourceKind == 2 && primitive.mode == 1) ||
+                    (primitive.sourceKind == 3 && primitive.mode == 0),
+                "replacement source kind and draw mode disagree");
+        if (primitive.mode == 4) {
+            triangles += primitive.nVerts / 3;
+            faceColors[primitive.sourceColor] += primitive.nVerts / 3;
+        } else if (primitive.mode == 1) {
+            lines += primitive.nVerts / 2;
+            lineColors[primitive.sourceColor] += primitive.nVerts / 2;
+        } else {
+            points += primitive.nVerts;
+            pointColors[primitive.sourceColor] += primitive.nVerts;
+        }
+    }
+
+    require(triangles == source.triangles,
+            "replacement triangle count differs");
+    require(lines >= source.minimumLines && lines <= source.maximumLines,
+            "replacement line count is outside legacy coverage");
+    require(points == source.points, "replacement point count differs");
+    require(std::memcmp(faceColors, source.faceColors,
+                        sizeof(faceColors)) == 0,
+            "replacement face colors differ");
+    require(std::memcmp(pointColors, source.pointColors,
+                        sizeof(pointColors)) == 0,
+            "replacement point colors differ");
+    for (int color = 0; color < 256; ++color) {
+        require(lineColors[color] >= source.minimumLineColors[color] &&
+                    lineColors[color] <= source.maximumLineColors[color],
+                "replacement line color coverage differs");
+    }
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    setReplacementRoot(&convertedRoot);
+
+    int containers = 0;
+    int shapes = 0;
+    for (const auto &entry :
+         std::filesystem::recursive_directory_iterator(originalRoot)) {
+        if (!entry.is_regular_file() || !is3d3(entry.path())) continue;
+        const std::vector<unsigned char> bytes = readFile(entry.path());
+        if (bytes.size() < 8) continue;
+        const unsigned shapeCount = read16(bytes, 2);
+        const size_t tableStart = 4;
+        const size_t modelSizePosition =
+            tableStart + (size_t)shapeCount * 2u;
+        if (modelSizePosition + 2 > bytes.size()) continue;
+        const unsigned modelSize = read16(bytes, modelSizePosition);
+        const size_t modelStart = modelSizePosition + 2;
+        if (modelStart + modelSize > bytes.size()) continue;
+        std::vector<unsigned> offsets;
+        for (unsigned i = 0; i < shapeCount; ++i) {
+            offsets.push_back(read16(bytes, tableStart + (size_t)i * 2u));
+        }
+        offsets.push_back(modelSize);
+        const std::string logicalName =
+            std::filesystem::relative(entry.path(), originalRoot).generic_string();
+        for (unsigned shape = 0; shape < shapeCount; ++shape) {
+            if (offsets[shape] >= offsets[shape + 1] ||
+                offsets[shape + 1] > modelSize) {
+                continue;
+            }
+            compareMesh(logicalName, (int)shape,
+                        bytes.data() + modelStart + offsets[shape],
+                        offsets[shape + 1] - offsets[shape]);
+            ++shapes;
+        }
+        r3dReplacementShutdown();
+        ++containers;
+    }
+
+    setReplacementRoot(nullptr);
+    require(containers > 0 && shapes > 0, "no 3D3 shapes were compared");
+    std::cout << "r3d_replacement_full_validation_tests compared "
+              << shapes << " shape slots in " << containers
+              << " containers\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- loads editable per-shape GLBs through a small checked GLMESH cache
- preserves triangles, lines, points, colors, primitive ordering, and legacy fallback
- supports campaign aliases and safely drains oversized converter output
- changes only the OpenGL renderer behavior

## Dependencies

- #29
- companion converter: #28

## Validation

- 1,286 shapes validated against legacy decoding and converter source proof
- full branch suite: 33/33 passed
- oversized converter-output regression test

Split from #20.
