### PR TITLE
[review: high] 17. [custom] Load structured world and table replacements from JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
+    ${SRC_DIR}/shared/structured_asset_replacement.c
     ${SRC_DIR}/shared/filepic.c
 
     # f15 launcher
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(structured_asset_replacement_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,22 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(structured_asset_replacement_behavior_tests LINK_CORE)
+if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(structured_asset_full_validation_tests LINK_CORE
+        DEFS
+            F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
+            F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}"
+            F15_ASSET_TOOL_COMMAND="python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/f15assets/cli.py")
+    set_tests_properties(structured_asset_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping structured full validation: set F15SE2_ORIGINAL_ASSETS and "
+        "F15SE2_CONVERTED_ASSETS to existing directories")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,10 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(structured_asset_replacement_behavior_tests LINK_CORE)
+set(F15SE2_ASSET_TOOL_COMMAND
+    "python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/f15assets/cli.py"
+    CACHE STRING "Asset converter command for structured full validation")
+
 if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
    AND IS_DIRECTORY "${F15SE2_ORIGINAL_ASSETS}"
    AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
@@ -472,7 +476,7 @@ if(F15SE2_ORIGINAL_ASSETS AND F15SE2_CONVERTED_ASSETS
         DEFS
             F15_ORIGINAL_ASSETS="${F15SE2_ORIGINAL_ASSETS}"
             F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}"
-            F15_ASSET_TOOL_COMMAND="python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/f15assets/cli.py")
+            F15_ASSET_TOOL_COMMAND="${F15SE2_ASSET_TOOL_COMMAND}")
     set_tests_properties(structured_asset_full_validation_tests PROPERTIES
         LABELS "assets;integration"
         TIMEOUT 120)

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/src/shared/file_io.c
+++ b/src/shared/file_io.c
@@ -3,6 +3,7 @@
  */
 
 #include "inttype.h"
+#include "structured_asset_replacement.h"
 #include "log.h"
 #include <SDL3/SDL.h>
 #include <quickdigest5.hpp>
@@ -62,6 +63,9 @@ static string resolveCasePath(const char *filename, const bool require = false) 
 SDL_IOStream *openFile(const char *filename, int mode) {
     (void)mode; /* the resident open service only distinguished read vs. write;
                  * every openFile caller in the game opens an asset for reading */
+    if (SDL_IOStream *replacement = openStructuredAssetReplacement(filename)) {
+        return replacement;
+    }
     return SDL_IOFromFile(resolveCasePath(filename).c_str(), "rb");
 }
 

--- a/src/shared/structured_asset_replacement.c
+++ b/src/shared/structured_asset_replacement.c
@@ -35,12 +35,14 @@ namespace {
 constexpr size_t MAX_JSON_BYTES = 1024 * 1024;
 constexpr size_t MAX_REBUILT_BYTES = 1024 * 1024;
 
+/* Fold one ASCII byte to uppercase for format and extension matching. */
 std::string upper(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(),
                    [](unsigned char c) { return (char)std::toupper(c); });
     return value;
 }
 
+/* Quote one path safely for the explicitly configured external asset-tool command. */
 std::string shellQuote(const std::string &value) {
 #if defined(_WIN32)
     std::string quoted = "\"";
@@ -59,6 +61,7 @@ std::string shellQuote(const std::string &value) {
 #endif
 }
 
+/* Return the converter format identifier for a supported structured legacy extension. */
 const char *formatFor(const fs::path &legacy) {
     const std::string extension = upper(legacy.extension().string());
     if (extension == ".WLD") return "WLD";
@@ -68,6 +71,7 @@ const char *formatFor(const fs::path &legacy) {
     return nullptr;
 }
 
+/* Resolve the replacement directory associated with a structured legacy asset. */
 std::string replacementDirectory(const fs::path &legacy) {
     const std::string stem = upper(legacy.stem().string());
     if (stem == "LB") return "LIBYA";
@@ -75,6 +79,7 @@ std::string replacementDirectory(const fs::path &legacy) {
     return stem;
 }
 
+/* Find the canonical editable JSON replacement for a structured asset. */
 bool findStructuredJson(const fs::path &legacy, char *path, size_t pathSize) {
     const std::string filename = upper(legacy.filename().string()) + ".json";
     const std::string directory = replacementDirectory(legacy);
@@ -96,6 +101,7 @@ bool findStructuredJson(const fs::path &legacy, char *path, size_t pathSize) {
     return false;
 }
 
+/* Check whether a constrained converter-generated JSON file contains a required property. */
 bool fileContainsProperty(const char *path, const char *property) {
     FILE *file;
     std::vector<char> bytes;
@@ -132,6 +138,7 @@ bool fileContainsProperty(const char *path, const char *property) {
     return false;
 }
 
+/* Build the default converter command path relative to the running executable. */
 std::string defaultToolCommand(const fs::path &jsonPath) {
     const char *configured = std::getenv("F15_ASSET_TOOL");
     if (configured && configured[0]) return configured;
@@ -158,6 +165,7 @@ std::string defaultToolCommand(const fs::path &jsonPath) {
     return "python3 -m tools.f15assets.cli";
 }
 
+/* Expose rebuilt structured bytes as a rewindable temporary FILE stream. */
 SDL_IOStream *streamFromBytes(const std::vector<unsigned char> &bytes) {
     SDL_IOStream *stream = SDL_IOFromDynamicMem();
     if (!stream) return nullptr;
@@ -171,6 +179,7 @@ SDL_IOStream *streamFromBytes(const std::vector<unsigned char> &bytes) {
 
 } // namespace
 
+/* Open an editable structured replacement, rebuilding legacy bytes only for the existing loader. */
 SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
     fs::path legacy;
     const char *format;
@@ -188,6 +197,7 @@ SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
     legacy = fs::path(legacyFilename);
     format = formatFor(legacy);
     if (!format ||
+/* Find the canonical editable JSON replacement for a structured asset. */
         !findStructuredJson(legacy, jsonPath, sizeof(jsonPath))) {
         return nullptr;
     }
@@ -196,6 +206,7 @@ SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
      * replacements. Only an explicitly exported model_data field can replace
      * the legacy 3D3 table stream. */
     if (std::strcmp(format, "3D3") == 0 &&
+/* Check whether a constrained converter-generated JSON file contains a required property. */
         !fileContainsProperty(jsonPath, "\"model_data\"")) {
         return nullptr;
     }

--- a/src/shared/structured_asset_replacement.c
+++ b/src/shared/structured_asset_replacement.c
@@ -1,0 +1,254 @@
+/*
+ * structured_asset_replacement.c - Feed editable structured JSON assets through
+ * the proven legacy loaders without teaching every loader about JSON.
+ */
+#include "structured_asset_replacement.h"
+
+#include "asset_path.h"
+#include "log.h"
+
+#include <SDL3/SDL.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+#if defined(_WIN32)
+#define F15_POPEN(command, mode) _popen((command), (mode))
+#define F15_PCLOSE(pipe) _pclose(pipe)
+#define F15_PIPE_READ_MODE "rb"
+#else
+#define F15_POPEN(command, mode) popen((command), (mode))
+#define F15_PCLOSE(pipe) pclose(pipe)
+#define F15_PIPE_READ_MODE "r"
+#endif
+
+namespace {
+
+constexpr size_t MAX_JSON_BYTES = 1024 * 1024;
+constexpr size_t MAX_REBUILT_BYTES = 1024 * 1024;
+
+std::string upper(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return (char)std::toupper(c); });
+    return value;
+}
+
+std::string shellQuote(const std::string &value) {
+#if defined(_WIN32)
+    std::string quoted = "\"";
+    for (char c : value) {
+        if (c == '"') quoted += "\\\"";
+        else quoted += c;
+    }
+    return quoted + "\"";
+#else
+    std::string quoted = "'";
+    for (char c : value) {
+        if (c == '\'') quoted += "'\\''";
+        else quoted += c;
+    }
+    return quoted + "'";
+#endif
+}
+
+const char *formatFor(const fs::path &legacy) {
+    const std::string extension = upper(legacy.extension().string());
+    if (extension == ".WLD") return "WLD";
+    if (extension == ".3DT") return "3DT";
+    if (extension == ".3DG") return "3DG";
+    if (extension == ".3D3") return "3D3";
+    return nullptr;
+}
+
+std::string replacementDirectory(const fs::path &legacy) {
+    const std::string stem = upper(legacy.stem().string());
+    if (stem == "LB") return "LIBYA";
+    if (stem == "PG") return "GULF";
+    return stem;
+}
+
+bool findStructuredJson(const fs::path &legacy, char *path, size_t pathSize) {
+    const std::string filename = upper(legacy.filename().string()) + ".json";
+    const std::string directory = replacementDirectory(legacy);
+    std::vector<fs::path> candidates;
+
+    if (!legacy.parent_path().empty()) {
+        candidates.push_back(legacy.parent_path() / directory / filename);
+        candidates.push_back(legacy.parent_path() / filename);
+    }
+    candidates.push_back(fs::path(directory) / filename);
+    candidates.push_back(filename);
+
+    for (const fs::path &candidate : candidates) {
+        if (findAssetReplacement(candidate.generic_string().c_str(),
+                                 path, pathSize)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool fileContainsProperty(const char *path, const char *property) {
+    FILE *file;
+    std::vector<char> bytes;
+    char chunk[4096];
+    size_t count;
+
+    if (!path || !property) return false;
+    file = std::fopen(path, "rb");
+    if (!file) return false;
+    while ((count = std::fread(chunk, 1, sizeof(chunk), file)) != 0) {
+        bytes.insert(bytes.end(), chunk, chunk + count);
+        if (bytes.size() > MAX_JSON_BYTES) {
+            std::fclose(file);
+            return false;
+        }
+    }
+    if (std::ferror(file)) {
+        std::fclose(file);
+        return false;
+    }
+    std::fclose(file);
+
+    const std::string text(bytes.begin(), bytes.end());
+    size_t position = 0;
+    while ((position = text.find(property, position)) != std::string::npos) {
+        size_t separator = position + std::strlen(property);
+        while (separator < text.size() &&
+               std::isspace((unsigned char)text[separator])) {
+            ++separator;
+        }
+        if (separator < text.size() && text[separator] == ':') return true;
+        ++position;
+    }
+    return false;
+}
+
+std::string defaultToolCommand(const fs::path &jsonPath) {
+    const char *configured = std::getenv("F15_ASSET_TOOL");
+    if (configured && configured[0]) return configured;
+
+    std::vector<fs::path> candidates;
+    fs::path cursor = jsonPath.parent_path();
+    while (!cursor.empty()) {
+        if (cursor.filename() == "converted_assets_all") {
+            candidates.push_back(cursor.parent_path() / "tools/f15assets/cli.py");
+            break;
+        }
+        const fs::path parent = cursor.parent_path();
+        if (parent == cursor) break;
+        cursor = parent;
+    }
+    candidates.push_back("tools/f15assets/cli.py");
+    candidates.push_back("../tools/f15assets/cli.py");
+    for (const fs::path &candidate : candidates) {
+        std::error_code error;
+        if (fs::is_regular_file(candidate, error) && !error) {
+            return "python3 " + shellQuote(candidate.string());
+        }
+    }
+    return "python3 -m tools.f15assets.cli";
+}
+
+SDL_IOStream *streamFromBytes(const std::vector<unsigned char> &bytes) {
+    SDL_IOStream *stream = SDL_IOFromDynamicMem();
+    if (!stream) return nullptr;
+    if (SDL_WriteIO(stream, bytes.data(), bytes.size()) != bytes.size() ||
+        SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET) < 0) {
+        SDL_CloseIO(stream);
+        return nullptr;
+    }
+    return stream;
+}
+
+} // namespace
+
+SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
+    fs::path legacy;
+    const char *format;
+    char jsonPath[512];
+    std::string command;
+    FILE *pipe;
+    std::vector<unsigned char> rebuilt;
+    unsigned char chunk[4096];
+    size_t count;
+    int status;
+    bool readFailed;
+    bool tooLarge = false;
+
+    if (!legacyFilename || !legacyFilename[0]) return nullptr;
+    legacy = fs::path(legacyFilename);
+    format = formatFor(legacy);
+    if (!format ||
+        !findStructuredJson(legacy, jsonPath, sizeof(jsonPath))) {
+        return nullptr;
+    }
+
+    /* Default 3D3 sidecars are indexes for per-shape GLBs, not complete binary
+     * replacements. Only an explicitly exported model_data field can replace
+     * the legacy 3D3 table stream. */
+    if (std::strcmp(format, "3D3") == 0 &&
+        !fileContainsProperty(jsonPath, "\"model_data\"")) {
+        return nullptr;
+    }
+
+    command = defaultToolCommand(jsonPath) + " build-binary " +
+              shellQuote(jsonPath) + " --format " + format;
+    pipe = F15_POPEN(command.c_str(), F15_PIPE_READ_MODE);
+    if (!pipe) {
+        LogWarn(("asset replacement: cannot start JSON importer for %s; using legacy asset",
+                 legacyFilename));
+        return nullptr;
+    }
+
+    while ((count = std::fread(chunk, 1, sizeof(chunk), pipe)) != 0) {
+        if (!tooLarge) {
+            if (count > MAX_REBUILT_BYTES - rebuilt.size()) {
+                /*
+                 * Keep draining the child after crossing the limit. Waiting
+                 * with unread pipe data can deadlock when the importer is
+                 * blocked trying to finish its write.
+                 */
+                tooLarge = true;
+                rebuilt.clear();
+            } else {
+                rebuilt.insert(rebuilt.end(), chunk, chunk + count);
+            }
+        }
+    }
+    readFailed = std::ferror(pipe) != 0;
+    status = F15_PCLOSE(pipe);
+    if (tooLarge) {
+        LogWarn(("asset replacement: rebuilt %s exceeds size limit; using legacy asset",
+                 legacyFilename));
+        return nullptr;
+    }
+    if (readFailed) {
+        LogWarn(("asset replacement: cannot read rebuilt %s; using legacy asset",
+                 legacyFilename));
+        return nullptr;
+    }
+    if (status != 0 || rebuilt.empty()) {
+        LogWarn(("asset replacement: JSON importer failed for %s; using legacy asset",
+                 legacyFilename));
+        return nullptr;
+    }
+
+    SDL_IOStream *stream = streamFromBytes(rebuilt);
+    if (!stream) {
+        LogWarn(("asset replacement: cannot open rebuilt bytes for %s; using legacy asset",
+                 legacyFilename));
+        return nullptr;
+    }
+    LogInfo(("asset replacement: loaded %s from JSON %s (%zu bytes)",
+             legacyFilename, jsonPath, rebuilt.size()));
+    return stream;
+}

--- a/src/shared/structured_asset_replacement.c
+++ b/src/shared/structured_asset_replacement.c
@@ -83,7 +83,7 @@ std::string replacementDirectory(const fs::path &legacy) {
 bool findStructuredJson(const fs::path &legacy, char *path, size_t pathSize) {
     const std::string filename = upper(legacy.filename().string()) + ".json";
     const std::string directory = replacementDirectory(legacy);
-    std::vector<fs::path> candidates;
+    std::vector<fs::path> candidates{};
 
     if (!legacy.parent_path().empty()) {
         candidates.push_back(legacy.parent_path() / directory / filename);
@@ -103,10 +103,10 @@ bool findStructuredJson(const fs::path &legacy, char *path, size_t pathSize) {
 
 /* Check whether a constrained converter-generated JSON file contains a required property. */
 bool fileContainsProperty(const char *path, const char *property) {
-    FILE *file;
-    std::vector<char> bytes;
-    char chunk[4096];
-    size_t count;
+    FILE *file{};
+    std::vector<char> bytes{};
+    char chunk[4096]{};
+    size_t count{};
 
     if (!path || !property) return false;
     file = std::fopen(path, "rb");
@@ -143,7 +143,7 @@ std::string defaultToolCommand(const fs::path &jsonPath) {
     const char *configured = std::getenv("F15_ASSET_TOOL");
     if (configured && configured[0]) return configured;
 
-    std::vector<fs::path> candidates;
+    std::vector<fs::path> candidates{};
     fs::path cursor = jsonPath.parent_path();
     while (!cursor.empty()) {
         if (cursor.filename() == "converted_assets_all") {
@@ -157,7 +157,7 @@ std::string defaultToolCommand(const fs::path &jsonPath) {
     candidates.push_back("tools/f15assets/cli.py");
     candidates.push_back("../tools/f15assets/cli.py");
     for (const fs::path &candidate : candidates) {
-        std::error_code error;
+        std::error_code error{};
         if (fs::is_regular_file(candidate, error) && !error) {
             return "python3 " + shellQuote(candidate.string());
         }
@@ -181,16 +181,16 @@ SDL_IOStream *streamFromBytes(const std::vector<unsigned char> &bytes) {
 
 /* Open an editable structured replacement, rebuilding legacy bytes only for the existing loader. */
 SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
-    fs::path legacy;
-    const char *format;
-    char jsonPath[512];
-    std::string command;
-    FILE *pipe;
-    std::vector<unsigned char> rebuilt;
-    unsigned char chunk[4096];
-    size_t count;
-    int status;
-    bool readFailed;
+    fs::path legacy{};
+    const char *format{};
+    char jsonPath[512]{};
+    std::string command{};
+    FILE *pipe{};
+    std::vector<unsigned char> rebuilt{};
+    unsigned char chunk[4096]{};
+    size_t count{};
+    int status{};
+    bool readFailed{};
     bool tooLarge = false;
 
     if (!legacyFilename || !legacyFilename[0]) return nullptr;

--- a/src/shared/structured_asset_replacement.c
+++ b/src/shared/structured_asset_replacement.c
@@ -138,7 +138,7 @@ bool fileContainsProperty(const char *path, const char *property) {
     return false;
 }
 
-/* Build the default converter command path relative to the running executable. */
+/* Search beside the asset pack, then relative to the working directory. */
 std::string defaultToolCommand(const fs::path &jsonPath) {
     const char *configured = std::getenv("F15_ASSET_TOOL");
     if (configured && configured[0]) return configured;
@@ -165,7 +165,7 @@ std::string defaultToolCommand(const fs::path &jsonPath) {
     return "python3 -m tools.f15assets.cli";
 }
 
-/* Expose rebuilt structured bytes as a rewindable temporary FILE stream. */
+/* Expose rebuilt bytes as a rewindable, owned SDL memory stream. */
 SDL_IOStream *streamFromBytes(const std::vector<unsigned char> &bytes) {
     SDL_IOStream *stream = SDL_IOFromDynamicMem();
     if (!stream) return nullptr;
@@ -181,23 +181,16 @@ SDL_IOStream *streamFromBytes(const std::vector<unsigned char> &bytes) {
 
 /* Open an editable structured replacement, rebuilding legacy bytes only for the existing loader. */
 SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
-    fs::path legacy{};
-    const char *format{};
     char jsonPath[512]{};
-    std::string command{};
-    FILE *pipe{};
     std::vector<unsigned char> rebuilt{};
     unsigned char chunk[4096]{};
     size_t count{};
-    int status{};
-    bool readFailed{};
     bool tooLarge = false;
 
     if (!legacyFilename || !legacyFilename[0]) return nullptr;
-    legacy = fs::path(legacyFilename);
-    format = formatFor(legacy);
+    const fs::path legacy(legacyFilename);
+    const char *format = formatFor(legacy);
     if (!format ||
-/* Find the canonical editable JSON replacement for a structured asset. */
         !findStructuredJson(legacy, jsonPath, sizeof(jsonPath))) {
         return nullptr;
     }
@@ -205,15 +198,15 @@ SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
     /* Default 3D3 sidecars are indexes for per-shape GLBs, not complete binary
      * replacements. Only an explicitly exported model_data field can replace
      * the legacy 3D3 table stream. */
-    if (std::strcmp(format, "3D3") == 0 &&
-/* Check whether a constrained converter-generated JSON file contains a required property. */
-        !fileContainsProperty(jsonPath, "\"model_data\"")) {
+    const bool incompleteShapeTable = std::strcmp(format, "3D3") == 0 &&
+        !fileContainsProperty(jsonPath, "\"model_data\"");
+    if (incompleteShapeTable) {
         return nullptr;
     }
 
-    command = defaultToolCommand(jsonPath) + " build-binary " +
+    const std::string command = defaultToolCommand(jsonPath) + " build-binary " +
               shellQuote(jsonPath) + " --format " + format;
-    pipe = F15_POPEN(command.c_str(), F15_PIPE_READ_MODE);
+    FILE *pipe = F15_POPEN(command.c_str(), F15_PIPE_READ_MODE);
     if (!pipe) {
         LogWarn(("asset replacement: cannot start JSON importer for %s; using legacy asset",
                  legacyFilename));
@@ -235,8 +228,8 @@ SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename) {
             }
         }
     }
-    readFailed = std::ferror(pipe) != 0;
-    status = F15_PCLOSE(pipe);
+    const bool readFailed = std::ferror(pipe) != 0;
+    const int status = F15_PCLOSE(pipe);
     if (tooLarge) {
         LogWarn(("asset replacement: rebuilt %s exceeds size limit; using legacy asset",
                  legacyFilename));

--- a/src/shared/structured_asset_replacement.h
+++ b/src/shared/structured_asset_replacement.h
@@ -1,0 +1,16 @@
+/*
+ * structured_asset_replacement.h - Optional JSON-to-legacy stream bridge.
+ */
+#ifndef F15_STRUCTURED_ASSET_REPLACEMENT_H
+#define F15_STRUCTURED_ASSET_REPLACEMENT_H
+
+struct SDL_IOStream;
+
+/*
+ * Rebuild an editable WLD/3DT/3DG/full-3D3 JSON replacement into the exact byte
+ * stream expected by the existing loaders. Returns NULL when no usable
+ * replacement exists, so callers can transparently open the legacy asset.
+ */
+struct SDL_IOStream *openStructuredAssetReplacement(const char *legacyFilename);
+
+#endif

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";

--- a/tests/structured_asset_full_validation_tests.cpp
+++ b/tests/structured_asset_full_validation_tests.cpp
@@ -1,0 +1,98 @@
+#include "shared/common.h"
+
+#include <SDL3/SDL.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern bool setGamePath(const char *path);
+
+#if !defined(F15_ORIGINAL_ASSETS)
+#define F15_ORIGINAL_ASSETS ""
+#endif
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+#if !defined(F15_ASSET_TOOL_COMMAND)
+#define F15_ASSET_TOOL_COMMAND ""
+#endif
+
+namespace {
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::string upper(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return (char)std::toupper(c); });
+    return value;
+}
+
+bool isStructured(const std::filesystem::path &path) {
+    const std::string extension = upper(path.extension().string());
+    return extension == ".WLD" || extension == ".3DT" || extension == ".3DG";
+}
+
+void setEnvironment(const char *name, const std::string *value) {
+#if defined(_WIN32)
+    _putenv_s(name, value ? value->c_str() : "");
+#else
+    if (value) setenv(name, value->c_str(), 1);
+    else unsetenv(name);
+#endif
+}
+
+std::vector<unsigned char> readAsset(const std::string &logicalName) {
+    SDL_IOStream *stream = openFile(logicalName.c_str(), 0);
+    require(stream != nullptr, "cannot open " + logicalName);
+    std::vector<unsigned char> bytes;
+    unsigned char chunk[4096];
+    size_t count;
+    while ((count = SDL_ReadIO(stream, chunk, sizeof(chunk))) != 0) {
+        bytes.insert(bytes.end(), chunk, chunk + count);
+    }
+    fileClose(stream);
+    return bytes;
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const std::string toolCommand = F15_ASSET_TOOL_COMMAND;
+    require(setGamePath(originalRoot.string().c_str()), "setGamePath failed");
+    setEnvironment("F15_ASSET_TOOL", &toolCommand);
+
+    int compared = 0;
+    for (const auto &entry :
+         std::filesystem::recursive_directory_iterator(originalRoot)) {
+        if (!entry.is_regular_file() || !isStructured(entry.path())) continue;
+        const std::string logicalName =
+            std::filesystem::relative(entry.path(), originalRoot).generic_string();
+        setEnvironment("F15_REPLACEMENT_ROOT", nullptr);
+        const std::vector<unsigned char> legacy = readAsset(logicalName);
+        const std::string replacementRoot = convertedRoot.string();
+        setEnvironment("F15_REPLACEMENT_ROOT", &replacementRoot);
+        const std::vector<unsigned char> replacement = readAsset(logicalName);
+        require(replacement == legacy,
+                "rebuilt structured bytes differ for " + logicalName);
+        ++compared;
+    }
+
+    setEnvironment("F15_REPLACEMENT_ROOT", nullptr);
+    setEnvironment("F15_ASSET_TOOL", nullptr);
+    require(compared > 0, "no WLD/3DT/3DG assets were compared");
+    std::cout << "structured_asset_full_validation_tests compared "
+              << compared << " assets\n";
+    return 0;
+}

--- a/tests/structured_asset_full_validation_tests.cpp
+++ b/tests/structured_asset_full_validation_tests.cpp
@@ -67,10 +67,20 @@ std::vector<unsigned char> readAsset(const std::string &logicalName) {
 } // namespace
 
 int main() {
-    const std::filesystem::path originalRoot = F15_ORIGINAL_ASSETS;
-    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const std::filesystem::path originalRoot = std::filesystem::absolute(F15_ORIGINAL_ASSETS);
+    const std::filesystem::path convertedRoot = std::filesystem::absolute(F15_CONVERTED_ASSETS);
     const std::string toolCommand = F15_ASSET_TOOL_COMMAND;
-    require(setGamePath(originalRoot.string().c_str()), "setGamePath failed");
+    const auto previousDirectory = std::filesystem::current_path();
+    const auto isolatedRoot = std::filesystem::temp_directory_path() /
+                              "f15se2-structured-full-validation";
+    const auto legacyRoot = isolatedRoot / "legacy";
+    const auto modernRoot = isolatedRoot / "modern";
+    std::filesystem::remove_all(isolatedRoot);
+    std::filesystem::create_directories(legacyRoot);
+    std::filesystem::create_directories(modernRoot);
+    // Neither read may discover the other format through fallback locations.
+    // In particular, a missing replacement must fail, not compare legacy to itself.
+    std::filesystem::current_path(isolatedRoot);
     setEnvironment("F15_ASSET_TOOL", &toolCommand);
 
     int compared = 0;
@@ -79,9 +89,14 @@ int main() {
         if (!entry.is_regular_file() || !isStructured(entry.path())) continue;
         const std::string logicalName =
             std::filesystem::relative(entry.path(), originalRoot).generic_string();
+        const auto isolatedOriginal = legacyRoot / logicalName;
+        std::filesystem::create_directories(isolatedOriginal.parent_path());
+        std::filesystem::copy_file(entry.path(), isolatedOriginal);
+        require(setGamePath(legacyRoot.string().c_str()), "legacy setGamePath failed");
         setEnvironment("F15_REPLACEMENT_ROOT", nullptr);
         const std::vector<unsigned char> legacy = readAsset(logicalName);
         const std::string replacementRoot = convertedRoot.string();
+        require(setGamePath(modernRoot.string().c_str()), "modern setGamePath failed");
         setEnvironment("F15_REPLACEMENT_ROOT", &replacementRoot);
         const std::vector<unsigned char> replacement = readAsset(logicalName);
         require(replacement == legacy,
@@ -91,6 +106,8 @@ int main() {
 
     setEnvironment("F15_REPLACEMENT_ROOT", nullptr);
     setEnvironment("F15_ASSET_TOOL", nullptr);
+    std::filesystem::current_path(previousDirectory);
+    std::filesystem::remove_all(isolatedRoot);
     require(compared > 0, "no WLD/3DT/3DG assets were compared");
     std::cout << "structured_asset_full_validation_tests compared "
               << compared << " assets\n";

--- a/tests/structured_asset_replacement_behavior_tests.cpp
+++ b/tests/structured_asset_replacement_behavior_tests.cpp
@@ -1,0 +1,114 @@
+#include "shared/common.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+extern bool setGamePath(const char *path);
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setEnvironment(const char *name, const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s(name, value.c_str());
+#else
+    if (value.empty()) unsetenv(name);
+    else setenv(name, value.c_str(), 1);
+#endif
+}
+
+void writeFile(const std::filesystem::path &path, const std::string &contents) {
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output << contents;
+}
+
+std::string readStream(SDL_IOStream *stream) {
+    std::string result;
+    char buffer[32];
+    size_t count;
+    while ((count = SDL_ReadIO(stream, buffer, sizeof(buffer))) != 0) {
+        result.append(buffer, count);
+    }
+    return result;
+}
+
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    const fs::path root =
+        fs::temp_directory_path() / "f15se2-structured-replacement-test";
+    const fs::path game = root / "game";
+    const fs::path replacements = root / "replacements";
+    const fs::path tool = root / "asset-tool.py";
+
+    fs::remove_all(root);
+    fs::create_directories(game);
+    writeFile(game / "LIBYA.WLD", "LEGACY_WLD");
+    writeFile(game / "LB.3D3", "LEGACY_3D3");
+    writeFile(replacements / "LIBYA" / "LIBYA.WLD.json",
+              "{\"format\":\"WLD\"}\n");
+    writeFile(replacements / "LIBYA" / "LB.3D3.json",
+              "{\"format\":\"3D3\"}\n");
+    writeFile(tool,
+              "import sys\n"
+              "sys.stdout.buffer.write(('BUILT_' + sys.argv[-1]).encode())\n");
+
+    setEnvironment("F15_REPLACEMENT_ROOT", replacements.string());
+    setEnvironment("F15_ASSET_TOOL", "python3 " + tool.string());
+    require(setGamePath(game.string().c_str()), "game path is accepted");
+
+    SDL_IOStream *stream = openFile("Libya.wld", 0);
+    require(stream != nullptr, "WLD JSON replacement opens");
+    require(readStream(stream) == "BUILT_WLD",
+            "WLD replacement bytes come from the configured importer");
+    fileClose(stream);
+
+    stream = openFile("LB.3D3", 0);
+    require(stream != nullptr, "legacy 3D3 fallback opens");
+    require(readStream(stream) == "LEGACY_3D3",
+            "metadata-only 3D3 JSON does not replace the table stream");
+    fileClose(stream);
+
+    writeFile(replacements / "LIBYA" / "LB.3D3.json",
+              "{\"format\":\"3D3\",\"model_data\":[]}\n");
+    stream = openFile("LB.3D3", 0);
+    require(stream != nullptr, "full 3D3 JSON replacement opens");
+    require(readStream(stream) == "BUILT_3D3",
+            "full 3D3 JSON is rebuilt through the configured importer");
+    fileClose(stream);
+
+    setEnvironment("F15_ASSET_TOOL", "python3 -c \"import sys; sys.exit(2)\"");
+    stream = openFile("Libya.wld", 0);
+    require(stream != nullptr, "legacy WLD fallback opens after importer failure");
+    require(readStream(stream) == "LEGACY_WLD",
+            "importer failure transparently falls back to the legacy asset");
+    fileClose(stream);
+
+    setEnvironment(
+        "F15_ASSET_TOOL",
+        "python3 -c \"import sys; sys.stdout.buffer.write(b'x' * 1048577)\"");
+    stream = openFile("Libya.wld", 0);
+    require(stream != nullptr, "legacy WLD fallback opens after oversized output");
+    require(readStream(stream) == "LEGACY_WLD",
+            "oversized importer output is drained then rejected");
+    fileClose(stream);
+
+    setEnvironment("F15_REPLACEMENT_ROOT", "");
+    setEnvironment("F15_ASSET_TOOL", "");
+    fs::remove_all(root);
+    std::cout << "structured_asset_replacement_behavior_tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- rebuilds editable WLD, 3DT, and 3DG JSON through the existing legacy loaders
- supports full 3D3 JSON only when model data is present
- drains importer output safely and falls back on missing, malformed, failed, or oversized replacements

## Dependencies

- #29
- importer/converter: #28

## Validation

- every WLD/3DT/3DG rebuilt byte stream compared through the real runtime loader
- full branch suite: 33/33 passed

Split from #20.
