### PR TITLE
[review: very high] 18. [custom] Support UTF-8 pilot-name input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,18 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(bitmap_font_replacement_behavior_tests LINK_CORE)
+if(F15SE2_CONVERTED_ASSETS
+   AND IS_DIRECTORY "${F15SE2_CONVERTED_ASSETS}")
+    add_behavior_test(bitmap_font_full_validation_tests LINK_CORE
+        DEFS F15_CONVERTED_ASSETS="${F15SE2_CONVERTED_ASSETS}")
+    set_tests_properties(bitmap_font_full_validation_tests PROPERTIES
+        LABELS "assets;integration"
+        TIMEOUT 120)
+else()
+    message(STATUS
+        "Skipping bitmap-font full validation: set "
+        "F15SE2_CONVERTED_ASSETS to an existing directory")
+endif()
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/bitmap_font_replacement.c
     ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
@@ -463,6 +464,7 @@ add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(asset_path_behavior_tests LINK_CORE)
+add_behavior_test(bitmap_font_replacement_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(F15SE2_SOURCES
 
     # Shared file + string helpers
     ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/asset_path.c
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
@@ -461,6 +462,7 @@ add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
+add_behavior_test(asset_path_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/shared/cleanup.c
     ${SRC_DIR}/shared/drawstr.c
     ${SRC_DIR}/shared/textfmt.c
+    ${SRC_DIR}/shared/utf8.c
     ${SRC_DIR}/shared/filepic.c
 
     # f15 launcher
@@ -211,6 +212,11 @@ find_package(OpenGL REQUIRED)
 # across toolchains (not all fold pthread into libc).
 find_package(Threads REQUIRED)
 
+# TrueType/OpenType font replacements are optional. When FreeType is available,
+# fonts/font_<id>.ttf and .otf are loaded directly by the runtime; otherwise the
+# game still builds and falls back to BDF/PNG/built-in font paths.
+find_package(Freetype QUIET)
+
 #------------------------------------------------------------------------------
 # Sanitizers (GCC/Clang, opt-in). Applied at directory scope so the executable
 # and the tests (which each compile the game code they exercise) are instrumented
@@ -273,6 +279,10 @@ if(AUTOSTART)
     target_compile_definitions(f15se2_core PUBLIC DEBUG_AUTOSTART)
 endif()
 target_link_libraries(f15se2_core PUBLIC SDL3::SDL3 OpenGL::GL)
+if(FREETYPE_FOUND)
+    target_compile_definitions(f15se2_core PUBLIC F15_HAVE_FREETYPE=1)
+    target_link_libraries(f15se2_core PUBLIC Freetype::Freetype)
+endif()
 
 add_executable(f15se2 ${SRC_DIR}/f15.c)
 set_target_properties(f15se2 PROPERTIES OUTPUT_NAME "f15se2-ex")
@@ -477,9 +487,26 @@ else()
         "Skipping bitmap-font full validation: set "
         "F15SE2_CONVERTED_ASSETS to an existing directory")
 endif()
+add_behavior_test(utf8_behavior_tests SOURCES
+    ${SRC_DIR}/shared/utf8.c)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)
+if(FREETYPE_FOUND)
+    find_file(F15_TEST_TTF
+        NAMES DejaVuSans.ttf LiberationSans-Regular.ttf
+        PATHS
+            /usr/share/fonts/truetype/dejavu
+            /usr/share/fonts/truetype/liberation2
+            /usr/share/fonts/truetype/liberation
+            /Library/Fonts
+            C:/Windows/Fonts
+    )
+    if(F15_TEST_TTF)
+        add_behavior_test(ttf_font_behavior_tests LINK_CORE
+            DEFS F15_TEST_TTF_PATH="${F15_TEST_TTF}")
+    endif()
+endif()
 add_behavior_test(view_behavior_tests LINK_CORE)
 add_behavior_test(egsys_internal_behavior_tests LINK_CORE)
 add_behavior_test(start_runtime_behavior_tests SOURCES

--- a/src/egtacmap.c
+++ b/src/egtacmap.c
@@ -50,8 +50,8 @@ void clearStatusPanel(void) {
 
 // ==== seg000:0x8e50 ====
 void renderHudFrame(int unused) {
-    static int hudStatusOverlayVisible;
-    static int directorOverlayVisible;
+    static int hudStatusOverlayVisible{};
+    static int directorOverlayVisible{};
     int climbMarkerY, angleFixed, waypointMarkerX, circleX, angle, circleY, prevX, speedBarLen, prevY, markerX, deltaX, markerY, deltaY;
     char seekerShift;
     // probably x,y

--- a/src/egtacmap.c
+++ b/src/egtacmap.c
@@ -23,6 +23,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Runtime TTF/OTF text is rendered out-of-page at final window resolution, so
+ * transient HUD strings need explicit row invalidation where the original bitmap
+ * renderer relied on the next 320x200 page repaint to erase old pixels. */
+#define HUD_STALL_TEXT_Y 30
+#define HUD_STATUS_TEXT_Y 24
+#define HUD_DIRECTOR_TEXT_Y 90
+#define HUD_TRANSIENT_TEXT_HEIGHT 8
+
 /* Private helpers for this translation unit. */
 void egDrawStringCentered(int16 *, const char *, int, int, int);
 void renderHudFrame();
@@ -42,6 +50,8 @@ void clearStatusPanel(void) {
 
 // ==== seg000:0x8e50 ====
 void renderHudFrame(int unused) {
+    static int hudStatusOverlayVisible;
+    static int directorOverlayVisible;
     int climbMarkerY, angleFixed, waypointMarkerX, circleX, angle, circleY, prevX, speedBarLen, prevY, markerX, deltaX, markerY, deltaY;
     char seekerShift;
     // probably x,y
@@ -90,6 +100,11 @@ void renderHudFrame(int unused) {
                 drawViewportLine(242, climbMarkerY - 2, 244, climbMarkerY);
                 drawViewportLine(242, climbMarkerY + 2, 244, climbMarkerY);
             }
+            /* The stall warning blinks on alternating frames. Bitmap text was
+             * naturally erased by the next HUD repaint; TTF overlay records are
+             * persistent, so clear this row before optionally drawing it again. */
+            gfx_invalidateTtfTextOverlayRect(0, HUD_STALL_TEXT_Y, 319,
+                                             HUD_STALL_TEXT_Y + HUD_TRANSIENT_TEXT_HEIGHT);
             // stall warning display
             if (g_knots < g_cornerSpeed && g_groundAltitude != g_viewZ && frameTick & 1) {
                 drawStringActivePage("stall warning", 132, 30, 0xf);
@@ -159,6 +174,7 @@ void renderHudFrame(int unused) {
     }
     if (g_hudMsgTimer != 0 && ((g_viewMode == VIEW_COCKPIT && g_halfScaleRender == 0) || (g_directorMode != 0))) {
         drawStringActivePage(tempString, -(((int16)strlen(tempString) >> 1) - 40) * 4, 24, 0xf);
+        hudStatusOverlayVisible = 1;
         g_hudMsgTimer--;
         if (g_hudMsgTimer == 0) { // cancel pending eject on message disappear
             g_ejectPending = 0;
@@ -166,10 +182,19 @@ void renderHudFrame(int unused) {
         if (g_autopilotEngaged == 1) {
             drawStringActivePage("Press any key to play", 120, 1, g_nightMode != 0 ? 0xe : 0);
         }
+    } else if (hudStatusOverlayVisible) {
+        gfx_invalidateTtfTextOverlayRect(0, HUD_STATUS_TEXT_Y, 319,
+                                         HUD_STATUS_TEXT_Y + HUD_TRANSIENT_TEXT_HEIGHT);
+        hudStatusOverlayVisible = 0;
     }
     if (g_dirMsgTimer != 0 && g_viewMode == VIEW_COCKPIT && g_halfScaleRender == 0) {
         drawStringActivePage(string_3C04A, -(((int16)strlen(string_3C04A) >> 1) - 40) * 4, 90, 0xf);
+        directorOverlayVisible = 1;
         g_dirMsgTimer--;
+    } else if (directorOverlayVisible) {
+        gfx_invalidateTtfTextOverlayRect(0, HUD_DIRECTOR_TEXT_Y, 319,
+                                         HUD_DIRECTOR_TEXT_Y + HUD_TRANSIENT_TEXT_HEIGHT);
+        directorOverlayVisible = 0;
     }
 }
 

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -111,6 +111,9 @@ void FAR CDECL gfx_copyRect(int srcPage, uint16 srcX, uint16 srcY, int dstPage, 
 void FAR CDECL gfx_dacAnimate();                                                                                                  /* slot 0x2c: DAC palette animation */
 void FAR CDECL gfx_dacCycle();                                                                                                    /* slot 0x2e: DAC fire/colour-cycle animation */
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx);                                                                             /* slot 0x2f: setup font metrics */
+int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx);                                                                        /* native UTF-aware font metric */
+int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx);                                                                   /* native UTF-aware line metric */
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2);
 int FAR CDECL gfx_getRowOffset(int y);                                                                                            /* slot 0x3a: returns y*320 */
 /* dseg:0xbe4 */
 void FAR CDECL gfx_setMode13(void);          /* slot 0x3c: switch to 320x200 (lo-res) */

--- a/src/gfx_font_replacement.inc
+++ b/src/gfx_font_replacement.inc
@@ -14,6 +14,7 @@ static void clearTtfTextOverlayRecords(void);
 #endif
 
 
+/* Release one FreeType face and clear its replacement-font cache entry. */
 static void freeReplacementFont(uint16 fontIdx) {
     if (fontIdx >= 8) return;
 #ifdef F15_HAVE_FREETYPE
@@ -26,6 +27,7 @@ static void freeReplacementFont(uint16 fontIdx) {
 #endif
 }
 
+/* Release all vector-font faces and the shared FreeType library. */
 static void cleanupReplacementFonts(void) {
 #ifdef F15_HAVE_FREETYPE
     int i;
@@ -37,6 +39,7 @@ static void cleanupReplacementFonts(void) {
     }
 #endif
 }
+/* Decode one UTF-8 codepoint and advance the caller cursor safely. */
 static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int *byteCountOut) {
     uint32_t codepoint;
     size_t byteCount;
@@ -47,6 +50,7 @@ static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int *byte
 }
 
 #ifdef F15_HAVE_FREETYPE
+/* Discard every retained vector-text overlay record for a new screen. */
 static void clearTtfTextOverlayRecords(void) {
     int i;
     for (i = 0; i < g_ttfTextOverlayCount; i++) {
@@ -56,10 +60,12 @@ static void clearTtfTextOverlayRecords(void) {
     g_ttfTextOverlayCount = 0;
 }
 
+/* Mark all retained vector-text overlays dirty after underlying pixels change. */
 static void invalidateTtfTextOverlayRecords(void) {
     if (g_ttfTextOverlayCount > 0) clearTtfTextOverlayRecords();
 }
 
+/* Detect broad framebuffer changes that invalidate the complete retained overlay. */
 static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
     int w, h;
     if (x2 < x1) {
@@ -77,11 +83,13 @@ static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
     return w > 0 && h > 0 && w * h >= 12000;
 }
 
+/* Return the logical width occupied by one retained vector-text record. */
 static int ttfTextOverlayRecordWidth(const TtfTextOverlayRecord *record) {
     if (!record || !record->text) return 0;
     return replacementTtfStringAdvance(record->fontIdx, record->text);
 }
 
+/* Return whether two retained text records cover overlapping logical rectangles. */
 static int ttfTextOverlayRecordsOverlap(const TtfTextOverlayRecord *a,
                                         int x, int y, int width, int height,
                                         int margin) {
@@ -99,6 +107,7 @@ static int ttfTextOverlayRecordsOverlap(const TtfTextOverlayRecord *a,
     return ax2 >= bx1 && ax1 <= bx2 && ay2 >= by1 && ay1 <= by2;
 }
 
+/* Recognize changing numeric HUD text that should replace an older row record. */
 static int ttfTextOverlaySameDynamicRow(const TtfTextOverlayRecord *a,
                                         int x, int y, int width, int height) {
     int dy;
@@ -111,6 +120,7 @@ static int ttfTextOverlaySameDynamicRow(const TtfTextOverlayRecord *a,
     return dy <= 1 && ttfTextOverlayRecordsOverlap(a, x, y, width, height, 1);
 }
 
+/* Remove one retained overlay record while keeping the array densely packed. */
 static void removeTtfTextOverlayRecord(int index) {
     if (index < 0 || index >= g_ttfTextOverlayCount) return;
     SDL_free(g_ttfTextOverlayRecords[index].text);
@@ -125,6 +135,7 @@ static void removeTtfTextOverlayRecord(int index) {
     memset(&g_ttfTextOverlayRecords[g_ttfTextOverlayCount], 0, sizeof(g_ttfTextOverlayRecords[0]));
 }
 
+/* Invalidate retained text touched by a legacy framebuffer update. */
 static void invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
     int i;
     if (x2 < x1) {
@@ -149,6 +160,7 @@ static void invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
     }
 }
 
+/* Recolor retained text records affected by a legacy palette animation. */
 static void switchTtfTextOverlayColorRect(int x1, int y1, int x2, int y2, int oldColor, int newColor) {
     int i;
     if (x2 < x1) {
@@ -176,6 +188,7 @@ static void switchTtfTextOverlayColorRect(int x1, int y1, int x2, int y2, int ol
 #endif
 
 #ifdef F15_HAVE_FREETYPE
+/* Initialize the shared FreeType library exactly once. */
 static int ensureFreetypeLibrary(void) {
     if (g_freetypeLibrary) return 1;
     if (FT_Init_FreeType(&g_freetypeLibrary) != 0) {
@@ -186,6 +199,7 @@ static int ensureFreetypeLibrary(void) {
     return 1;
 }
 
+/* Sample either monochrome or antialiased FreeType bitmap coverage. */
 static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
     const uint8 *row;
     int pitch;
@@ -201,6 +215,7 @@ static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
     return 0;
 }
 
+/* Choose a vector-font pixel size that matches the legacy font slot metrics. */
 static int replacementTtfPixelSize(uint16 fontIdx) {
     int h;
     if (fontIdx >= 8) return 8;
@@ -211,6 +226,7 @@ static int replacementTtfPixelSize(uint16 fontIdx) {
     return h;
 }
 
+/* Return the FreeType advance for one Unicode codepoint at the active size. */
 static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
     const uint8 *widths;
     int idx;
@@ -223,6 +239,7 @@ static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
     return g_fontMaxWidths[fontIdx] > 0 ? g_fontMaxWidths[fontIdx] : 8;
 }
 
+/* Return the logical advance for one legacy byte through its UTF-8-compatible mapping. */
 static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
     FT_Face face;
     int advance;
@@ -238,6 +255,7 @@ static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
     return advance > 0 ? advance : 1;
 }
 
+/* Choose one consistent line scale that fits the original game text rectangle. */
 static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
                                       float targetScaleX, float targetScaleY,
                                       float *layoutScaleX, float *layoutScaleY) {
@@ -277,6 +295,7 @@ static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
     }
 }
 
+/* Measure a complete UTF-8 string using the same layout rules as rendering. */
 static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
     FT_Face face;
     FT_UInt previousGlyphIndex = 0;
@@ -344,6 +363,7 @@ static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
     return (int)(x + 0.5f);
 }
 
+/* Load and cache an optional TTF or OTF face for one legacy font slot. */
 static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
     FT_Face face = NULL;
     int fontWidth;
@@ -371,6 +391,7 @@ static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
     return 1;
 }
 
+/* Retain one UTF-8 line for vector rendering and return its logical advance. */
 static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
                                           int clipL, int clipR, int clipT, int clipB) {
     TtfTextOverlayRecord *record;
@@ -411,6 +432,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
         if (candidate->fontIdx == fontIdx &&
             candidate->clipL == clipL && candidate->clipR == clipR &&
             candidate->clipT == clipT && candidate->clipB == clipB &&
+/* Recognize changing numeric HUD text that should replace an older row record. */
             ttfTextOverlaySameDynamicRow(candidate, newX, newY, newWidth, newHeight)) {
             removeTtfTextOverlayRecord(i);
             if (recordIndex > i) recordIndex--;
@@ -475,6 +497,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
     return 1;
 }
 
+/* Render one FreeType glyph through the SDL framebuffer backend. */
 static void renderTtfTextOverlayGlyphSDL(SDL_Renderer *renderer, FT_Bitmap *bitmap, float x, float y,
                                          float pixelScaleX, float pixelScaleY, uint8 r, uint8 g, uint8 b, SDL_FRect clip) {
     int row, col;
@@ -495,6 +518,7 @@ static void renderTtfTextOverlayGlyphSDL(SDL_Renderer *renderer, FT_Bitmap *bitm
     }
 }
 
+/* Render one FreeType glyph through the OpenGL overlay backend. */
 static void renderTtfTextOverlayGlyphGL(FT_Bitmap *bitmap, float x, float y, float pixelScaleX, float pixelScaleY,
                                         uint8 r, uint8 g, uint8 b, SDL_FRect clip) {
     int row, col;
@@ -522,6 +546,7 @@ static void renderTtfTextOverlayGlyphGL(FT_Bitmap *bitmap, float x, float y, flo
     glDisable(GL_BLEND);
 }
 
+/* Lay out and render one retained UTF-8 text record as a coherent line. */
 static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMapping *m,
                                        SDL_Renderer *renderer, int useGL) {
     SDL_Color c;
@@ -640,6 +665,7 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
     }
 }
 
+/* Render all retained vector-text records for the current frame. */
 static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL) {
     int i;
     if (!m || g_ttfTextOverlayCount <= 0) return;
@@ -648,6 +674,7 @@ static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useG
     }
 }
 
+/* Render retained vector text into the active OpenGL presentation mapping. */
 void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
     R2DMapping m;
     r2d_computeMapping(virtW, virtH, winW, winH, 0, &m);
@@ -660,21 +687,26 @@ void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
     renderTtfTextOverlay(&m, NULL, 1);
 }
 
+/* Clear retained vector text when the legacy screen contents are replaced. */
 void gfx_clearTtfTextOverlay(void) {
     clearTtfTextOverlayRecords();
 }
 
+/* Invalidate retained vector text intersecting a changed logical rectangle. */
 void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
     invalidateTtfTextOverlayRect(x1, y1, x2, y2);
 }
 #else
+/* Render retained vector text into the active OpenGL presentation mapping. */
 void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
     (void)virtW;
     (void)virtH;
     (void)winW;
     (void)winH;
 }
+/* Clear retained vector text when the legacy screen contents are replaced. */
 void gfx_clearTtfTextOverlay(void) {}
+/* Invalidate retained vector text intersecting a changed logical rectangle. */
 void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
     (void)x1;
     (void)y1;
@@ -684,6 +716,7 @@ void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
 #endif
 
 
+/* Find a TTF or OTF replacement using stable per-slot filenames. */
 static int findReplacementVectorFont(uint16 fontIdx, const char *extension,
                                      char *path, size_t pathSize) {
     char relative[64];
@@ -692,6 +725,7 @@ static int findReplacementVectorFont(uint16 fontIdx, const char *extension,
     return findAssetReplacement(relative, path, pathSize);
 }
 
+/* Activate a vector-font replacement for one legacy font slot when available. */
 static void tryLoadReplacementFont(uint16 fontIdx) {
     char path[512];
     int vectorFontPresent = 0;

--- a/src/gfx_font_replacement.inc
+++ b/src/gfx_font_replacement.inc
@@ -10,7 +10,7 @@ typedef struct TtfTextOverlayRecord {
 } TtfTextOverlayRecord;
 static TtfTextOverlayRecord g_ttfTextOverlayRecords[512];
 static int g_ttfTextOverlayCount;
-static int g_ttfTextOverlayGeneration;
+static void clearTtfTextOverlayRecords(void);
 #endif
 
 
@@ -29,6 +29,7 @@ static void freeReplacementFont(uint16 fontIdx) {
 static void cleanupReplacementFonts(void) {
 #ifdef F15_HAVE_FREETYPE
     int i;
+    clearTtfTextOverlayRecords();
     for (i = 0; i < 8; i++) freeReplacementFont((uint16)i);
     if (g_freetypeLibrary) {
         FT_Done_FreeType(g_freetypeLibrary);
@@ -435,7 +436,12 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
 
     record->text = SDL_strdup(string);
     if (!record->text) {
-        record->x = 0;
+        if (recordIndex < 0) {
+            --g_ttfTextOverlayCount;
+            memset(record, 0, sizeof(*record));
+        } else {
+            removeTtfTextOverlayRecord(recordIndex);
+        }
         return 0;
     }
     record->x = newX;

--- a/src/gfx_font_replacement.inc
+++ b/src/gfx_font_replacement.inc
@@ -1,0 +1,714 @@
+#ifdef F15_HAVE_FREETYPE
+static FT_Library g_freetypeLibrary = NULL;
+static FT_Face g_fontReplacementTtfFaces[8] = {NULL};
+static char *g_fontReplacementTtfPaths[8] = {NULL};
+typedef struct TtfTextOverlayRecord {
+    char *text;
+    int x, y, color;
+    uint16 fontIdx;
+    int clipL, clipR, clipT, clipB;
+} TtfTextOverlayRecord;
+static TtfTextOverlayRecord g_ttfTextOverlayRecords[512];
+static int g_ttfTextOverlayCount;
+static int g_ttfTextOverlayGeneration;
+#endif
+
+
+static void freeReplacementFont(uint16 fontIdx) {
+    if (fontIdx >= 8) return;
+#ifdef F15_HAVE_FREETYPE
+    if (g_fontReplacementTtfFaces[fontIdx]) {
+        FT_Done_Face(g_fontReplacementTtfFaces[fontIdx]);
+        g_fontReplacementTtfFaces[fontIdx] = NULL;
+    }
+    SDL_free(g_fontReplacementTtfPaths[fontIdx]);
+    g_fontReplacementTtfPaths[fontIdx] = NULL;
+#endif
+}
+
+static void cleanupReplacementFonts(void) {
+#ifdef F15_HAVE_FREETYPE
+    int i;
+    for (i = 0; i < 8; i++) freeReplacementFont((uint16)i);
+    if (g_freetypeLibrary) {
+        FT_Done_FreeType(g_freetypeLibrary);
+        g_freetypeLibrary = NULL;
+    }
+#endif
+}
+static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int *byteCountOut) {
+    uint32_t codepoint;
+    size_t byteCount;
+    if (!utf8DecodeCodepoint(text, &codepoint, &byteCount)) return 0;
+    *codepointOut = (uint32)codepoint;
+    *byteCountOut = (int)byteCount;
+    return 1;
+}
+
+#ifdef F15_HAVE_FREETYPE
+static void clearTtfTextOverlayRecords(void) {
+    int i;
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        SDL_free(g_ttfTextOverlayRecords[i].text);
+        g_ttfTextOverlayRecords[i].text = NULL;
+    }
+    g_ttfTextOverlayCount = 0;
+}
+
+static void invalidateTtfTextOverlayRecords(void) {
+    if (g_ttfTextOverlayCount > 0) clearTtfTextOverlayRecords();
+}
+
+static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
+    int w, h;
+    if (x2 < x1) {
+        int tmp = x1;
+        x1 = x2;
+        x2 = tmp;
+    }
+    if (y2 < y1) {
+        int tmp = y1;
+        y1 = y2;
+        y2 = tmp;
+    }
+    w = x2 - x1 + 1;
+    h = y2 - y1 + 1;
+    return w > 0 && h > 0 && w * h >= 12000;
+}
+
+static int ttfTextOverlayRecordWidth(const TtfTextOverlayRecord *record) {
+    if (!record || !record->text) return 0;
+    return replacementTtfStringAdvance(record->fontIdx, record->text);
+}
+
+static int ttfTextOverlayRecordsOverlap(const TtfTextOverlayRecord *a,
+                                        int x, int y, int width, int height,
+                                        int margin) {
+    int ax1, ay1, ax2, ay2;
+    int bx1, by1, bx2, by2;
+    if (!a || width <= 0 || height <= 0) return 0;
+    ax1 = a->x - margin;
+    ay1 = a->y - margin;
+    ax2 = a->x + ttfTextOverlayRecordWidth(a) + margin - 1;
+    ay2 = a->y + g_fontHeightsArr[a->fontIdx] + margin - 1;
+    bx1 = x - margin;
+    by1 = y - margin;
+    bx2 = x + width + margin - 1;
+    by2 = y + height + margin - 1;
+    return ax2 >= bx1 && ax1 <= bx2 && ay2 >= by1 && ay1 <= by2;
+}
+
+static int ttfTextOverlaySameDynamicRow(const TtfTextOverlayRecord *a,
+                                        int x, int y, int width, int height) {
+    int dy;
+    if (!a) return 0;
+    dy = a->y - y;
+    if (dy < 0) dy = -dy;
+    /* Only treat one-pixel HUD jitter as a replacement. Menu rows are retained
+     * text and can share wide clip windows; deleting by broad overlap there can
+     * remove neighboring labels such as the TODAY'S MISSION header. */
+    return dy <= 1 && ttfTextOverlayRecordsOverlap(a, x, y, width, height, 1);
+}
+
+static void removeTtfTextOverlayRecord(int index) {
+    if (index < 0 || index >= g_ttfTextOverlayCount) return;
+    SDL_free(g_ttfTextOverlayRecords[index].text);
+    if (index + 1 < g_ttfTextOverlayCount) {
+        memmove(
+            &g_ttfTextOverlayRecords[index],
+            &g_ttfTextOverlayRecords[index + 1],
+            (size_t)(g_ttfTextOverlayCount - index - 1) * sizeof(g_ttfTextOverlayRecords[0])
+        );
+    }
+    g_ttfTextOverlayCount--;
+    memset(&g_ttfTextOverlayRecords[g_ttfTextOverlayCount], 0, sizeof(g_ttfTextOverlayRecords[0]));
+}
+
+static void invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
+    int i;
+    if (x2 < x1) {
+        int tmp = x1;
+        x1 = x2;
+        x2 = tmp;
+    }
+    if (y2 < y1) {
+        int tmp = y1;
+        y1 = y2;
+        y2 = tmp;
+    }
+    for (i = g_ttfTextOverlayCount - 1; i >= 0; i--) {
+        TtfTextOverlayRecord *record = &g_ttfTextOverlayRecords[i];
+        int rx1 = record->x;
+        int ry1 = record->y;
+        int rx2 = record->x + ttfTextOverlayRecordWidth(record) - 1;
+        int ry2 = record->y + g_fontHeightsArr[record->fontIdx] - 1;
+        if (rx2 >= x1 && rx1 <= x2 && ry2 >= y1 && ry1 <= y2) {
+            removeTtfTextOverlayRecord(i);
+        }
+    }
+}
+
+static void switchTtfTextOverlayColorRect(int x1, int y1, int x2, int y2, int oldColor, int newColor) {
+    int i;
+    if (x2 < x1) {
+        int tmp = x1;
+        x1 = x2;
+        x2 = tmp;
+    }
+    if (y2 < y1) {
+        int tmp = y1;
+        y1 = y2;
+        y2 = tmp;
+    }
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        TtfTextOverlayRecord *record = &g_ttfTextOverlayRecords[i];
+        int rx1 = record->x;
+        int ry1 = record->y;
+        int rx2 = record->x + ttfTextOverlayRecordWidth(record) - 1;
+        int ry2 = record->y + g_fontHeightsArr[record->fontIdx] - 1;
+        if ((record->color & 0xff) == (oldColor & 0xff) &&
+            rx2 >= x1 && rx1 <= x2 && ry2 >= y1 && ry1 <= y2) {
+            record->color = newColor;
+        }
+    }
+}
+#endif
+
+#ifdef F15_HAVE_FREETYPE
+static int ensureFreetypeLibrary(void) {
+    if (g_freetypeLibrary) return 1;
+    if (FT_Init_FreeType(&g_freetypeLibrary) != 0) {
+        g_freetypeLibrary = NULL;
+        LogWarn(("asset replacement: FreeType initialization failed; TTF/OTF fonts disabled"));
+        return 0;
+    }
+    return 1;
+}
+
+static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
+    const uint8 *row;
+    int pitch;
+    if (!bitmap || !bitmap->buffer || x < 0 || y < 0 || x >= (int)bitmap->width || y >= (int)bitmap->rows) return 0;
+    pitch = bitmap->pitch < 0 ? -bitmap->pitch : bitmap->pitch;
+    row = bitmap->buffer + (size_t)y * (size_t)pitch;
+    if (bitmap->pixel_mode == FT_PIXEL_MODE_MONO) {
+        return (row[x >> 3] & (0x80u >> (x & 7))) ? 255 : 0;
+    }
+    if (bitmap->pixel_mode == FT_PIXEL_MODE_GRAY) {
+        return row[x];
+    }
+    return 0;
+}
+
+static int replacementTtfPixelSize(uint16 fontIdx) {
+    int h;
+    if (fontIdx >= 8) return 8;
+    h = g_fontHeightsArr[fontIdx];
+    /* Replacement TTF text must occupy the same screen footprint as the original
+     * bitmap fonts. FreeType still supplies shape/coverage, but layout remains
+     * compatible with the legacy menu coordinates and clipping windows. */
+    return h;
+}
+
+static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
+    const uint8 *widths;
+    int idx;
+    if (fontIdx >= 8) return 8;
+    widths = g_fontWidthTables[fontIdx];
+    if (widths) {
+        idx = 'n' - 0x20;
+        if (idx >= 0 && idx < 96 && widths[idx] > 0) return widths[idx];
+    }
+    return g_fontMaxWidths[fontIdx] > 0 ? g_fontMaxWidths[fontIdx] : 8;
+}
+
+static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
+    FT_Face face;
+    int advance;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 8;
+    if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
+        return g_fontWidthTables[fontIdx][codepoint - 0x20];
+    }
+    if (codepoint >= 0x80) return replacementTtfUnicodeAdvance(fontIdx);
+    face = g_fontReplacementTtfFaces[fontIdx];
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return 8;
+    if (FT_Load_Char(face, (FT_ULong)codepoint, FT_LOAD_DEFAULT) != 0) return 8;
+    advance = (int)((face->glyph->advance.x + 32) >> 6);
+    return advance > 0 ? advance : 1;
+}
+
+static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
+                                      float targetScaleX, float targetScaleY,
+                                      float *layoutScaleX, float *layoutScaleY) {
+    FT_Face face;
+    const uint8 *legacyWidths;
+    int ch;
+    int legacyAdvance = 0;
+    int ftAdvance = 0;
+    float targetHeight;
+    float ftHeight;
+
+    *layoutScaleX = 1.0f;
+    *layoutScaleY = 1.0f;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return;
+    face = g_fontReplacementTtfFaces[fontIdx];
+    legacyWidths = g_fontWidthTables[fontIdx];
+    if (!legacyWidths) return;
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)SDL_max(1, pixelSize)) != 0) return;
+
+    /* Calibrate the scalable face once per rendered font size against the whole
+     * printable ASCII width table. This keeps all TTF/OTF lines for a font at a
+     * single consistent scale while still matching the old menu footprint. */
+    for (ch = 0x20; ch < 0x80; ch++) {
+        legacyAdvance += legacyWidths[ch - 0x20];
+        if (FT_Load_Glyph(face, FT_Get_Char_Index(face, (FT_ULong)ch), FT_LOAD_DEFAULT) == 0) {
+            ftAdvance += (int)(face->glyph->advance.x >> 6);
+        }
+    }
+    if (ftAdvance > 0) {
+        *layoutScaleX = ((float)legacyAdvance * targetScaleX) / (float)ftAdvance;
+    }
+
+    targetHeight = (float)g_fontHeightsArr[fontIdx] * targetScaleY;
+    ftHeight = face->size ? (float)(face->size->metrics.height >> 6) : (float)pixelSize;
+    if (ftHeight > 0.0f) {
+        *layoutScaleY = targetHeight / ftHeight;
+    }
+}
+
+static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
+    FT_Face face;
+    FT_UInt previousGlyphIndex = 0;
+    float layoutScaleX;
+    float layoutScaleY;
+    float x = 0.0f;
+    int charIdx;
+    int drawnChars;
+
+    if (!text || fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    if (fontIdx == 0) {
+        int width = 0;
+        for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+            uint32 codepoint;
+            uint8 ch = (uint8)text[charIdx];
+            int byteCount = 1;
+            if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
+                codepoint = ch;
+                byteCount = 1;
+            }
+            if (byteCount == 1 && (ch & 0x80)) {
+                charIdx++;
+                continue;
+            }
+            width += replacementTtfAdvance(fontIdx, codepoint);
+            charIdx += byteCount;
+            drawnChars++;
+        }
+        return width;
+    }
+    face = g_fontReplacementTtfFaces[fontIdx];
+    replacementTtfLayoutScale(fontIdx, replacementTtfPixelSize(fontIdx), 1.0f, 1.0f,
+                              &layoutScaleX, &layoutScaleY);
+    (void)layoutScaleY;
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return 0;
+
+    for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)text[charIdx];
+        int byteCount = 1;
+        FT_UInt glyphIndex;
+        FT_Vector kerning;
+
+        if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            charIdx++;
+            continue;
+        }
+        glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
+        if (previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+            if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
+                x += (float)(kerning.x >> 6) * layoutScaleX;
+            }
+        }
+        if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT) == 0) {
+            x += (float)(face->glyph->advance.x >> 6) * layoutScaleX;
+        }
+        previousGlyphIndex = glyphIndex;
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    return (int)(x + 0.5f);
+}
+
+static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
+    FT_Face face = NULL;
+    int fontWidth;
+    int fontHeight;
+
+    if (fontIdx >= 8 || !replacementPath) return 0;
+    fontWidth = g_fontMaxWidths[fontIdx];
+    fontHeight = g_fontHeightsArr[fontIdx];
+    if (fontWidth <= 0 || fontWidth > 8 || fontHeight <= 0 || fontHeight > 32) return 0;
+    if (!ensureFreetypeLibrary()) return 0;
+    if (FT_New_Face(g_freetypeLibrary, replacementPath, 0, &face) != 0 || !face) {
+        LogWarn(("asset replacement: failed to load TTF/OTF font %u at %s", (unsigned)fontIdx, replacementPath));
+        return 0;
+    }
+    /* Runtime TTF/OTF replacement is the Unicode source of truth. Some faces do
+     * not expose their Unicode cmap as the default charmap, which makes Cyrillic
+     * and other non-ASCII input resolve to glyph 0 and render as blank cells. */
+    (void)FT_Select_Charmap(face, FT_ENCODING_UNICODE);
+
+    freeReplacementFont(fontIdx);
+    g_fontReplacementTtfFaces[fontIdx] = face;
+    g_fontReplacementTtfPaths[fontIdx] = SDL_strdup(replacementPath);
+
+    LogInfo(("asset replacement: loaded font %u from runtime TTF/OTF %s", (unsigned)fontIdx, replacementPath));
+    return 1;
+}
+
+static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
+                                          int clipL, int clipR, int clipT, int clipB) {
+    TtfTextOverlayRecord *record;
+    int charIdx;
+    int drawnChars;
+    int color;
+    uint16 fontIdx;
+    int i;
+    int newX;
+    int newY;
+    int newWidth;
+    int newHeight;
+    int recordIndex;
+
+    if (!params || !string) return 0;
+    fontIdx = (uint16)params[6] & 7;
+    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    newX = (int)params[4];
+    newY = (int)params[5];
+    newWidth = replacementTtfStringAdvance(fontIdx, string);
+    newHeight = g_fontHeightsArr[fontIdx];
+
+    recordIndex = -1;
+    for (i = g_ttfTextOverlayCount - 1; i >= 0; i--) {
+        TtfTextOverlayRecord *candidate = &g_ttfTextOverlayRecords[i];
+        if (candidate->fontIdx == fontIdx &&
+            candidate->clipL == clipL && candidate->clipR == clipR &&
+            candidate->clipT == clipT && candidate->clipB == clipB &&
+            candidate->x == newX && candidate->y == newY) {
+            recordIndex = i;
+            continue;
+        }
+        /* Dynamic HUD values are often cleared/redrawn with a one-pixel anchor
+         * shift as their width changes. Exact-position keys leave the old TTF
+         * overlay on screen, because it was never baked into the page being
+         * cleared. Treat near/overlapping same-font text in the same clip window
+         * as a replacement candidate. */
+        if (candidate->fontIdx == fontIdx &&
+            candidate->clipL == clipL && candidate->clipR == clipR &&
+            candidate->clipT == clipT && candidate->clipB == clipB &&
+            ttfTextOverlaySameDynamicRow(candidate, newX, newY, newWidth, newHeight)) {
+            removeTtfTextOverlayRecord(i);
+            if (recordIndex > i) recordIndex--;
+        }
+    }
+
+    if (string[0] == '\0') {
+        if (recordIndex >= 0) {
+            removeTtfTextOverlayRecord(recordIndex);
+        }
+        return 1;
+    }
+
+    if (recordIndex < 0) {
+        if (g_ttfTextOverlayCount >= (int)(sizeof(g_ttfTextOverlayRecords) / sizeof(g_ttfTextOverlayRecords[0]))) return 0;
+        record = &g_ttfTextOverlayRecords[g_ttfTextOverlayCount++];
+        memset(record, 0, sizeof(*record));
+    } else {
+        record = &g_ttfTextOverlayRecords[recordIndex];
+        SDL_free(record->text);
+        record->text = NULL;
+    }
+
+    record->text = SDL_strdup(string);
+    if (!record->text) {
+        record->x = 0;
+        return 0;
+    }
+    record->x = newX;
+    record->y = newY;
+    record->color = (int)params[2];
+    record->fontIdx = fontIdx;
+    record->clipL = clipL;
+    record->clipR = clipR;
+    record->clipT = clipT;
+    record->clipB = clipB;
+
+    color = record->color;
+    for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)string[charIdx];
+        int byteCount = 1;
+        if (!decodeUtf8Codepoint(&string[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            color = ch & 0x7F;
+            charIdx++;
+            continue;
+        }
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    params[4] = (int16)(record->x + newWidth);
+    params[2] = (int16)color;
+    return 1;
+}
+
+static void renderTtfTextOverlayGlyphSDL(SDL_Renderer *renderer, FT_Bitmap *bitmap, float x, float y,
+                                         float pixelScaleX, float pixelScaleY, uint8 r, uint8 g, uint8 b, SDL_FRect clip) {
+    int row, col;
+    SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    for (row = 0; row < (int)bitmap->rows; row++) {
+        for (col = 0; col < (int)bitmap->width; col++) {
+            uint8 coverage = freetypeBitmapPixel(bitmap, col, row);
+            SDL_FRect px;
+            if (!coverage) continue;
+            px.x = x + (float)col * pixelScaleX;
+            px.y = y + (float)row * pixelScaleY;
+            px.w = pixelScaleX;
+            px.h = pixelScaleY;
+            if (px.x < clip.x || px.y < clip.y || px.x >= clip.x + clip.w || px.y >= clip.y + clip.h) continue;
+            SDL_SetRenderDrawColor(renderer, r, g, b, coverage);
+            SDL_RenderFillRect(renderer, &px);
+        }
+    }
+}
+
+static void renderTtfTextOverlayGlyphGL(FT_Bitmap *bitmap, float x, float y, float pixelScaleX, float pixelScaleY,
+                                        uint8 r, uint8 g, uint8 b, SDL_FRect clip) {
+    int row, col;
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBegin(GL_QUADS);
+    for (row = 0; row < (int)bitmap->rows; row++) {
+        for (col = 0; col < (int)bitmap->width; col++) {
+            uint8 coverage = freetypeBitmapPixel(bitmap, col, row);
+            float x0, y0, x1, y1;
+            if (!coverage) continue;
+            x0 = x + (float)col * pixelScaleX;
+            y0 = y + (float)row * pixelScaleY;
+            if (x0 < clip.x || y0 < clip.y || x0 >= clip.x + clip.w || y0 >= clip.y + clip.h) continue;
+            x1 = x0 + pixelScaleX;
+            y1 = y0 + pixelScaleY;
+            glColor4ub(r, g, b, coverage);
+            glVertex2f(x0, y0);
+            glVertex2f(x1, y0);
+            glVertex2f(x1, y1);
+            glVertex2f(x0, y1);
+        }
+    }
+    glEnd();
+    glDisable(GL_BLEND);
+}
+
+static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMapping *m,
+                                       SDL_Renderer *renderer, int useGL) {
+    SDL_Color c;
+    SDL_Palette *pal;
+    FT_Face face;
+    FT_UInt previousGlyphIndex = 0;
+    float x;
+    int charIdx;
+    int drawnChars;
+    int pixelSize;
+    float cellY;
+    float cellHeight;
+    float baseline;
+    float ascender;
+    float layoutScaleX;
+    float layoutScaleY;
+    SDL_FRect clip;
+
+    if (!record || !record->text || record->fontIdx >= 8 || !g_fontReplacementTtfFaces[record->fontIdx]) return;
+    face = g_fontReplacementTtfFaces[record->fontIdx];
+    pixelSize = SDL_max(1, (int)((float)g_fontHeightsArr[record->fontIdx] * m->scaleY + 0.5f));
+    if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)pixelSize) != 0) return;
+    replacementTtfLayoutScale(record->fontIdx, pixelSize, m->scaleX, m->scaleY,
+                              &layoutScaleX, &layoutScaleY);
+    pal = gfx_getPalette();
+    if (!pal) return;
+    c = pal->colors[record->color & 0xff];
+    x = (float)m->offX + (float)record->x * m->scaleX;
+    cellY = (float)m->offY + (float)record->y * m->scaleY;
+    cellHeight = (float)g_fontHeightsArr[record->fontIdx] * m->scaleY;
+    ascender = face->size ? (float)(face->size->metrics.ascender >> 6) * layoutScaleY : cellHeight;
+    baseline = cellY + ascender;
+    clip.x = (float)m->offX + (float)record->clipL * m->scaleX;
+    clip.y = (float)m->offY + (float)record->clipT * m->scaleY;
+    clip.w = (float)(record->clipR - record->clipL + 1) * m->scaleX;
+    clip.h = (float)(record->clipB - record->clipT + 1) * m->scaleY;
+    if (record->fontIdx == 0 && record->y >= HUD_BOTTOM_TTF_CLIP_Y) {
+        float maxBottom = (float)m->offY + (float)VGA_PAGE_HEIGHT * m->scaleY;
+        float wantedBottom =
+            ((float)record->y + (float)g_fontHeightsArr[record->fontIdx] +
+             HUD_BOTTOM_TTF_EXTRA_LINES) *
+                m->scaleY +
+            (float)m->offY;
+        if (wantedBottom > clip.y + clip.h) clip.h = wantedBottom - clip.y;
+        if (clip.y + clip.h > maxBottom) clip.h = maxBottom - clip.y;
+    }
+
+    for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)record->text[charIdx];
+        int byteCount = 1;
+        FT_UInt glyphIndex;
+        FT_Vector kerning;
+        FT_GlyphSlot glyph;
+        FT_Bitmap *bitmap;
+        float gx;
+        float gy;
+        float glyphScaleX;
+        float glyphScaleY;
+
+        if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            c = pal->colors[ch & 0x7f];
+            charIdx++;
+            continue;
+        }
+        glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
+        if (previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+            if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
+                x += (float)(kerning.x >> 6) * layoutScaleX;
+            }
+        }
+        if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_RENDER) == 0) {
+            glyph = face->glyph;
+            bitmap = &glyph->bitmap;
+            glyphScaleX = layoutScaleX;
+            glyphScaleY = layoutScaleY;
+            if (record->fontIdx == 0) {
+                float targetAdvance = (float)replacementTtfAdvance(record->fontIdx, codepoint) * m->scaleX;
+                /* HUD font_0 is position-sensitive: original glyph cells are
+                 * anchored at the exact (x,y) page coordinate. FreeType natural
+                 * bearings make speed/altitude labels drift by pixels compared
+                 * with the bitmap HUD. Keep high-resolution rasterization, but fit
+                 * each glyph into the old cell width so digits/letters do not
+                 * collide or overflow the tiny legacy clear rectangles. */
+                if (bitmap->width > 0 && targetAdvance > 1.0f) {
+                    float fitScale = (targetAdvance * 0.82f) / (float)bitmap->width;
+                    if (fitScale > 0.0f && fitScale < glyphScaleX) glyphScaleX = fitScale;
+                }
+                gx = x;
+                if (glyph->bitmap_top > 0 &&
+                    (float)bitmap->rows * glyphScaleY < cellHeight * 0.8f) {
+                    gy = baseline - (float)glyph->bitmap_top * glyphScaleY;
+                } else {
+                    gy = cellY;
+                }
+            } else {
+                gx = x + (float)glyph->bitmap_left * layoutScaleX;
+                gy = baseline - (float)glyph->bitmap_top * layoutScaleY;
+            }
+            if (gy < cellY) gy = cellY;
+            if (useGL) renderTtfTextOverlayGlyphGL(bitmap, gx, gy, glyphScaleX, glyphScaleY, c.r, c.g, c.b, clip);
+            else renderTtfTextOverlayGlyphSDL(renderer, bitmap, gx, gy, glyphScaleX, glyphScaleY, c.r, c.g, c.b, clip);
+        }
+        if (record->fontIdx == 0) {
+            x += (float)replacementTtfAdvance(record->fontIdx, codepoint) * m->scaleX;
+        } else if (FT_Load_Glyph(face, glyphIndex, FT_LOAD_DEFAULT) == 0) {
+            x += (float)(face->glyph->advance.x >> 6) * layoutScaleX;
+        }
+        previousGlyphIndex = glyphIndex;
+        charIdx += byteCount;
+        drawnChars++;
+    }
+}
+
+static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL) {
+    int i;
+    if (!m || g_ttfTextOverlayCount <= 0) return;
+    for (i = 0; i < g_ttfTextOverlayCount; i++) {
+        renderTtfTextOverlayRecord(&g_ttfTextOverlayRecords[i], m, renderer, useGL);
+    }
+}
+
+void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
+    R2DMapping m;
+    r2d_computeMapping(virtW, virtH, winW, winH, 0, &m);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0, winW, winH, 0, -1, 1);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    glDisable(GL_TEXTURE_2D);
+    renderTtfTextOverlay(&m, NULL, 1);
+}
+
+void gfx_clearTtfTextOverlay(void) {
+    clearTtfTextOverlayRecords();
+}
+
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
+    invalidateTtfTextOverlayRect(x1, y1, x2, y2);
+}
+#else
+void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
+    (void)virtW;
+    (void)virtH;
+    (void)winW;
+    (void)winH;
+}
+void gfx_clearTtfTextOverlay(void) {}
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
+    (void)x1;
+    (void)y1;
+    (void)x2;
+    (void)y2;
+}
+#endif
+
+
+static int findReplacementVectorFont(uint16 fontIdx, const char *extension,
+                                     char *path, size_t pathSize) {
+    char relative[64];
+    snprintf(relative, sizeof(relative), "fonts/font_%u.%s",
+             (unsigned)fontIdx, extension);
+    return findAssetReplacement(relative, path, pathSize);
+}
+
+static void tryLoadReplacementFont(uint16 fontIdx) {
+    char path[512];
+    int vectorFontPresent = 0;
+
+    if (fontIdx >= 8 || g_fontReplacementTried[fontIdx]) return;
+    g_fontReplacementTried[fontIdx] = 1;
+#ifdef F15_HAVE_FREETYPE
+    if (findReplacementVectorFont(fontIdx, "ttf", path, sizeof(path))) {
+        vectorFontPresent = 1;
+        if (loadReplacementFontTtf(fontIdx, path)) return;
+    }
+    if (findReplacementVectorFont(fontIdx, "otf", path, sizeof(path))) {
+        vectorFontPresent = 1;
+        if (loadReplacementFontTtf(fontIdx, path)) return;
+    }
+#else
+    vectorFontPresent =
+        findReplacementVectorFont(fontIdx, "ttf", path, sizeof(path)) ||
+        findReplacementVectorFont(fontIdx, "otf", path, sizeof(path));
+#endif
+    if (vectorFontPresent) {
+        LogWarn(("asset replacement: rejected vector font %u; using bitmap fallback",
+                 (unsigned)fontIdx));
+    }
+    tryLoadBitmapFontReplacement(fontIdx);
+}

--- a/src/gfx_font_replacement.inc
+++ b/src/gfx_font_replacement.inc
@@ -8,8 +8,8 @@ typedef struct TtfTextOverlayRecord {
     uint16 fontIdx;
     int clipL, clipR, clipT, clipB;
 } TtfTextOverlayRecord;
-static TtfTextOverlayRecord g_ttfTextOverlayRecords[512];
-static int g_ttfTextOverlayCount;
+static TtfTextOverlayRecord g_ttfTextOverlayRecords[512]{};
+static int g_ttfTextOverlayCount{};
 static void clearTtfTextOverlayRecords(void);
 #endif
 
@@ -30,7 +30,7 @@ static void freeReplacementFont(uint16 fontIdx) {
 /* Release all vector-font faces and the shared FreeType library. */
 static void cleanupReplacementFonts(void) {
 #ifdef F15_HAVE_FREETYPE
-    int i;
+    int i{};
     clearTtfTextOverlayRecords();
     for (i = 0; i < 8; i++) freeReplacementFont((uint16)i);
     if (g_freetypeLibrary) {
@@ -41,8 +41,8 @@ static void cleanupReplacementFonts(void) {
 }
 /* Decode one UTF-8 codepoint and advance the caller cursor safely. */
 static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int *byteCountOut) {
-    uint32_t codepoint;
-    size_t byteCount;
+    uint32_t codepoint{};
+    size_t byteCount{};
     if (!utf8DecodeCodepoint(text, &codepoint, &byteCount)) return 0;
     *codepointOut = (uint32)codepoint;
     *byteCountOut = (int)byteCount;
@@ -52,7 +52,7 @@ static int decodeUtf8Codepoint(const char *text, uint32 *codepointOut, int *byte
 #ifdef F15_HAVE_FREETYPE
 /* Discard every retained vector-text overlay record for a new screen. */
 static void clearTtfTextOverlayRecords(void) {
-    int i;
+    int i{};
     for (i = 0; i < g_ttfTextOverlayCount; i++) {
         SDL_free(g_ttfTextOverlayRecords[i].text);
         g_ttfTextOverlayRecords[i].text = NULL;
@@ -110,7 +110,7 @@ static int ttfTextOverlayRecordsOverlap(const TtfTextOverlayRecord *a,
 /* Recognize changing numeric HUD text that should replace an older row record. */
 static int ttfTextOverlaySameDynamicRow(const TtfTextOverlayRecord *a,
                                         int x, int y, int width, int height) {
-    int dy;
+    int dy{};
     if (!a) return 0;
     dy = a->y - y;
     if (dy < 0) dy = -dy;
@@ -137,7 +137,7 @@ static void removeTtfTextOverlayRecord(int index) {
 
 /* Invalidate retained text touched by a legacy framebuffer update. */
 static void invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
-    int i;
+    int i{};
     if (x2 < x1) {
         int tmp = x1;
         x1 = x2;
@@ -162,7 +162,7 @@ static void invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
 
 /* Recolor retained text records affected by a legacy palette animation. */
 static void switchTtfTextOverlayColorRect(int x1, int y1, int x2, int y2, int oldColor, int newColor) {
-    int i;
+    int i{};
     if (x2 < x1) {
         int tmp = x1;
         x1 = x2;
@@ -201,8 +201,8 @@ static int ensureFreetypeLibrary(void) {
 
 /* Sample either monochrome or antialiased FreeType bitmap coverage. */
 static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
-    const uint8 *row;
-    int pitch;
+    const uint8 *row{};
+    int pitch{};
     if (!bitmap || !bitmap->buffer || x < 0 || y < 0 || x >= (int)bitmap->width || y >= (int)bitmap->rows) return 0;
     pitch = bitmap->pitch < 0 ? -bitmap->pitch : bitmap->pitch;
     row = bitmap->buffer + (size_t)y * (size_t)pitch;
@@ -217,7 +217,7 @@ static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
 
 /* Choose a vector-font pixel size that matches the legacy font slot metrics. */
 static int replacementTtfPixelSize(uint16 fontIdx) {
-    int h;
+    int h{};
     if (fontIdx >= 8) return 8;
     h = g_fontHeightsArr[fontIdx];
     /* Replacement TTF text must occupy the same screen footprint as the original
@@ -228,8 +228,8 @@ static int replacementTtfPixelSize(uint16 fontIdx) {
 
 /* Return the FreeType advance for one Unicode codepoint at the active size. */
 static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
-    const uint8 *widths;
-    int idx;
+    const uint8 *widths{};
+    int idx{};
     if (fontIdx >= 8) return 8;
     widths = g_fontWidthTables[fontIdx];
     if (widths) {
@@ -241,8 +241,8 @@ static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
 
 /* Return the logical advance for one legacy byte through its UTF-8-compatible mapping. */
 static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
-    FT_Face face;
-    int advance;
+    FT_Face face{};
+    int advance{};
     if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 8;
     if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
         return g_fontWidthTables[fontIdx][codepoint - 0x20];
@@ -259,13 +259,13 @@ static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
 static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
                                       float targetScaleX, float targetScaleY,
                                       float *layoutScaleX, float *layoutScaleY) {
-    FT_Face face;
-    const uint8 *legacyWidths;
-    int ch;
+    FT_Face face{};
+    const uint8 *legacyWidths{};
+    int ch{};
     int legacyAdvance = 0;
     int ftAdvance = 0;
-    float targetHeight;
-    float ftHeight;
+    float targetHeight{};
+    float ftHeight{};
 
     *layoutScaleX = 1.0f;
     *layoutScaleY = 1.0f;
@@ -297,19 +297,19 @@ static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
 
 /* Measure a complete UTF-8 string using the same layout rules as rendering. */
 static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
-    FT_Face face;
+    FT_Face face{};
     FT_UInt previousGlyphIndex = 0;
-    float layoutScaleX;
-    float layoutScaleY;
+    float layoutScaleX{};
+    float layoutScaleY{};
     float x = 0.0f;
-    int charIdx;
-    int drawnChars;
+    int charIdx{};
+    int drawnChars{};
 
     if (!text || fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
     if (fontIdx == 0) {
         int width = 0;
         for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
-            uint32 codepoint;
+            uint32 codepoint{};
             uint8 ch = (uint8)text[charIdx];
             int byteCount = 1;
             if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
@@ -333,11 +333,11 @@ static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
     if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return 0;
 
     for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
-        uint32 codepoint;
+        uint32 codepoint{};
         uint8 ch = (uint8)text[charIdx];
         int byteCount = 1;
-        FT_UInt glyphIndex;
-        FT_Vector kerning;
+        FT_UInt glyphIndex{};
+        FT_Vector kerning{};
 
         if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
             codepoint = ch;
@@ -366,8 +366,8 @@ static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
 /* Load and cache an optional TTF or OTF face for one legacy font slot. */
 static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
     FT_Face face = NULL;
-    int fontWidth;
-    int fontHeight;
+    int fontWidth{};
+    int fontHeight{};
 
     if (fontIdx >= 8 || !replacementPath) return 0;
     fontWidth = g_fontMaxWidths[fontIdx];
@@ -394,17 +394,17 @@ static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
 /* Retain one UTF-8 line for vector rendering and return its logical advance. */
 static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
                                           int clipL, int clipR, int clipT, int clipB) {
-    TtfTextOverlayRecord *record;
-    int charIdx;
-    int drawnChars;
-    int color;
-    uint16 fontIdx;
-    int i;
-    int newX;
-    int newY;
-    int newWidth;
-    int newHeight;
-    int recordIndex;
+    TtfTextOverlayRecord *record{};
+    int charIdx{};
+    int drawnChars{};
+    int color{};
+    uint16 fontIdx{};
+    int i{};
+    int newX{};
+    int newY{};
+    int newWidth{};
+    int newHeight{};
+    int recordIndex{};
 
     if (!params || !string) return 0;
     fontIdx = (uint16)params[6] & 7;
@@ -477,7 +477,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
 
     color = record->color;
     for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < 256;) {
-        uint32 codepoint;
+        uint32 codepoint{};
         uint8 ch = (uint8)string[charIdx];
         int byteCount = 1;
         if (!decodeUtf8Codepoint(&string[charIdx], &codepoint, &byteCount)) {
@@ -505,7 +505,7 @@ static void renderTtfTextOverlayGlyphSDL(SDL_Renderer *renderer, FT_Bitmap *bitm
     for (row = 0; row < (int)bitmap->rows; row++) {
         for (col = 0; col < (int)bitmap->width; col++) {
             uint8 coverage = freetypeBitmapPixel(bitmap, col, row);
-            SDL_FRect px;
+            SDL_FRect px{};
             if (!coverage) continue;
             px.x = x + (float)col * pixelScaleX;
             px.y = y + (float)row * pixelScaleY;
@@ -549,21 +549,21 @@ static void renderTtfTextOverlayGlyphGL(FT_Bitmap *bitmap, float x, float y, flo
 /* Lay out and render one retained UTF-8 text record as a coherent line. */
 static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMapping *m,
                                        SDL_Renderer *renderer, int useGL) {
-    SDL_Color c;
-    SDL_Palette *pal;
-    FT_Face face;
+    SDL_Color c{};
+    SDL_Palette *pal{};
+    FT_Face face{};
     FT_UInt previousGlyphIndex = 0;
-    float x;
-    int charIdx;
-    int drawnChars;
-    int pixelSize;
-    float cellY;
-    float cellHeight;
-    float baseline;
-    float ascender;
-    float layoutScaleX;
-    float layoutScaleY;
-    SDL_FRect clip;
+    float x{};
+    int charIdx{};
+    int drawnChars{};
+    int pixelSize{};
+    float cellY{};
+    float cellHeight{};
+    float baseline{};
+    float ascender{};
+    float layoutScaleX{};
+    float layoutScaleY{};
+    SDL_FRect clip{};
 
     if (!record || !record->text || record->fontIdx >= 8 || !g_fontReplacementTtfFaces[record->fontIdx]) return;
     face = g_fontReplacementTtfFaces[record->fontIdx];
@@ -595,17 +595,17 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
     }
 
     for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
-        uint32 codepoint;
+        uint32 codepoint{};
         uint8 ch = (uint8)record->text[charIdx];
         int byteCount = 1;
-        FT_UInt glyphIndex;
-        FT_Vector kerning;
-        FT_GlyphSlot glyph;
-        FT_Bitmap *bitmap;
-        float gx;
-        float gy;
-        float glyphScaleX;
-        float glyphScaleY;
+        FT_UInt glyphIndex{};
+        FT_Vector kerning{};
+        FT_GlyphSlot glyph{};
+        FT_Bitmap *bitmap{};
+        float gx{};
+        float gy{};
+        float glyphScaleX{};
+        float glyphScaleY{};
 
         if (!decodeUtf8Codepoint(&record->text[charIdx], &codepoint, &byteCount)) {
             codepoint = ch;
@@ -667,7 +667,7 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
 
 /* Render all retained vector-text records for the current frame. */
 static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL) {
-    int i;
+    int i{};
     if (!m || g_ttfTextOverlayCount <= 0) return;
     for (i = 0; i < g_ttfTextOverlayCount; i++) {
         renderTtfTextOverlayRecord(&g_ttfTextOverlayRecords[i], m, renderer, useGL);
@@ -676,7 +676,7 @@ static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useG
 
 /* Render retained vector text into the active OpenGL presentation mapping. */
 void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH) {
-    R2DMapping m;
+    R2DMapping m{};
     r2d_computeMapping(virtW, virtH, winW, winH, 0, &m);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
@@ -719,7 +719,7 @@ void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2) {
 /* Find a TTF or OTF replacement using stable per-slot filenames. */
 static int findReplacementVectorFont(uint16 fontIdx, const char *extension,
                                      char *path, size_t pathSize) {
-    char relative[64];
+    char relative[64]{};
     snprintf(relative, sizeof(relative), "fonts/font_%u.%s",
              (unsigned)fontIdx, extension);
     return findAssetReplacement(relative, path, pathSize);
@@ -727,7 +727,7 @@ static int findReplacementVectorFont(uint16 fontIdx, const char *extension,
 
 /* Activate a vector-font replacement for one legacy font slot when available. */
 static void tryLoadReplacementFont(uint16 fontIdx) {
-    char path[512];
+    char path[512]{};
     int vectorFontPresent = 0;
 
     if (fontIdx >= 8 || g_fontReplacementTried[fontIdx]) return;

--- a/src/gfx_font_replacement.inc
+++ b/src/gfx_font_replacement.inc
@@ -432,7 +432,6 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
         if (candidate->fontIdx == fontIdx &&
             candidate->clipL == clipL && candidate->clipR == clipR &&
             candidate->clipT == clipT && candidate->clipB == clipB &&
-/* Recognize changing numeric HUD text that should replace an older row record. */
             ttfTextOverlaySameDynamicRow(candidate, newX, newY, newWidth, newHeight)) {
             removeTtfTextOverlayRecord(i);
             if (recordIndex > i) recordIndex--;
@@ -617,7 +616,7 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
             continue;
         }
         glyphIndex = FT_Get_Char_Index(face, (FT_ULong)codepoint);
-        if (previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
+        if (record->fontIdx != 0 && previousGlyphIndex && glyphIndex && FT_HAS_KERNING(face)) {
             if (FT_Get_Kerning(face, previousGlyphIndex, glyphIndex, FT_KERNING_DEFAULT, &kerning) == 0) {
                 x += (float)(kerning.x >> 6) * layoutScaleX;
             }

--- a/src/gfx_font_replacement.inc
+++ b/src/gfx_font_replacement.inc
@@ -1,14 +1,21 @@
+enum {
+    TTF_FONT_SLOT_COUNT = 8,
+    TTF_MAX_OVERLAY_RECORDS = 512,
+    TTF_MAX_LINE_GLYPHS = 256,
+    TTF_SCREEN_CHANGE_AREA_PIXELS = 12000
+};
+
 #ifdef F15_HAVE_FREETYPE
 static FT_Library g_freetypeLibrary = NULL;
-static FT_Face g_fontReplacementTtfFaces[8] = {NULL};
-static char *g_fontReplacementTtfPaths[8] = {NULL};
+static FT_Face g_fontReplacementTtfFaces[TTF_FONT_SLOT_COUNT] = {NULL};
+static char *g_fontReplacementTtfPaths[TTF_FONT_SLOT_COUNT] = {NULL};
 typedef struct TtfTextOverlayRecord {
     char *text;
     int x, y, color;
     uint16 fontIdx;
     int clipL, clipR, clipT, clipB;
 } TtfTextOverlayRecord;
-static TtfTextOverlayRecord g_ttfTextOverlayRecords[512]{};
+static TtfTextOverlayRecord g_ttfTextOverlayRecords[TTF_MAX_OVERLAY_RECORDS]{};
 static int g_ttfTextOverlayCount{};
 static void clearTtfTextOverlayRecords(void);
 #endif
@@ -16,7 +23,7 @@ static void clearTtfTextOverlayRecords(void);
 
 /* Release one FreeType face and clear its replacement-font cache entry. */
 static void freeReplacementFont(uint16 fontIdx) {
-    if (fontIdx >= 8) return;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT) return;
 #ifdef F15_HAVE_FREETYPE
     if (g_fontReplacementTtfFaces[fontIdx]) {
         FT_Done_Face(g_fontReplacementTtfFaces[fontIdx]);
@@ -32,7 +39,7 @@ static void cleanupReplacementFonts(void) {
 #ifdef F15_HAVE_FREETYPE
     int i{};
     clearTtfTextOverlayRecords();
-    for (i = 0; i < 8; i++) freeReplacementFont((uint16)i);
+    for (i = 0; i < TTF_FONT_SLOT_COUNT; i++) freeReplacementFont((uint16)i);
     if (g_freetypeLibrary) {
         FT_Done_FreeType(g_freetypeLibrary);
         g_freetypeLibrary = NULL;
@@ -80,7 +87,7 @@ static int ttfOverlayRectIsScreenChange(int x1, int y1, int x2, int y2) {
     }
     w = x2 - x1 + 1;
     h = y2 - y1 + 1;
-    return w > 0 && h > 0 && w * h >= 12000;
+    return w > 0 && h > 0 && w * h >= TTF_SCREEN_CHANGE_AREA_PIXELS;
 }
 
 /* Return the logical width occupied by one retained vector-text record. */
@@ -179,8 +186,9 @@ static void switchTtfTextOverlayColorRect(int x1, int y1, int x2, int y2, int ol
         int ry1 = record->y;
         int rx2 = record->x + ttfTextOverlayRecordWidth(record) - 1;
         int ry2 = record->y + g_fontHeightsArr[record->fontIdx] - 1;
-        if ((record->color & 0xff) == (oldColor & 0xff) &&
-            rx2 >= x1 && rx1 <= x2 && ry2 >= y1 && ry1 <= y2) {
+        const bool matchesColor = (record->color & 0xff) == (oldColor & 0xff);
+        const bool overlapsUpdate = rx2 >= x1 && rx1 <= x2 && ry2 >= y1 && ry1 <= y2;
+        if (matchesColor && overlapsUpdate) {
             record->color = newColor;
         }
     }
@@ -218,7 +226,7 @@ static uint8 freetypeBitmapPixel(const FT_Bitmap *bitmap, int x, int y) {
 /* Choose a vector-font pixel size that matches the legacy font slot metrics. */
 static int replacementTtfPixelSize(uint16 fontIdx) {
     int h{};
-    if (fontIdx >= 8) return 8;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT) return 8;
     h = g_fontHeightsArr[fontIdx];
     /* Replacement TTF text must occupy the same screen footprint as the original
      * bitmap fonts. FreeType still supplies shape/coverage, but layout remains
@@ -230,7 +238,7 @@ static int replacementTtfPixelSize(uint16 fontIdx) {
 static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
     const uint8 *widths{};
     int idx{};
-    if (fontIdx >= 8) return 8;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT) return 8;
     widths = g_fontWidthTables[fontIdx];
     if (widths) {
         idx = 'n' - 0x20;
@@ -243,7 +251,7 @@ static int replacementTtfUnicodeAdvance(uint16 fontIdx) {
 static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint) {
     FT_Face face{};
     int advance{};
-    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 8;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT || !g_fontReplacementTtfFaces[fontIdx]) return 8;
     if (codepoint >= 0x20 && codepoint < 0x80 && g_fontWidthTables[fontIdx]) {
         return g_fontWidthTables[fontIdx][codepoint - 0x20];
     }
@@ -269,7 +277,7 @@ static void replacementTtfLayoutScale(uint16 fontIdx, int pixelSize,
 
     *layoutScaleX = 1.0f;
     *layoutScaleY = 1.0f;
-    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT || !g_fontReplacementTtfFaces[fontIdx]) return;
     face = g_fontReplacementTtfFaces[fontIdx];
     legacyWidths = g_fontWidthTables[fontIdx];
     if (!legacyWidths) return;
@@ -305,10 +313,10 @@ static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
     int charIdx{};
     int drawnChars{};
 
-    if (!text || fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    if (!text || fontIdx >= TTF_FONT_SLOT_COUNT || !g_fontReplacementTtfFaces[fontIdx]) return 0;
     if (fontIdx == 0) {
         int width = 0;
-        for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+        for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < TTF_MAX_LINE_GLYPHS;) {
             uint32 codepoint{};
             uint8 ch = (uint8)text[charIdx];
             int byteCount = 1;
@@ -332,7 +340,7 @@ static int replacementTtfStringAdvance(uint16 fontIdx, const char *text) {
     (void)layoutScaleY;
     if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)replacementTtfPixelSize(fontIdx)) != 0) return 0;
 
-    for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+    for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < TTF_MAX_LINE_GLYPHS;) {
         uint32 codepoint{};
         uint8 ch = (uint8)text[charIdx];
         int byteCount = 1;
@@ -369,7 +377,7 @@ static int loadReplacementFontTtf(uint16 fontIdx, const char *replacementPath) {
     int fontWidth{};
     int fontHeight{};
 
-    if (fontIdx >= 8 || !replacementPath) return 0;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT || !replacementPath) return 0;
     fontWidth = g_fontMaxWidths[fontIdx];
     fontHeight = g_fontHeightsArr[fontIdx];
     if (fontWidth <= 0 || fontWidth > 8 || fontHeight <= 0 || fontHeight > 32) return 0;
@@ -408,7 +416,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
 
     if (!params || !string) return 0;
     fontIdx = (uint16)params[6] & 7;
-    if (fontIdx >= 8 || !g_fontReplacementTtfFaces[fontIdx]) return 0;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT || !g_fontReplacementTtfFaces[fontIdx]) return 0;
     newX = (int)params[4];
     newY = (int)params[5];
     newWidth = replacementTtfStringAdvance(fontIdx, string);
@@ -417,10 +425,11 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
     recordIndex = -1;
     for (i = g_ttfTextOverlayCount - 1; i >= 0; i--) {
         TtfTextOverlayRecord *candidate = &g_ttfTextOverlayRecords[i];
-        if (candidate->fontIdx == fontIdx &&
+        const bool sameFontAndClip = candidate->fontIdx == fontIdx &&
             candidate->clipL == clipL && candidate->clipR == clipR &&
-            candidate->clipT == clipT && candidate->clipB == clipB &&
-            candidate->x == newX && candidate->y == newY) {
+            candidate->clipT == clipT && candidate->clipB == clipB;
+        if (!sameFontAndClip) continue;
+        if (candidate->x == newX && candidate->y == newY) {
             recordIndex = i;
             continue;
         }
@@ -429,10 +438,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
          * overlay on screen, because it was never baked into the page being
          * cleared. Treat near/overlapping same-font text in the same clip window
          * as a replacement candidate. */
-        if (candidate->fontIdx == fontIdx &&
-            candidate->clipL == clipL && candidate->clipR == clipR &&
-            candidate->clipT == clipT && candidate->clipB == clipB &&
-            ttfTextOverlaySameDynamicRow(candidate, newX, newY, newWidth, newHeight)) {
+        if (ttfTextOverlaySameDynamicRow(candidate, newX, newY, newWidth, newHeight)) {
             removeTtfTextOverlayRecord(i);
             if (recordIndex > i) recordIndex--;
         }
@@ -475,7 +481,7 @@ static int recordTtfTextOverlayAndAdvance(int16 *params, const char *string,
     record->clipB = clipB;
 
     color = record->color;
-    for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < 256;) {
+    for (charIdx = 0, drawnChars = 0; string[charIdx] != 0 && drawnChars < TTF_MAX_LINE_GLYPHS;) {
         uint32 codepoint{};
         uint8 ch = (uint8)string[charIdx];
         int byteCount = 1;
@@ -564,7 +570,7 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
     float layoutScaleY{};
     SDL_FRect clip{};
 
-    if (!record || !record->text || record->fontIdx >= 8 || !g_fontReplacementTtfFaces[record->fontIdx]) return;
+    if (!record || !record->text || record->fontIdx >= TTF_FONT_SLOT_COUNT || !g_fontReplacementTtfFaces[record->fontIdx]) return;
     face = g_fontReplacementTtfFaces[record->fontIdx];
     pixelSize = SDL_max(1, (int)((float)g_fontHeightsArr[record->fontIdx] * m->scaleY + 0.5f));
     if (FT_Set_Pixel_Sizes(face, 0, (FT_UInt)pixelSize) != 0) return;
@@ -593,7 +599,7 @@ static void renderTtfTextOverlayRecord(const TtfTextOverlayRecord *record, R2DMa
         if (clip.y + clip.h > maxBottom) clip.h = maxBottom - clip.y;
     }
 
-    for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < 256;) {
+    for (charIdx = 0, drawnChars = 0; record->text[charIdx] != 0 && drawnChars < TTF_MAX_LINE_GLYPHS;) {
         uint32 codepoint{};
         uint8 ch = (uint8)record->text[charIdx];
         int byteCount = 1;
@@ -729,7 +735,7 @@ static void tryLoadReplacementFont(uint16 fontIdx) {
     char path[512]{};
     int vectorFontPresent = 0;
 
-    if (fontIdx >= 8 || g_fontReplacementTried[fontIdx]) return;
+    if (fontIdx >= TTF_FONT_SLOT_COUNT || g_fontReplacementTried[fontIdx]) return;
     g_fontReplacementTried[fontIdx] = 1;
 #ifdef F15_HAVE_FREETYPE
     if (findReplacementVectorFont(fontIdx, "ttf", path, sizeof(path))) {

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -752,7 +752,7 @@ static void drawStringCore(int16 *params, const char *string,
 #ifdef F15_HAVE_FREETYPE
     if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
         (void)recordTtfTextOverlayAndAdvance(params, string, clipL, clipR, clipT, clipB);
-        return;
+        return{};
     }
 #endif
 
@@ -1357,8 +1357,8 @@ int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
 /* Measure a complete UTF-8 string using the active replacement font layout. */
 int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx) {
     int width = 0;
-    int charIdx;
-    int drawnChars;
+    int charIdx{};
+    int drawnChars{};
     if (!text) return 0;
     if (fontIdx >= 8) return 0;
     tryLoadReplacementFont(fontIdx);
@@ -1368,7 +1368,7 @@ int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx) {
     }
 #endif
     for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
-        uint32 codepoint;
+        uint32 codepoint{};
         uint8 ch = (uint8)text[charIdx];
         int byteCount = 1;
         if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -3,6 +3,11 @@
  */
 
 #include <SDL3/SDL.h>
+#ifdef F15_HAVE_FREETYPE
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include <SDL3/SDL_opengl.h>
+#endif
 
 #include "gfx_impl.h"
 #include "gfx.h"
@@ -11,8 +16,13 @@
 #include "struct.h"
 #include "log.h"
 #include "version.h"
+#include "shared/asset_path.h"
+#include "shared/common.h"
+#include "shared/utf8.h"
 #include <dos.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "fontdata.h"
 #include "shared/bitmap_font_replacement.h"
@@ -24,6 +34,15 @@
  * in gfx.h. */
 #define INITIAL_WINDOW_WIDTH 640
 #define INITIAL_WINDOW_HEIGHT 400
+#define VGA_PAGE_HEIGHT 200
+
+/* The 3D HUD draws missile ammo at y=190 with the original bitmap font. Runtime
+ * TTF glyphs can extend below the old bitmap cell, so bottom-HUD overlay records
+ * need a small clip relaxation while still staying inside the native 320x200
+ * page. Keep this named because the threshold is a DOS-screen coordinate, not a
+ * renderer pixel value. */
+#define HUD_BOTTOM_TTF_CLIP_Y 188
+#define HUD_BOTTOM_TTF_EXTRA_LINES 2.0f
 
 /* Fixed fire colour-cycle rate, independent of render frame rate. The original
  * stepped the cycle once per rendered frame; we pin it at 15 Hz so the pulse
@@ -44,6 +63,13 @@ static void gfx_swLine(int x1, int y1, int x2, int y2, int color);
 static void gfx_swPoint(int x, int y, int color);
 static void gfx_swImage(struct R2DImage *img, int srcX, int srcY, int w, int h,
                         int dstX, int dstY, int key);
+static void cleanupReplacementFonts(void);
+#ifdef F15_HAVE_FREETYPE
+static void renderTtfTextOverlay(R2DMapping *m, SDL_Renderer *renderer, int useGL);
+static void invalidateTtfTextOverlayRecords(void);
+static int replacementTtfAdvance(uint16 fontIdx, uint32 codepoint);
+static int replacementTtfStringAdvance(uint16 fontIdx, const char *text);
+#endif
 
 /* Bring up the SDL window and renderer. The 320x200 logical surface is stretched
  * to fill the resizable window (SDL_LOGICAL_PRESENTATION_STRETCH). */
@@ -137,6 +163,7 @@ void gfx_videoShutdown(void) {
         SDL_DestroyPalette(gfxPalette);
         gfxPalette = NULL;
     }
+    cleanupReplacementFonts();
     bitmapFontReplacementShutdown();
     if (sdlRenderer) SDL_DestroyRenderer(sdlRenderer);
     if (sdlWindow) SDL_DestroyWindow(sdlWindow);
@@ -418,6 +445,9 @@ static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
     dst.w = (float)surf->w * m.scaleX;
     dst.h = (float)surf->h * m.scaleY;
     SDL_RenderTexture(sdlRenderer, tex, NULL, &dst);
+#ifdef F15_HAVE_FREETYPE
+    renderTtfTextOverlay(&m, sdlRenderer, 0);
+#endif
     SDL_RenderPresent(sdlRenderer);
     SDL_DestroyTexture(tex);
 }
@@ -471,6 +501,9 @@ static void initRowOffsets(void) {
  * SDL. This is also the lo-res restore after the (possibly hi-res) title. */
 void FAR CDECL gfx_setMode13(void) {
     initRowOffsets();
+#ifdef F15_HAVE_FREETYPE
+    invalidateTtfTextOverlayRecords();
+#endif
     gfxHiResActive = false;
     gfx_getState()->modeFlag = 1;
 }
@@ -480,6 +513,9 @@ void FAR CDECL gfx_setMode13(void) {
  * derives the virtual size from the surface), so this just flags hi-res; the
  * present picks up the 640x350 hi-res surface from gfx_presentHiRes. */
 bool video_setHiRes(void) {
+#ifdef F15_HAVE_FREETYPE
+    invalidateTtfTextOverlayRecords();
+#endif
     gfxHiResActive = true;
     return true;
 }
@@ -598,6 +634,7 @@ static uint8 *g_fontBitmapPtrs[8] = {
     (uint8 *)g_font0_bitmaps, (uint8 *)g_font1_bitmaps, NULL, (uint8 *)g_font3_bitmaps,
     (uint8 *)g_font4_bitmaps, (uint8 *)g_font5_bitmaps, NULL, NULL};
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+static uint8 g_fontReplacementTried[8] = {0};
 /* Override one legacy bitmap font slot from editable BDF or PNG media when available. */
 static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     BitmapFontReplacement replacement{};
@@ -664,6 +701,11 @@ int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut,
 }
 #endif
 
+/* Runtime font replacement is kept outside this legacy renderer body while
+ * remaining in the same translation unit, so it can use the original private
+ * font tables without widening the graphics API. */
+#include "gfx_font_replacement.inc"
+
 /* ---- Shared glyph engine (slots 0x01-0x06) ----
  * MGRAPHIC has one core blitter (0x04 @0x4ab) that the string slots fall into
  * after running 0-3 clip stages. The clip stages cut partial glyphs at the
@@ -706,6 +748,13 @@ static void drawStringCore(int16 *params, const char *string,
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
     widthTab = g_fontWidthTables[fontIdx];
+
+#ifdef F15_HAVE_FREETYPE
+    if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
+        (void)recordTtfTextOverlayAndAdvance(params, string, clipL, clipR, clipT, clipB);
+        return;
+    }
+#endif
 
     /* On a GL flight frame, submit each lit glyph pixel as a native point (drawn
      * over the composited frame at window resolution) instead of baking it into the
@@ -763,15 +812,6 @@ static void drawStringCore(int16 *params, const char *string,
     params[2] = (int16)color;
 }
 
-/* Rotated, sub-grid HUD label (GL native-res overlay only). Draws `string` in font
- * `fontIdx`/`color` with its glyph grid placed by two basis vectors: (exX,exY) is the
- * on-screen 320-space step per text column, (eyX,eyY) per row, both emanating from the
- * float anchor (ax,ay) = the string's top-left in absolute 320-space. Each lit font
- * texel becomes one rotated parallelogram cell submitted via r2d_submitQuadF, so the
- * label rotates with (and glides sub-grid along) the pitch-ladder lines instead of
- * snapping upright to the 320x200 grid. The software backend keeps the upright integer
- * glyph engine (drawStringCore); this is a no-op there. Scissored to the half-open
- * clip rect, matching the glyph slot's clip window. */
 void FAR gfx_drawGlyphStrRot(const char *string, int fontIdx, int color,
                              float ax, float ay, float exX, float exY,
                              float eyX, float eyY,
@@ -783,7 +823,6 @@ void FAR gfx_drawGlyphStrRot(const char *string, int fontIdx, int color,
     float penX = 0.0f; /* running text-column offset (in glyph texels) */
     if (!string) return;
     fontIdx &= 7;
-    tryLoadBitmapFontReplacement((uint16)fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -889,6 +928,11 @@ void FAR CDECL gfx_drawGlyphStr(int16 *desc, const char *str, int slot) {
 void FAR CDECL gfx_copyRect(int srcPage, uint16 srcX, uint16 srcY,
                             int dstPage, uint16 dstX, uint16 dstY,
                             int width, int height) {
+#ifdef F15_HAVE_FREETYPE
+    if (ttfOverlayRectIsScreenChange((int)dstX, (int)dstY, (int)dstX + width - 1, (int)dstY + height - 1)) {
+        invalidateTtfTextOverlayRecords();
+    }
+#endif
     r2d_blit(ensurePage(srcPage), (int)srcX, (int)srcY,
              ensurePage(dstPage), (int)dstX, (int)dstY,
              width, height, -1);
@@ -910,6 +954,11 @@ void gfx_captureToImage(struct R2DImage *img, int srcPage, int srcX, int srcY,
 
 void gfx_restoreFromImage(struct R2DImage *img, int dstPage, int srcX, int srcY,
                           int dstX, int dstY, int w, int h) {
+#ifdef F15_HAVE_FREETYPE
+    if (ttfOverlayRectIsScreenChange(dstX, dstY, dstX + w - 1, dstY + h - 1)) {
+        invalidateTtfTextOverlayRecords();
+    }
+#endif
     r2d_drawImage(img, srcX, srcY, w, h, ensurePage(dstPage), dstX, dstY, -1);
 }
 
@@ -930,6 +979,9 @@ void gfx_drawSpriteOpaque(int handle, int srcX, int srcY, int dstPage,
 /* ---- Slot 0x29: gfx_switchColor ---- */
 void FAR CDECL gfx_switchColor(int16 *pageDesc, int x1, int y1,
                                int x2, int y2, int oldColor, int newColor) {
+#ifdef F15_HAVE_FREETYPE
+    switchTtfTextOverlayColorRect(x1, y1, x2, y2, oldColor, newColor);
+#endif
     SDL_Surface *surf = gfx_getPageSurface((int)*pageDesc);
     uint8 *base;
     int pitch, row, col;
@@ -957,6 +1009,13 @@ void FAR CDECL gfx_switchColor(int16 *pageDesc, int x1, int y1,
  * colour. Writes straight into the page's backing SDL surface — the same buffer
  * the pic decoder and blitters target — so no DOS segment is involved. */
 void clearRect(int16 *pageNum, int16 x1, int16 y1, int16 x2, int16 y2) {
+#ifdef F15_HAVE_FREETYPE
+    if (ttfOverlayRectIsScreenChange(x1, y1, x2, y2)) {
+        invalidateTtfTextOverlayRecords();
+    } else {
+        invalidateTtfTextOverlayRect(x1, y1, x2, y2);
+    }
+#endif
     SDL_Surface *surf = gfx_getPageSurface((int)*pageNum);
     uint8 color = (uint8)pageNum[3];
     uint8 *base;
@@ -1269,21 +1328,64 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
     }
 }
 
-int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
-    /* Returns the pixel advance width of a single character. stringWidth()
-     * sums this over a string to centre text, so it MUST agree with the
-     * x-advance gfx_drawString uses (wt[ch-0x20]); otherwise centred text
-     * lands off-screen and drawString's clip test discards every glyph.
-     * The width tables are file-scope arrays reached directly as native
-     * pointers, exactly as drawStringCore reads them. */
+int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
+    /* Returns the pixel advance width of one decoded character. stringWidth()
+     * and gfx_setFont both route here so centered/right-aligned UTF-8 text
+     * agrees with drawStringCore's glyph selection and x-advance behavior. */
     const uint8 *wt;
     if (fontIdx >= 8) return 8;
-    tryLoadBitmapFontReplacement(fontIdx);
-    /* Chars >= 0x80 are inline color escapes - no glyph, no width */
-    if (ch >= 0x80) return 0;
+    /* TTF/OTF takes precedence; bitmap fallback updates the original width
+     * table through bitmap_font_replacement.c. */
+    tryLoadReplacementFont(fontIdx);
+#ifdef F15_HAVE_FREETYPE
+    if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
+        if (codepoint <= 0xff && codepoint >= 0x80) return 0;
+        return replacementTtfAdvance(fontIdx, codepoint);
+    }
+#endif
+    if (codepoint >= 0x80) {
+        /* Legacy single-byte chars >= 0x80 are inline color escapes. */
+        if (codepoint <= 0xff) return 0;
+        return 8;
+    }
     wt = g_fontWidthTables[fontIdx];
-    if (!wt || ch < 0x20) return 8;
-    return wt[ch - 0x20];
+    if (!wt || codepoint < 0x20) return 8;
+    return wt[codepoint - 0x20];
+}
+
+int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx) {
+    int width = 0;
+    int charIdx;
+    int drawnChars;
+    if (!text) return 0;
+    if (fontIdx >= 8) return 0;
+    tryLoadReplacementFont(fontIdx);
+#ifdef F15_HAVE_FREETYPE
+    if (g_fontReplacementTtfFaces[fontIdx]) {
+        return replacementTtfStringAdvance(fontIdx, text);
+    }
+#endif
+    for (charIdx = 0, drawnChars = 0; text[charIdx] != 0 && drawnChars < 256;) {
+        uint32 codepoint;
+        uint8 ch = (uint8)text[charIdx];
+        int byteCount = 1;
+        if (!decodeUtf8Codepoint(&text[charIdx], &codepoint, &byteCount)) {
+            codepoint = ch;
+            byteCount = 1;
+        }
+        if (byteCount == 1 && (ch & 0x80)) {
+            charIdx++;
+            continue;
+        }
+        width += gfx_getGlyphAdvance(codepoint, fontIdx);
+        charIdx += byteCount;
+        drawnChars++;
+    }
+    return width;
+}
+
+int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
+    return gfx_getGlyphAdvance((uint32)ch, fontIdx);
 }
 void FAR CDECL gfx_setFadeSteps(int steps) {
     (void)steps;

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -598,6 +598,7 @@ static uint8 *g_fontBitmapPtrs[8] = {
     (uint8 *)g_font0_bitmaps, (uint8 *)g_font1_bitmaps, NULL, (uint8 *)g_font3_bitmaps,
     (uint8 *)g_font4_bitmaps, (uint8 *)g_font5_bitmaps, NULL, NULL};
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+/* Override one legacy bitmap font slot from editable BDF or PNG media when available. */
 static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     BitmapFontReplacement replacement;
     if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -600,10 +600,10 @@ static uint8 *g_fontBitmapPtrs[8] = {
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
 /* Override one legacy bitmap font slot from editable BDF or PNG media when available. */
 static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
-    BitmapFontReplacement replacement;
+    BitmapFontReplacement replacement{};
     if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]
         || !g_fontBitmapPtrs[fontIdx]) {
-        return;
+        return{};
     }
     if (bitmapFontReplacementGet(fontIdx, g_fontMaxWidths[fontIdx],
                                  g_fontHeightsArr[fontIdx],

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -640,7 +640,7 @@ static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     BitmapFontReplacement replacement{};
     if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]
         || !g_fontBitmapPtrs[fontIdx]) {
-        return{};
+        return;
     }
     if (bitmapFontReplacementGet(fontIdx, g_fontMaxWidths[fontIdx],
                                  g_fontHeightsArr[fontIdx],
@@ -752,7 +752,7 @@ static void drawStringCore(int16 *params, const char *string,
 #ifdef F15_HAVE_FREETYPE
     if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
         (void)recordTtfTextOverlayAndAdvance(params, string, clipL, clipR, clipT, clipB);
-        return{};
+        return;
     }
 #endif
 

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -612,6 +612,57 @@ static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
     }
 }
 
+#ifdef DEBUG
+static int copyFontTables(const uint8 *bitmap, const uint8 *widths,
+                          int height, int maxWidth,
+                          uint8 *bitmapOut, size_t bitmapOutSize,
+                          uint8 *widthsOut, size_t widthsOutSize,
+                          int *heightOut, int *maxWidthOut) {
+    const size_t bitmapSize = (size_t)96 * (size_t)height;
+    if (!bitmap || !widths || height <= 0 || maxWidth <= 0) return 0;
+    if (bitmapOut && bitmapOutSize < bitmapSize) return 0;
+    if (widthsOut && widthsOutSize < 96u) return 0;
+    if (bitmapOut) memcpy(bitmapOut, bitmap, bitmapSize);
+    if (widthsOut) memcpy(widthsOut, widths, 96u);
+    if (heightOut) *heightOut = height;
+    if (maxWidthOut) *maxWidthOut = maxWidth;
+    return 1;
+}
+
+int gfx_testCopyEffectiveFont(uint16 fontIdx, uint8 *bitmapOut,
+                              size_t bitmapOutSize, uint8 *widthsOut,
+                              size_t widthsOutSize, int *heightOut,
+                              int *maxWidthOut) {
+    if (fontIdx >= 8) return 0;
+    tryLoadBitmapFontReplacement(fontIdx);
+    return copyFontTables(
+        g_fontBitmapPtrs[fontIdx], g_fontWidthTables[fontIdx],
+        g_fontBitmapRowSize[fontIdx], g_fontMaxWidths[fontIdx],
+        bitmapOut, bitmapOutSize, widthsOut, widthsOutSize,
+        heightOut, maxWidthOut);
+}
+
+int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut,
+                            size_t bitmapOutSize, uint8 *widthsOut,
+                            size_t widthsOutSize, int *heightOut,
+                            int *maxWidthOut) {
+    const uint8 *bitmap = NULL;
+    const uint8 *widths = NULL;
+    switch (fontIdx) {
+    case 0: bitmap = &g_font0_bitmaps[0][0]; widths = g_font0_widths; break;
+    case 1: bitmap = &g_font1_bitmaps[0][0]; widths = g_font1_widths; break;
+    case 3: bitmap = &g_font3_bitmaps[0][0]; widths = g_font3_widths; break;
+    case 4: bitmap = &g_font4_bitmaps[0][0]; widths = g_font4_widths; break;
+    case 5: bitmap = &g_font5_bitmaps[0][0]; widths = g_font5_widths; break;
+    default: return 0;
+    }
+    return copyFontTables(
+        bitmap, widths, g_fontBitmapRowSize[fontIdx],
+        g_fontMaxWidths[fontIdx], bitmapOut, bitmapOutSize,
+        widthsOut, widthsOutSize, heightOut, maxWidthOut);
+}
+#endif
+
 /* ---- Shared glyph engine (slots 0x01-0x06) ----
  * MGRAPHIC has one core blitter (0x04 @0x4ab) that the string slots fall into
  * after running 0-3 clip stages. The clip stages cut partial glyphs at the

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 
 #include "fontdata.h"
+#include "shared/bitmap_font_replacement.h"
 
 /* The SDL window and renderer are owned here: the graphics layer brings up the
  * video output and every gfx_* function presents through it. The original game
@@ -136,6 +137,7 @@ void gfx_videoShutdown(void) {
         SDL_DestroyPalette(gfxPalette);
         gfxPalette = NULL;
     }
+    bitmapFontReplacementShutdown();
     if (sdlRenderer) SDL_DestroyRenderer(sdlRenderer);
     if (sdlWindow) SDL_DestroyWindow(sdlWindow);
     SDL_Quit();
@@ -585,7 +587,7 @@ static const uint8 g_font0_widths[96] = {
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-static const uint8 *const g_fontWidthTables[8] = {
+static const uint8 *g_fontWidthTables[8] = {
     g_font0_widths, g_font1_widths, NULL, g_font3_widths,
     g_font4_widths, g_font5_widths, NULL, NULL};
 static const uint8 g_fontHeightsArr[8] = {5, 8, 7, 6, 7, 6, 4, 0};
@@ -596,6 +598,19 @@ static uint8 *g_fontBitmapPtrs[8] = {
     (uint8 *)g_font0_bitmaps, (uint8 *)g_font1_bitmaps, NULL, (uint8 *)g_font3_bitmaps,
     (uint8 *)g_font4_bitmaps, (uint8 *)g_font5_bitmaps, NULL, NULL};
 static const uint8 g_fontBitmapRowSize[8] = {5, 8, 0, 6, 7, 6, 0, 0};
+static void tryLoadBitmapFontReplacement(uint16 fontIdx) {
+    BitmapFontReplacement replacement;
+    if (fontIdx >= 8 || !g_fontWidthTables[fontIdx]
+        || !g_fontBitmapPtrs[fontIdx]) {
+        return;
+    }
+    if (bitmapFontReplacementGet(fontIdx, g_fontMaxWidths[fontIdx],
+                                 g_fontHeightsArr[fontIdx],
+                                 g_fontWidthTables[fontIdx], &replacement)) {
+        g_fontBitmapPtrs[fontIdx] = (uint8 *)replacement.bitmaps;
+        g_fontWidthTables[fontIdx] = (const uint8 *)replacement.widths;
+    }
+}
 
 /* ---- Shared glyph engine (slots 0x01-0x06) ----
  * MGRAPHIC has one core blitter (0x04 @0x4ab) that the string slots fall into
@@ -634,6 +649,7 @@ static void drawStringCore(int16 *params, const char *string,
     y = (int)params[5];
     color = (int)params[2];
     fontIdx = (uint16)params[6] & 7;
+    tryLoadBitmapFontReplacement(fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -715,6 +731,7 @@ void FAR gfx_drawGlyphStrRot(const char *string, int fontIdx, int color,
     float penX = 0.0f; /* running text-column offset (in glyph texels) */
     if (!string) return;
     fontIdx &= 7;
+    tryLoadBitmapFontReplacement((uint16)fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -1209,6 +1226,7 @@ int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
      * pointers, exactly as drawStringCore reads them. */
     const uint8 *wt;
     if (fontIdx >= 8) return 8;
+    tryLoadBitmapFontReplacement(fontIdx);
     /* Chars >= 0x80 are inline color escapes - no glyph, no width */
     if (ch >= 0x80) return 0;
     wt = g_fontWidthTables[fontIdx];

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -1328,6 +1328,7 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
     }
 }
 
+/* Return the logical advance of one glyph for the active bitmap or vector font. */
 int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
     /* Returns the pixel advance width of one decoded character. stringWidth()
      * and gfx_setFont both route here so centered/right-aligned UTF-8 text
@@ -1353,6 +1354,7 @@ int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
     return wt[codepoint - 0x20];
 }
 
+/* Measure a complete UTF-8 string using the active replacement font layout. */
 int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx) {
     int width = 0;
     int charIdx;

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -804,7 +804,7 @@ static void drawStringCore(int16 *params, const char *string,
     y = (int)params[5];
     color = (int)params[2];
     fontIdx = (uint16)params[6] & 7;
-    tryLoadBitmapFontReplacement(fontIdx);
+    tryLoadReplacementFont(fontIdx);
     height = g_fontHeightsArr[fontIdx];
     rowSize = g_fontBitmapRowSize[fontIdx];
     bitmaps = g_fontBitmapPtrs[fontIdx];
@@ -1405,13 +1405,11 @@ int gfx_getGlyphAdvance(uint32 codepoint, uint16 fontIdx) {
     tryLoadReplacementFont(fontIdx);
 #ifdef F15_HAVE_FREETYPE
     if (fontIdx < 8 && g_fontReplacementTtfFaces[fontIdx]) {
-        if (codepoint <= 0xff && codepoint >= 0x80) return 0;
         return replacementTtfAdvance(fontIdx, codepoint);
     }
 #endif
     if (codepoint >= 0x80) {
-        /* Legacy single-byte chars >= 0x80 are inline color escapes. */
-        if (codepoint <= 0xff) return 0;
+        /* Decoded Unicode is a glyph, not a legacy single-byte color escape. */
         return 8;
     }
     wt = g_fontWidthTables[fontIdx];
@@ -1452,6 +1450,8 @@ int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx) {
 }
 
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {
+    /* Only this legacy byte API interprets the high bit as a color command. */
+    if (ch >= 0x80) return 0;
     return gfx_getGlyphAdvance((uint32)ch, fontIdx);
 }
 void FAR CDECL gfx_setFadeSteps(int steps) {

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -61,6 +61,17 @@ struct SDL_Palette *gfx_getPalette(void);
 void gfx_paletteRGB(int idx, uint8 *r, uint8 *g, uint8 *b);
 int gfx_paletteGeneration(void);
 
+#ifdef DEBUG
+int gfx_testCopyEffectiveFont(uint16 fontIdx, uint8 *bitmapOut,
+                              size_t bitmapOutSize, uint8 *widthsOut,
+                              size_t widthsOutSize, int *heightOut,
+                              int *maxWidthOut);
+int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut,
+                            size_t bitmapOutSize, uint8 *widthsOut,
+                            size_t widthsOutSize, int *heightOut,
+                            int *maxWidthOut);
+#endif
+
 /* Current explosion screen-shake (0-3 virtual px, set by gfx_dacCycle). The GL
  * backend reads it mid-frame to offset the immediate 2D overlay, matching the
  * software present's shake shift. */

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -77,6 +77,13 @@ int gfx_testCopyBuiltinFont(uint16 fontIdx, uint8 *bitmapOut,
  * software present's shake shift. */
 int gfx_getShakeOffset(void);
 
+/* Draw recorded runtime TTF/OTF text after the legacy page has been scaled to
+ * the window. This keeps text positions in original 320x200 coordinates while
+ * rasterizing glyphs at native/window resolution. */
+void gfx_renderTtfTextOverlayOpenGL(int virtW, int virtH, int winW, int winH);
+void gfx_clearTtfTextOverlay(void);
+void gfx_invalidateTtfTextOverlayRect(int x1, int y1, int x2, int y2);
+
 /*
  * Reference structures documenting how the overlay accesses caller data.
  * These CANNOT be used in the asm data segments (which must maintain exact

--- a/src/input.c
+++ b/src/input.c
@@ -14,7 +14,6 @@
  * the menus, so that part is gated on the mode set by the phase's key readers.
  */
 #include "input.h"
-#include "shared/utf8.h"
 #include "inttype.h"
 #include "const.h"
 #include "gfx.h"
@@ -63,10 +62,6 @@ bool input_preferGamepad(void) { return g_lastWasGamepad && joy_connected(); }
 static uint16 keyRing[KEY_RING];
 static int ringHead = 0, ringTail = 0;
 
-#define TEXT_RING 32
-static char textRing[TEXT_RING][8]{};
-static int textRingHead = 0, textRingTail = 0;
-
 static void ringPush(uint16 word) {
     int next = (ringTail + 1) % KEY_RING;
     if (next == ringHead) return; /* full: drop, as the BIOS buffer would */
@@ -74,20 +69,8 @@ static void ringPush(uint16 word) {
     ringTail = next;
 }
 
-/* Append one UTF-8 text-input event to the bounded menu input ring. */
-static void textRingPushUtf8(const char *text, int len) {
-    int next{};
-    if (!text || len <= 0 || len >= (int)sizeof(textRing[0])) return;
-    next = (textRingTail + 1) % TEXT_RING;
-    if (next == textRingHead) return;
-    SDL_memcpy(textRing[textRingTail], text, (size_t)len);
-    textRing[textRingTail][len] = '\0';
-    textRingTail = next;
-}
-
 void input_ringReset(void) {
     ringHead = ringTail = 0;
-    textRingHead = textRingTail = 0;
     g_joyRawX = 0x80;
     g_joyRawY = 0x80;
 }
@@ -107,31 +90,6 @@ uint16 input_readKey(void) {
     word = keyRing[ringHead];
     ringHead = (ringHead + 1) % KEY_RING;
     return word;
-}
-
-/* Read one complete UTF-8 menu text event into the caller buffer. */
-int input_readMenuTextUtf8(char *out, int outSize) {
-    int len{};
-    input_pumpEvents();
-    if (!out || outSize <= 0 || textRingHead == textRingTail) return 0;
-    len = (int)SDL_strlen(textRing[textRingHead]);
-    if (len >= outSize) len = outSize - 1;
-    SDL_memcpy(out, textRing[textRingHead], (size_t)len);
-    out[len] = '\0';
-    textRingHead = (textRingHead + 1) % TEXT_RING;
-    return len;
-}
-
-/* Return whether an unconsumed UTF-8 menu text event is queued. */
-bool input_menuTextWaiting(void) {
-    return textRingHead != textRingTail;
-}
-
-/* Suppress the legacy ASCII key event paired with an SDL text-input event. */
-void input_discardNextAsciiKey(uint8 ascii) {
-    if (ringHead != ringTail && (keyRing[ringHead] & 0xff) == ascii) {
-        ringHead = (ringHead + 1) % KEY_RING;
-    }
 }
 
 /* --- keyboard translation --------------------------------------------------
@@ -793,27 +751,13 @@ void input_pumpEvents(void) {
             break;
         case SDL_EVENT_TEXT_INPUT:
             /* Printable characters for menu text entry arrive here already
-             * shifted/localized. The BIOS key ring remains byte-oriented for
-             * legacy menu code; the text ring preserves full UTF-8 characters
-             * for modern text entry such as pilot names. */
+             * shifted/localized; queue each ASCII byte in AL (AH = 0). Flight
+             * takes its letters as commands from biosWord instead. */
             if (g_mode == INPUT_MODE_MENU) {
-                const unsigned char *p =
-                    (const unsigned char *)ev.text.text;
-                while (p && *p) {
-                    uint32_t codepoint{};
-                    size_t length{};
-                    if (!utf8DecodeCodepoint((const char *)p, &codepoint,
-                                             &length)) {
-                        ++p;
-                        continue;
-                    }
-                    if (codepoint < 0x20 || codepoint == 0x7f) {
-                        p += length;
-                        continue;
-                    }
-                    if (length == 1) ringPush((uint16)codepoint);
-                    textRingPushUtf8((const char *)p, (int)length);
-                    p += length;
+                const char *p = ev.text.text;
+                for (; *p; ++p) {
+                    unsigned char c = (unsigned char)*p;
+                    if (c >= 0x20 && c < 0x80) ringPush(c);
                 }
             }
             break;

--- a/src/input.c
+++ b/src/input.c
@@ -14,6 +14,7 @@
  * the menus, so that part is gated on the mode set by the phase's key readers.
  */
 #include "input.h"
+#include "shared/utf8.h"
 #include "inttype.h"
 #include "const.h"
 #include "gfx.h"
@@ -62,6 +63,10 @@ bool input_preferGamepad(void) { return g_lastWasGamepad && joy_connected(); }
 static uint16 keyRing[KEY_RING];
 static int ringHead = 0, ringTail = 0;
 
+#define TEXT_RING 32
+static char textRing[TEXT_RING][8];
+static int textRingHead = 0, textRingTail = 0;
+
 static void ringPush(uint16 word) {
     int next = (ringTail + 1) % KEY_RING;
     if (next == ringHead) return; /* full: drop, as the BIOS buffer would */
@@ -69,8 +74,19 @@ static void ringPush(uint16 word) {
     ringTail = next;
 }
 
+static void textRingPushUtf8(const char *text, int len) {
+    int next;
+    if (!text || len <= 0 || len >= (int)sizeof(textRing[0])) return;
+    next = (textRingTail + 1) % TEXT_RING;
+    if (next == textRingHead) return;
+    SDL_memcpy(textRing[textRingTail], text, (size_t)len);
+    textRing[textRingTail][len] = '\0';
+    textRingTail = next;
+}
+
 void input_ringReset(void) {
     ringHead = ringTail = 0;
+    textRingHead = textRingTail = 0;
     g_joyRawX = 0x80;
     g_joyRawY = 0x80;
 }
@@ -90,6 +106,28 @@ uint16 input_readKey(void) {
     word = keyRing[ringHead];
     ringHead = (ringHead + 1) % KEY_RING;
     return word;
+}
+
+int input_readMenuTextUtf8(char *out, int outSize) {
+    int len;
+    input_pumpEvents();
+    if (!out || outSize <= 0 || textRingHead == textRingTail) return 0;
+    len = (int)SDL_strlen(textRing[textRingHead]);
+    if (len >= outSize) len = outSize - 1;
+    SDL_memcpy(out, textRing[textRingHead], (size_t)len);
+    out[len] = '\0';
+    textRingHead = (textRingHead + 1) % TEXT_RING;
+    return len;
+}
+
+bool input_menuTextWaiting(void) {
+    return textRingHead != textRingTail;
+}
+
+void input_discardNextAsciiKey(uint8 ascii) {
+    if (ringHead != ringTail && (keyRing[ringHead] & 0xff) == ascii) {
+        ringHead = (ringHead + 1) % KEY_RING;
+    }
 }
 
 /* --- keyboard translation --------------------------------------------------
@@ -751,13 +789,27 @@ void input_pumpEvents(void) {
             break;
         case SDL_EVENT_TEXT_INPUT:
             /* Printable characters for menu text entry arrive here already
-             * shifted/localized; queue each ASCII byte in AL (AH = 0). Flight
-             * takes its letters as commands from biosWord instead. */
+             * shifted/localized. The BIOS key ring remains byte-oriented for
+             * legacy menu code; the text ring preserves full UTF-8 characters
+             * for modern text entry such as pilot names. */
             if (g_mode == INPUT_MODE_MENU) {
-                const char *p = ev.text.text;
-                for (; *p; ++p) {
-                    unsigned char c = (unsigned char)*p;
-                    if (c >= 0x20 && c < 0x80) ringPush(c);
+                const unsigned char *p =
+                    (const unsigned char *)ev.text.text;
+                while (p && *p) {
+                    uint32_t codepoint;
+                    size_t length;
+                    if (!utf8DecodeCodepoint((const char *)p, &codepoint,
+                                             &length)) {
+                        ++p;
+                        continue;
+                    }
+                    if (codepoint < 0x20 || codepoint == 0x7f) {
+                        p += length;
+                        continue;
+                    }
+                    if (length == 1) ringPush((uint16)codepoint);
+                    textRingPushUtf8((const char *)p, (int)length);
+                    p += length;
                 }
             }
             break;

--- a/src/input.c
+++ b/src/input.c
@@ -64,7 +64,7 @@ static uint16 keyRing[KEY_RING];
 static int ringHead = 0, ringTail = 0;
 
 #define TEXT_RING 32
-static char textRing[TEXT_RING][8];
+static char textRing[TEXT_RING][8]{};
 static int textRingHead = 0, textRingTail = 0;
 
 static void ringPush(uint16 word) {
@@ -76,7 +76,7 @@ static void ringPush(uint16 word) {
 
 /* Append one UTF-8 text-input event to the bounded menu input ring. */
 static void textRingPushUtf8(const char *text, int len) {
-    int next;
+    int next{};
     if (!text || len <= 0 || len >= (int)sizeof(textRing[0])) return;
     next = (textRingTail + 1) % TEXT_RING;
     if (next == textRingHead) return;
@@ -111,7 +111,7 @@ uint16 input_readKey(void) {
 
 /* Read one complete UTF-8 menu text event into the caller buffer. */
 int input_readMenuTextUtf8(char *out, int outSize) {
-    int len;
+    int len{};
     input_pumpEvents();
     if (!out || outSize <= 0 || textRingHead == textRingTail) return 0;
     len = (int)SDL_strlen(textRing[textRingHead]);
@@ -800,8 +800,8 @@ void input_pumpEvents(void) {
                 const unsigned char *p =
                     (const unsigned char *)ev.text.text;
                 while (p && *p) {
-                    uint32_t codepoint;
-                    size_t length;
+                    uint32_t codepoint{};
+                    size_t length{};
                     if (!utf8DecodeCodepoint((const char *)p, &codepoint,
                                              &length)) {
                         ++p;

--- a/src/input.c
+++ b/src/input.c
@@ -74,6 +74,7 @@ static void ringPush(uint16 word) {
     ringTail = next;
 }
 
+/* Append one UTF-8 text-input event to the bounded menu input ring. */
 static void textRingPushUtf8(const char *text, int len) {
     int next;
     if (!text || len <= 0 || len >= (int)sizeof(textRing[0])) return;
@@ -108,6 +109,7 @@ uint16 input_readKey(void) {
     return word;
 }
 
+/* Read one complete UTF-8 menu text event into the caller buffer. */
 int input_readMenuTextUtf8(char *out, int outSize) {
     int len;
     input_pumpEvents();
@@ -120,10 +122,12 @@ int input_readMenuTextUtf8(char *out, int outSize) {
     return len;
 }
 
+/* Return whether an unconsumed UTF-8 menu text event is queued. */
 bool input_menuTextWaiting(void) {
     return textRingHead != textRingTail;
 }
 
+/* Suppress the legacy ASCII key event paired with an SDL text-input event. */
 void input_discardNextAsciiKey(uint8 ascii) {
     if (ringHead != ringTail && (keyRing[ringHead] & 0xff) == ascii) {
         ringHead = (ringHead + 1) % KEY_RING;

--- a/src/input.c
+++ b/src/input.c
@@ -63,30 +63,31 @@ bool input_preferGamepad(void) { return g_lastWasGamepad && joy_connected(); }
 static uint16 keyRing[KEY_RING];
 static int ringHead = 0, ringTail = 0;
 
-#define TEXT_RING 32
-static char textRing[TEXT_RING][8];
-static int textRingHead = 0, textRingTail = 0;
+/* Text and navigation share the BIOS ring's order. A non-ASCII text event has
+ * key word zero and its UTF-8 payload is retrieved after popping that entry. */
+static char keyText[KEY_RING][5]{};
+static char lastMenuText[5]{};
 
 static void ringPush(uint16 word) {
     int next = (ringTail + 1) % KEY_RING;
     if (next == ringHead) return; /* full: drop, as the BIOS buffer would */
     keyRing[ringTail] = word;
+    keyText[ringTail][0] = '\0';
     ringTail = next;
 }
 
-static void textRingPushUtf8(const char *text, int len) {
-    int next;
-    if (!text || len <= 0 || len >= (int)sizeof(textRing[0])) return;
-    next = (textRingTail + 1) % TEXT_RING;
-    if (next == textRingHead) return;
-    SDL_memcpy(textRing[textRingTail], text, (size_t)len);
-    textRing[textRingTail][len] = '\0';
-    textRingTail = next;
+static void ringPushTextUtf8(const char *text, int len) {
+    if (!text || len <= 0 || len >= (int)sizeof(keyText[0])) return;
+    if ((ringTail + 1) % KEY_RING == ringHead) return;
+    const int slot = ringTail;
+    ringPush(len == 1 ? (uint8)text[0] : 0);
+    SDL_memcpy(keyText[slot], text, (size_t)len);
+    keyText[slot][len] = '\0';
 }
 
 void input_ringReset(void) {
     ringHead = ringTail = 0;
-    textRingHead = textRingTail = 0;
+    lastMenuText[0] = '\0';
     g_joyRawX = 0x80;
     g_joyRawY = 0x80;
 }
@@ -104,30 +105,20 @@ uint16 input_readKey(void) {
         input_pumpEvents();
     }
     word = keyRing[ringHead];
+    SDL_memcpy(lastMenuText, keyText[ringHead], sizeof(lastMenuText));
     ringHead = (ringHead + 1) % KEY_RING;
     return word;
 }
 
 int input_readMenuTextUtf8(char *out, int outSize) {
-    int len;
-    input_pumpEvents();
-    if (!out || outSize <= 0 || textRingHead == textRingTail) return 0;
-    len = (int)SDL_strlen(textRing[textRingHead]);
-    if (len >= outSize) len = outSize - 1;
-    SDL_memcpy(out, textRing[textRingHead], (size_t)len);
-    out[len] = '\0';
-    textRingHead = (textRingHead + 1) % TEXT_RING;
+    if (!out || outSize <= 0) return 0;
+    out[0] = '\0';
+    const int len = (int)SDL_strlen(lastMenuText);
+    /* Never return half a codepoint. A caller can retry with a larger buffer. */
+    if (len >= outSize) return 0;
+    SDL_memcpy(out, lastMenuText, (size_t)len + 1);
+    lastMenuText[0] = '\0';
     return len;
-}
-
-bool input_menuTextWaiting(void) {
-    return textRingHead != textRingTail;
-}
-
-void input_discardNextAsciiKey(uint8 ascii) {
-    if (ringHead != ringTail && (keyRing[ringHead] & 0xff) == ascii) {
-        ringHead = (ringHead + 1) % KEY_RING;
-    }
 }
 
 /* --- keyboard translation --------------------------------------------------
@@ -789,9 +780,8 @@ void input_pumpEvents(void) {
             break;
         case SDL_EVENT_TEXT_INPUT:
             /* Printable characters for menu text entry arrive here already
-             * shifted/localized. The BIOS key ring remains byte-oriented for
-             * legacy menu code; the text ring preserves full UTF-8 characters
-             * for modern text entry such as pilot names. */
+             * shifted/localized. Preserve their order relative to navigation
+             * keys while retaining UTF-8 for pilot-name editing. */
             if (g_mode == INPUT_MODE_MENU) {
                 const unsigned char *p =
                     (const unsigned char *)ev.text.text;
@@ -807,8 +797,7 @@ void input_pumpEvents(void) {
                         p += length;
                         continue;
                     }
-                    if (length == 1) ringPush((uint16)codepoint);
-                    textRingPushUtf8((const char *)p, (int)length);
+                    ringPushTextUtf8((const char *)p, (int)length);
                     p += length;
                 }
             }

--- a/src/input.h
+++ b/src/input.h
@@ -40,6 +40,13 @@ void input_ringReset(void);  /* drop any queued keys, recentre stick */
 bool input_keyWaiting(void); /* true when a key word is queued */
 uint16 input_readKey(void);  /* blocking pop: pump + wait, then return */
 
+/* Menu text input queue. Unlike the BIOS-style key ring, this preserves the
+ * UTF-8 bytes SDL_TEXT_INPUT delivers, so text editors can accept Unicode while
+ * old menu navigation keeps using input_readKey(). Returns byte count. */
+int input_readMenuTextUtf8(char *out, int outSize);
+bool input_menuTextWaiting(void);
+void input_discardNextAsciiKey(uint8 ascii);
+
 /* --- window state, set by the pump, for callers that want to react --------- */
 bool input_quitRequested(void); /* SDL_EVENT_QUIT (window close) has been seen */
 bool input_hasFocus(void);      /* window currently has keyboard focus */

--- a/src/input.h
+++ b/src/input.h
@@ -40,13 +40,6 @@ void input_ringReset(void);  /* drop any queued keys, recentre stick */
 bool input_keyWaiting(void); /* true when a key word is queued */
 uint16 input_readKey(void);  /* blocking pop: pump + wait, then return */
 
-/* Menu text input queue. Unlike the BIOS-style key ring, this preserves the
- * UTF-8 bytes SDL_TEXT_INPUT delivers, so text editors can accept Unicode while
- * old menu navigation keeps using input_readKey(). Returns byte count. */
-int input_readMenuTextUtf8(char *out, int outSize);
-bool input_menuTextWaiting(void);
-void input_discardNextAsciiKey(uint8 ascii);
-
 /* --- window state, set by the pump, for callers that want to react --------- */
 bool input_quitRequested(void); /* SDL_EVENT_QUIT (window close) has been seen */
 bool input_hasFocus(void);      /* window currently has keyboard focus */

--- a/src/input.h
+++ b/src/input.h
@@ -40,12 +40,10 @@ void input_ringReset(void);  /* drop any queued keys, recentre stick */
 bool input_keyWaiting(void); /* true when a key word is queued */
 uint16 input_readKey(void);  /* blocking pop: pump + wait, then return */
 
-/* Menu text input queue. Unlike the BIOS-style key ring, this preserves the
- * UTF-8 bytes SDL_TEXT_INPUT delivers, so text editors can accept Unicode while
- * old menu navigation keeps using input_readKey(). Returns byte count. */
+/* Retrieve UTF-8 text from the last input_readKey() entry, once. Non-ASCII
+ * text entries return key word zero. Returns byte count, or zero for command
+ * keys / insufficient output space; codepoints are never split. */
 int input_readMenuTextUtf8(char *out, int outSize);
-bool input_menuTextWaiting(void);
-void input_discardNextAsciiKey(uint8 ascii);
 
 /* --- window state, set by the pump, for callers that want to react --------- */
 bool input_quitRequested(void); /* SDL_EVENT_QUIT (window close) has been seen */

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -2202,11 +2202,17 @@ static void composePageBackdrop(SDL_Surface *page, int shakeOffset) {
 }
 
 void r3dgl_present(SDL_Surface *page, int shakeOffset) {
+    int win_w = 0, win_h = 0;
     if (!page || !s_active) return;
     /* Flight frames composed the page backdrop at the main-scene anchor (before the
      * frame's immediate HUD/MFD draws); only pure-2D screens (no 3D pass) compose it
      * here, on top of the black-cleared window. */
     if (!s_sceneRendered && !s_pageComposited) composePageBackdrop(page, shakeOffset);
+    SDL_GetWindowSizeInPixels(s_win, &win_w, &win_h);
+    /* Runtime TTF/OTF text is deliberately kept out of the 320x200 page. Draw it
+     * after both pure-2D and live-3D frames so HUD/menu glyphs are rasterized at
+     * final window resolution instead of being baked tiny and scaled up. */
+    gfx_renderTtfTextOverlayOpenGL(page->w, page->h, win_w, win_h);
     /* Remember whether THIS present carried a live 3D view. gfx_repaint (window
      * expose/resize) re-presents only the page — which would blank the GL 3D (it
      * lives in the framebuffer, not the page) — so on a flight frame it must instead

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -32,7 +32,7 @@ static bool isSafeRelativePath(const fs::path &path) {
 
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
-    std::error_code error;
+    std::error_code error{};
     const fs::path exact = directory / component;
     if (fs::exists(exact, error) && !error) {
         *resolved = exact;
@@ -61,12 +61,12 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     if (!isSafeRelativePath(relative)) return 0;
 
     fs::path resolved{rootValue};
-    std::error_code error;
+    std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
-        fs::path next;
+        fs::path next{};
         if (!resolveComponent(resolved, component, &next)) return 0;
         resolved = next;
     }

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -1,0 +1,81 @@
+/*
+ * asset_path.c - Shared path lookup for optional modern asset packs.
+ */
+
+#include "asset_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static bool namesEqualIgnoringCase(const std::string &left, const std::string &right) {
+    return left.size() == right.size()
+        && std::equal(left.begin(), left.end(), right.begin(),
+            [](unsigned char a, unsigned char b) {
+                return std::tolower(a) == std::tolower(b);
+            });
+}
+
+static bool isSafeRelativePath(const fs::path &path) {
+    if (path.empty() || path.is_absolute() || path.has_root_path()) return false;
+    for (const fs::path &component : path) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+static bool resolveComponent(const fs::path &directory, const fs::path &component,
+                             fs::path *resolved) {
+    std::error_code error;
+    const fs::path exact = directory / component;
+    if (fs::exists(exact, error) && !error) {
+        *resolved = exact;
+        return true;
+    }
+
+    error.clear();
+    for (fs::directory_iterator item(directory, error), end; !error && item != end;
+         item.increment(error)) {
+        if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            *resolved = item->path();
+            return true;
+        }
+    }
+    return false;
+}
+
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
+    if (outPath && outPathSize) outPath[0] = '\0';
+    if (!relativePath || !relativePath[0] || !outPath || !outPathSize) return 0;
+
+    const char *rootValue = getenv("F15_REPLACEMENT_ROOT");
+    if (!rootValue || !rootValue[0]) return 0;
+
+    const fs::path relative{relativePath};
+    if (!isSafeRelativePath(relative)) return 0;
+
+    fs::path resolved{rootValue};
+    std::error_code error;
+    if (!fs::is_directory(resolved, error) || error) return 0;
+
+    for (const fs::path &component : relative) {
+        if (component == ".") continue;
+        fs::path next;
+        if (!resolveComponent(resolved, component, &next)) return 0;
+        resolved = next;
+    }
+
+    error.clear();
+    if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    const std::string value = resolved.string();
+    if (value.size() + 1 > outPathSize) return 0;
+    memcpy(outPath, value.c_str(), value.size() + 1);
+    return 1;
+}

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -33,13 +33,9 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
-    const fs::path exact = directory / component;
-    if (fs::exists(exact, error) && !error) {
-        *resolved = exact;
-        return true;
-    }
-
-    error.clear();
+    /* Enumerate even when the requested spelling opens directly. On case-insensitive
+     * filesystems, exists(directory / component) succeeds without revealing the
+     * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {

--- a/src/shared/asset_path.c
+++ b/src/shared/asset_path.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <string>
 
@@ -18,7 +17,9 @@ static bool namesEqualIgnoringCase(const std::string &left, const std::string &r
     return left.size() == right.size()
         && std::equal(left.begin(), left.end(), right.begin(),
             [](unsigned char a, unsigned char b) {
-                return std::tolower(a) == std::tolower(b);
+                if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+                if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+                return a == b;
             });
 }
 
@@ -33,17 +34,20 @@ static bool isSafeRelativePath(const fs::path &path) {
 static bool resolveComponent(const fs::path &directory, const fs::path &component,
                              fs::path *resolved) {
     std::error_code error{};
+    bool found = false;
     /* Enumerate even when the requested spelling opens directly. On case-insensitive
      * filesystems, exists(directory / component) succeeds without revealing the
      * directory entry's actual spelling, which callers use in diagnostics. */
     for (fs::directory_iterator item(directory, error), end; !error && item != end;
          item.increment(error)) {
         if (namesEqualIgnoringCase(item->path().filename().string(), component.string())) {
+            /* Duplicate DOS spellings have no portable winner. */
+            if (found) return false;
             *resolved = item->path();
-            return true;
+            found = true;
         }
     }
-    return false;
+    return found && !error;
 }
 
 int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize) {
@@ -59,6 +63,8 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
     fs::path resolved{rootValue};
     std::error_code error{};
     if (!fs::is_directory(resolved, error) || error) return 0;
+    const fs::path root = fs::canonical(resolved, error);
+    if (error) return 0;
 
     for (const fs::path &component : relative) {
         if (component == ".") continue;
@@ -69,6 +75,13 @@ int findAssetReplacement(const char *relativePath, char *outPath, size_t outPath
 
     error.clear();
     if (!fs::is_regular_file(resolved, error) || error) return 0;
+
+    /* Lexical checks alone do not catch symlinks into another directory.
+     * Compare complete canonical components, not a string prefix. */
+    const fs::path target = fs::canonical(resolved, error);
+    if (error) return 0;
+    const auto boundary = std::mismatch(root.begin(), root.end(), target.begin(), target.end());
+    if (boundary.first != root.end()) return 0;
 
     const std::string value = resolved.string();
     if (value.size() + 1 > outPathSize) return 0;

--- a/src/shared/asset_path.h
+++ b/src/shared/asset_path.h
@@ -1,0 +1,29 @@
+/*
+ * asset_path.h - Locate optional modern assets without changing legacy I/O.
+ */
+#ifndef ASSET_PATH_H
+#define ASSET_PATH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Resolve relativePath below F15_REPLACEMENT_ROOT.
+ *
+ * Components are matched case-insensitively because converted DOS assets
+ * commonly retain uppercase names. Absolute paths and parent traversal are
+ * rejected so a custom pack cannot escape its declared root.
+ *
+ * Returns non-zero and writes a NUL-terminated path on success. On failure,
+ * returns zero and leaves outPath as an empty string when space permits.
+ */
+int findAssetReplacement(const char *relativePath, char *outPath, size_t outPathSize);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSET_PATH_H */

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -24,12 +24,12 @@ typedef struct CachedFont {
     int tried;
 } CachedFont;
 
-static CachedFont g_fonts[FONT_SLOT_COUNT];
+static CachedFont g_fonts[FONT_SLOT_COUNT]{};
 
 /* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
 static int replacementPath(unsigned font_id, const char *extension,
                            char *path, size_t path_size) {
-    char relative[64];
+    char relative[64]{};
     snprintf(relative, sizeof(relative), "fonts/font_%u.%s",
              font_id, extension);
     return findAssetReplacement(relative, path, path_size);
@@ -54,7 +54,7 @@ static int parseBdf(const char *path, unsigned height,
     int advance = -1;
     unsigned row = 0;
     int in_bitmap = 0;
-    char line[512];
+    char line[512]{};
 
     if (!file) return 0;
     bitmaps = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, height);
@@ -181,8 +181,8 @@ fail:
 int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
                              unsigned height, const uint8_t *original_widths,
                              BitmapFontReplacement *result) {
-    CachedFont *font;
-    char path[1024];
+    CachedFont *font{};
+    char path[1024]{};
 
     if (!result || !original_widths || font_id >= FONT_SLOT_COUNT
         || cell_width == 0 || cell_width > 8 || height == 0) {

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -1,0 +1,222 @@
+/*
+ * bitmap_font_replacement.c - BDF/PNG font replacement loader.
+ */
+
+#include "bitmap_font_replacement.h"
+
+#include "asset_path.h"
+#include "../log.h"
+
+#include <SDL3/SDL.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FONT_SLOT_COUNT 8
+#define FONT_FIRST_CODEPOINT 0x20
+#define FONT_GLYPH_COUNT 96
+
+typedef struct CachedFont {
+    uint8_t *bitmaps;
+    uint8_t *widths;
+    int tried;
+} CachedFont;
+
+static CachedFont g_fonts[FONT_SLOT_COUNT];
+
+static int replacementPath(unsigned font_id, const char *extension,
+                           char *path, size_t path_size) {
+    char relative[64];
+    snprintf(relative, sizeof(relative), "fonts/font_%u.%s",
+             font_id, extension);
+    return findAssetReplacement(relative, path, path_size);
+}
+
+static void discardFont(CachedFont *font) {
+    SDL_free(font->bitmaps);
+    SDL_free(font->widths);
+    font->bitmaps = NULL;
+    font->widths = NULL;
+}
+
+static int parseBdf(const char *path, unsigned height,
+                    uint8_t **bitmaps_out, uint8_t **widths_out) {
+    FILE *file = fopen(path, "rb");
+    uint8_t *bitmaps = NULL;
+    uint8_t *widths = NULL;
+    unsigned char complete[FONT_GLYPH_COUNT] = {0};
+    int encoding = -1;
+    int advance = -1;
+    unsigned row = 0;
+    int in_bitmap = 0;
+    char line[512];
+
+    if (!file) return 0;
+    bitmaps = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, height);
+    widths = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, 1);
+    if (!bitmaps || !widths) goto fail;
+
+    while (fgets(line, sizeof(line), file)) {
+        char *text = line;
+        while (isspace((unsigned char)*text)) ++text;
+        if (strncmp(text, "STARTCHAR ", 10) == 0) {
+            encoding = -1;
+            advance = -1;
+            row = 0;
+            in_bitmap = 0;
+        } else if (sscanf(text, "ENCODING %d", &encoding) == 1) {
+            continue;
+        } else if (sscanf(text, "DWIDTH %d", &advance) == 1) {
+            continue;
+        } else if (strncmp(text, "BITMAP", 6) == 0) {
+            in_bitmap = 1;
+            row = 0;
+        } else if (strncmp(text, "ENDCHAR", 7) == 0) {
+            if (encoding >= FONT_FIRST_CODEPOINT
+                && encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT
+                && advance > 0 && advance <= 255 && row == height) {
+                const unsigned index =
+                    (unsigned)(encoding - FONT_FIRST_CODEPOINT);
+                widths[index] = (uint8_t)advance;
+                complete[index] = 1;
+            }
+            in_bitmap = 0;
+        } else if (in_bitmap) {
+            char *end = NULL;
+            if (row >= height) goto fail;
+            const unsigned long value = strtoul(text, &end, 16);
+            if (end == text || value > 255) goto fail;
+            while (isspace((unsigned char)*end)) ++end;
+            if (*end != '\0') goto fail;
+            if (encoding >= FONT_FIRST_CODEPOINT
+                && encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT) {
+                const unsigned index =
+                    (unsigned)(encoding - FONT_FIRST_CODEPOINT);
+                bitmaps[index * height + row] = (uint8_t)value;
+            }
+            ++row;
+        }
+    }
+    fclose(file);
+
+    for (unsigned index = 0; index < FONT_GLYPH_COUNT; ++index) {
+        if (!complete[index]) goto invalid;
+    }
+    *bitmaps_out = bitmaps;
+    *widths_out = widths;
+    return 1;
+
+invalid:
+    SDL_free(bitmaps);
+    SDL_free(widths);
+    return 0;
+fail:
+    fclose(file);
+    SDL_free(bitmaps);
+    SDL_free(widths);
+    return 0;
+}
+
+static int pixelIsLit(SDL_Surface *surface, int x, int y) {
+    Uint8 r, g, b, a;
+    if (!SDL_ReadSurfacePixel(surface, x, y, &r, &g, &b, &a)) return 0;
+    return a != 0 && (r != 0 || g != 0 || b != 0);
+}
+
+static int parsePng(const char *path, unsigned cell_width, unsigned height,
+                    const uint8_t *original_widths,
+                    uint8_t **bitmaps_out, uint8_t **widths_out) {
+    SDL_Surface *surface = SDL_LoadPNG(path);
+    uint8_t *bitmaps = NULL;
+    uint8_t *widths = NULL;
+    const unsigned expected_width = 16 * (cell_width + 1) - 1;
+    const unsigned expected_height = 6 * (height + 1) - 1;
+
+    if (!surface) return 0;
+    if (cell_width == 0 || cell_width > 8 || height == 0
+        || surface->w < (int)expected_width
+        || surface->h < (int)expected_height) {
+        SDL_DestroySurface(surface);
+        return 0;
+    }
+
+    bitmaps = (uint8_t *)SDL_calloc(FONT_GLYPH_COUNT, height);
+    widths = (uint8_t *)SDL_malloc(FONT_GLYPH_COUNT);
+    if (!bitmaps || !widths) goto fail;
+    memcpy(widths, original_widths, FONT_GLYPH_COUNT);
+
+    for (unsigned index = 0; index < FONT_GLYPH_COUNT; ++index) {
+        const unsigned x0 = (index % 16) * (cell_width + 1);
+        const unsigned y0 = (index / 16) * (height + 1);
+        for (unsigned y = 0; y < height; ++y) {
+            uint8_t bits = 0;
+            for (unsigned x = 0; x < cell_width; ++x) {
+                if (pixelIsLit(surface, (int)(x0 + x), (int)(y0 + y))) {
+                    bits |= (uint8_t)(0x80u >> x);
+                }
+            }
+            bitmaps[index * height + y] = bits;
+        }
+    }
+    SDL_DestroySurface(surface);
+    *bitmaps_out = bitmaps;
+    *widths_out = widths;
+    return 1;
+
+fail:
+    SDL_DestroySurface(surface);
+    SDL_free(bitmaps);
+    SDL_free(widths);
+    return 0;
+}
+
+int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
+                             unsigned height, const uint8_t *original_widths,
+                             BitmapFontReplacement *result) {
+    CachedFont *font;
+    char path[1024];
+
+    if (!result || !original_widths || font_id >= FONT_SLOT_COUNT
+        || cell_width == 0 || cell_width > 8 || height == 0) {
+        return 0;
+    }
+    result->bitmaps = NULL;
+    result->widths = NULL;
+    font = &g_fonts[font_id];
+    if (!font->tried) {
+        font->tried = 1;
+        if (replacementPath(font_id, "bdf", path, sizeof(path))) {
+            if (parseBdf(path, height, &font->bitmaps, &font->widths)) {
+                LogInfo(("asset replacement: loaded bitmap font %u from %s",
+                         font_id, path));
+            } else {
+                LogWarn(("asset replacement: rejected BDF font %u at %s",
+                         font_id, path));
+            }
+        }
+        if (!font->bitmaps
+            && replacementPath(font_id, "png", path, sizeof(path))) {
+            if (parsePng(path, cell_width, height, original_widths,
+                         &font->bitmaps, &font->widths)) {
+                LogInfo(("asset replacement: loaded bitmap font %u from %s",
+                         font_id, path));
+            } else {
+                LogWarn(("asset replacement: rejected PNG font %u at %s",
+                         font_id, path));
+            }
+        }
+    }
+    if (!font->bitmaps) return 0;
+    result->bitmaps = font->bitmaps;
+    result->widths = font->widths;
+    return 1;
+}
+
+void bitmapFontReplacementShutdown(void) {
+    for (unsigned index = 0; index < FONT_SLOT_COUNT; ++index) {
+        discardFont(&g_fonts[index]);
+        g_fonts[index].tried = 0;
+    }
+}

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -26,6 +26,7 @@ typedef struct CachedFont {
 
 static CachedFont g_fonts[FONT_SLOT_COUNT];
 
+/* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
 static int replacementPath(unsigned font_id, const char *extension,
                            char *path, size_t path_size) {
     char relative[64];
@@ -34,6 +35,7 @@ static int replacementPath(unsigned font_id, const char *extension,
     return findAssetReplacement(relative, path, path_size);
 }
 
+/* Release one decoded bitmap font replacement and clear its cached state. */
 static void discardFont(CachedFont *font) {
     SDL_free(font->bitmaps);
     SDL_free(font->widths);
@@ -41,6 +43,7 @@ static void discardFont(CachedFont *font) {
     font->widths = NULL;
 }
 
+/* Parse editable BDF glyph bitmaps and advances into the legacy font slot representation. */
 static int parseBdf(const char *path, unsigned height,
                     uint8_t **bitmaps_out, uint8_t **widths_out) {
     FILE *file = fopen(path, "rb");
@@ -119,12 +122,14 @@ fail:
     return 0;
 }
 
+/* Interpret one atlas pixel as foreground using alpha and luminance. */
 static int pixelIsLit(SDL_Surface *surface, int x, int y) {
     Uint8 r, g, b, a;
     if (!SDL_ReadSurfacePixel(surface, x, y, &r, &g, &b, &a)) return 0;
     return a != 0 && (r != 0 || g != 0 || b != 0);
 }
 
+/* Parse a replacement font atlas while preserving the established glyph-cell layout. */
 static int parsePng(const char *path, unsigned cell_width, unsigned height,
                     const uint8_t *original_widths,
                     uint8_t **bitmaps_out, uint8_t **widths_out) {
@@ -172,6 +177,7 @@ fail:
     return 0;
 }
 
+/* Load and cache the first available BDF or PNG replacement for a font slot. */
 int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
                              unsigned height, const uint8_t *original_widths,
                              BitmapFontReplacement *result) {
@@ -197,6 +203,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
             }
         }
         if (!font->bitmaps
+/* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
             && replacementPath(font_id, "png", path, sizeof(path))) {
             if (parsePng(path, cell_width, height, original_widths,
                          &font->bitmaps, &font->widths)) {
@@ -214,6 +221,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
     return 1;
 }
 
+/* Release all cached bitmap font replacements at renderer shutdown. */
 void bitmapFontReplacementShutdown(void) {
     for (unsigned index = 0; index < FONT_SLOT_COUNT; ++index) {
         discardFont(&g_fonts[index]);

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -193,6 +193,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
     font = &g_fonts[font_id];
     if (!font->tried) {
         font->tried = 1;
+        /* Prefer the editable BDF. Try the PNG font sheet only if no BDF loads. */
         if (replacementPath(font_id, "bdf", path, sizeof(path))) {
             if (parseBdf(path, height, &font->bitmaps, &font->widths)) {
                 LogInfo(("asset replacement: loaded bitmap font %u from %s",
@@ -202,9 +203,8 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
                          font_id, path));
             }
         }
-        if (!font->bitmaps
-/* Resolve one optional BDF or PNG font replacement using the shared asset search rules. */
-            && replacementPath(font_id, "png", path, sizeof(path))) {
+        if (!font->bitmaps &&
+            replacementPath(font_id, "png", path, sizeof(path))) {
             if (parsePng(path, cell_width, height, original_widths,
                          &font->bitmaps, &font->widths)) {
                 LogInfo(("asset replacement: loaded bitmap font %u from %s",

--- a/src/shared/bitmap_font_replacement.c
+++ b/src/shared/bitmap_font_replacement.c
@@ -14,9 +14,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define FONT_SLOT_COUNT 8
-#define FONT_FIRST_CODEPOINT 0x20
-#define FONT_GLYPH_COUNT 96
+enum {
+    FONT_SLOT_COUNT = 8,
+    FONT_FIRST_CODEPOINT = 0x20,
+    FONT_GLYPH_COUNT = 96,
+    FONT_ROW_BITS = 8,
+    ATLAS_COLUMNS = 16,
+    ATLAS_ROWS = FONT_GLYPH_COUNT / ATLAS_COLUMNS,
+    ATLAS_GAP_PIXELS = 1
+};
 
 typedef struct CachedFont {
     uint8_t *bitmaps;
@@ -77,9 +83,10 @@ static int parseBdf(const char *path, unsigned height,
             in_bitmap = 1;
             row = 0;
         } else if (strncmp(text, "ENDCHAR", 7) == 0) {
-            if (encoding >= FONT_FIRST_CODEPOINT
-                && encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT
-                && advance > 0 && advance <= 255 && row == height) {
+            const bool supportedCodepoint = encoding >= FONT_FIRST_CODEPOINT &&
+                encoding < FONT_FIRST_CODEPOINT + FONT_GLYPH_COUNT;
+            const bool completeGlyph = advance > 0 && advance <= UINT8_MAX && row == height;
+            if (supportedCodepoint && completeGlyph) {
                 const unsigned index =
                     (unsigned)(encoding - FONT_FIRST_CODEPOINT);
                 widths[index] = (uint8_t)advance;
@@ -90,7 +97,7 @@ static int parseBdf(const char *path, unsigned height,
             char *end = NULL;
             if (row >= height) goto fail;
             const unsigned long value = strtoul(text, &end, 16);
-            if (end == text || value > 255) goto fail;
+            if (end == text || value > UINT8_MAX) goto fail;
             while (isspace((unsigned char)*end)) ++end;
             if (*end != '\0') goto fail;
             if (encoding >= FONT_FIRST_CODEPOINT
@@ -124,7 +131,7 @@ fail:
 
 /* Interpret one atlas pixel as foreground using alpha and luminance. */
 static int pixelIsLit(SDL_Surface *surface, int x, int y) {
-    Uint8 r, g, b, a;
+    Uint8 r = 0, g = 0, b = 0, a = 0;
     if (!SDL_ReadSurfacePixel(surface, x, y, &r, &g, &b, &a)) return 0;
     return a != 0 && (r != 0 || g != 0 || b != 0);
 }
@@ -136,11 +143,11 @@ static int parsePng(const char *path, unsigned cell_width, unsigned height,
     SDL_Surface *surface = SDL_LoadPNG(path);
     uint8_t *bitmaps = NULL;
     uint8_t *widths = NULL;
-    const unsigned expected_width = 16 * (cell_width + 1) - 1;
-    const unsigned expected_height = 6 * (height + 1) - 1;
+    const unsigned expected_width = ATLAS_COLUMNS * (cell_width + ATLAS_GAP_PIXELS) - ATLAS_GAP_PIXELS;
+    const unsigned expected_height = ATLAS_ROWS * (height + ATLAS_GAP_PIXELS) - ATLAS_GAP_PIXELS;
 
     if (!surface) return 0;
-    if (cell_width == 0 || cell_width > 8 || height == 0
+    if (cell_width == 0 || cell_width > FONT_ROW_BITS || height == 0
         || surface->w < (int)expected_width
         || surface->h < (int)expected_height) {
         SDL_DestroySurface(surface);
@@ -153,8 +160,8 @@ static int parsePng(const char *path, unsigned cell_width, unsigned height,
     memcpy(widths, original_widths, FONT_GLYPH_COUNT);
 
     for (unsigned index = 0; index < FONT_GLYPH_COUNT; ++index) {
-        const unsigned x0 = (index % 16) * (cell_width + 1);
-        const unsigned y0 = (index / 16) * (height + 1);
+        const unsigned x0 = (index % ATLAS_COLUMNS) * (cell_width + ATLAS_GAP_PIXELS);
+        const unsigned y0 = (index / ATLAS_COLUMNS) * (height + ATLAS_GAP_PIXELS);
         for (unsigned y = 0; y < height; ++y) {
             uint8_t bits = 0;
             for (unsigned x = 0; x < cell_width; ++x) {
@@ -185,7 +192,7 @@ int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
     char path[1024]{};
 
     if (!result || !original_widths || font_id >= FONT_SLOT_COUNT
-        || cell_width == 0 || cell_width > 8 || height == 0) {
+        || cell_width == 0 || cell_width > FONT_ROW_BITS || height == 0) {
         return 0;
     }
     result->bitmaps = NULL;

--- a/src/shared/bitmap_font_replacement.h
+++ b/src/shared/bitmap_font_replacement.h
@@ -1,0 +1,31 @@
+/*
+ * bitmap_font_replacement.h - Optional editable bitmap-font media.
+ */
+#ifndef BITMAP_FONT_REPLACEMENT_H
+#define BITMAP_FONT_REPLACEMENT_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct BitmapFontReplacement {
+    const uint8_t *bitmaps;
+    const uint8_t *widths;
+} BitmapFontReplacement;
+
+/*
+ * Load fonts/font_<id>.bdf, falling back to fonts/font_<id>.png.
+ * Replacement data retains the legacy 96-glyph, one-byte-per-row layout.
+ */
+int bitmapFontReplacementGet(unsigned font_id, unsigned cell_width,
+                             unsigned height, const uint8_t *original_widths,
+                             BitmapFontReplacement *result);
+void bitmapFontReplacementShutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/shared/picimpl.c
+++ b/src/shared/picimpl.c
@@ -20,7 +20,7 @@ extern int fileReadRaw(SDL_IOStream *handle, void *dst, int count);
 /* Hi-res title surface + present (gfx_impl.c). */
 extern SDL_Surface *gfx_getHiResSurface(void);
 extern void gfx_presentHiRes(void);
-extern void gfx_clearTtfTextOverlay(void) __attribute__((weak));
+extern void gfx_clearTtfTextOverlay(void);
 
 /* Pic decode work data */
 extern uint8 picDecodedRowBuf[320];
@@ -318,7 +318,7 @@ static SDL_Surface *picScratchSurface(void) {
 void showPicFile(SDL_IOStream *handle, int page) {
     if (!handle) return;
     (void)page; /* all pages are the single back buffer */
-    if (gfx_clearTtfTextOverlay) gfx_clearTtfTextOverlay();
+    gfx_clearTtfTextOverlay();
     /* Decode straight into the back buffer; the decoder overwrites every row. */
     picDecodeToSurface(handle, gfx_getCurPageSurface());
 }
@@ -358,7 +358,7 @@ void picBlit(SDL_IOStream *handle, int pageIndex) {
     (void)pageIndex;
     if (!handle) return;
 
-    if (gfx_clearTtfTextOverlay) gfx_clearTtfTextOverlay();
+    gfx_clearTtfTextOverlay();
     dst = gfx_getHiResSurface();
     if (!dst) return;
     base = (uint8 *)dst->pixels;

--- a/src/shared/picimpl.c
+++ b/src/shared/picimpl.c
@@ -20,6 +20,7 @@ extern int fileReadRaw(SDL_IOStream *handle, void *dst, int count);
 /* Hi-res title surface + present (gfx_impl.c). */
 extern SDL_Surface *gfx_getHiResSurface(void);
 extern void gfx_presentHiRes(void);
+extern void gfx_clearTtfTextOverlay(void) __attribute__((weak));
 
 /* Pic decode work data */
 extern uint8 picDecodedRowBuf[320];
@@ -317,6 +318,7 @@ static SDL_Surface *picScratchSurface(void) {
 void showPicFile(SDL_IOStream *handle, int page) {
     if (!handle) return;
     (void)page; /* all pages are the single back buffer */
+    if (gfx_clearTtfTextOverlay) gfx_clearTtfTextOverlay();
     /* Decode straight into the back buffer; the decoder overwrites every row. */
     picDecodeToSurface(handle, gfx_getCurPageSurface());
 }
@@ -356,6 +358,7 @@ void picBlit(SDL_IOStream *handle, int pageIndex) {
     (void)pageIndex;
     if (!handle) return;
 
+    if (gfx_clearTtfTextOverlay) gfx_clearTtfTextOverlay();
     dst = gfx_getHiResSurface();
     if (!dst) return;
     base = (uint8 *)dst->pixels;

--- a/src/shared/textfmt.c
+++ b/src/shared/textfmt.c
@@ -7,6 +7,7 @@
 #include <dos.h>
 
 extern int FAR gfx_setFont(uint16 ch, uint16 font);
+extern int gfx_getStringAdvanceUtf8(const char *text, uint16 fontIdx);
 
 void drawStringCentered(int16 *page, const char *str, int16 startx, int16 y, int16 endx) {
     int16 width;
@@ -15,16 +16,7 @@ void drawStringCentered(int16 *page, const char *str, int16 startx, int16 y, int
 }
 
 int16 stringWidth(int16 *page, const char *str) {
-    int16 n;
-    const char *l;
-    int16 j;
-    l = str;
-    j = page[6];
-    n = 0;
-    while (*l != '\0') {
-        n += gfx_setFont(*(l++), j);
-    }
-    return n;
+    return (int16)gfx_getStringAdvanceUtf8(str, (uint16)page[6]);
 }
 
 void my_ltoa(int32 value, char *buf) {

--- a/src/shared/utf8.c
+++ b/src/shared/utf8.c
@@ -7,9 +7,9 @@
 int utf8DecodeCodepoint(const char *text, uint32_t *codepoint,
                         size_t *byte_count) {
     const unsigned char *bytes = (const unsigned char *)text;
-    uint32_t value;
-    size_t length;
-    size_t index;
+    uint32_t value{};
+    size_t length{};
+    size_t index{};
 
     if (!bytes || !codepoint || !byte_count || bytes[0] == 0) return 0;
     if (bytes[0] < 0x80) {

--- a/src/shared/utf8.c
+++ b/src/shared/utf8.c
@@ -1,0 +1,47 @@
+/*
+ * utf8.c - Strict single-codepoint UTF-8 decoding.
+ */
+#include "utf8.h"
+
+int utf8DecodeCodepoint(const char *text, uint32_t *codepoint,
+                        size_t *byte_count) {
+    const unsigned char *bytes = (const unsigned char *)text;
+    uint32_t value;
+    size_t length;
+    size_t index;
+
+    if (!bytes || !codepoint || !byte_count || bytes[0] == 0) return 0;
+    if (bytes[0] < 0x80) {
+        *codepoint = bytes[0];
+        *byte_count = 1;
+        return 1;
+    }
+    if ((bytes[0] & 0xe0) == 0xc0) {
+        value = bytes[0] & 0x1f;
+        length = 2;
+    } else if ((bytes[0] & 0xf0) == 0xe0) {
+        value = bytes[0] & 0x0f;
+        length = 3;
+    } else if ((bytes[0] & 0xf8) == 0xf0) {
+        value = bytes[0] & 0x07;
+        length = 4;
+    } else {
+        return 0;
+    }
+
+    for (index = 1; index < length; ++index) {
+        if (bytes[index] == 0 || (bytes[index] & 0xc0) != 0x80) return 0;
+        value = (value << 6) | (bytes[index] & 0x3f);
+    }
+    if ((length == 2 && value < 0x80) ||
+        (length == 3 && value < 0x800) ||
+        (length == 4 && value < 0x10000) ||
+        value > 0x10ffff ||
+        (value >= 0xd800 && value <= 0xdfff)) {
+        return 0;
+    }
+
+    *codepoint = value;
+    *byte_count = length;
+    return 1;
+}

--- a/src/shared/utf8.c
+++ b/src/shared/utf8.c
@@ -3,6 +3,7 @@
  */
 #include "utf8.h"
 
+/* Decode one UTF-8 codepoint, replacing malformed input without reading past the terminator. */
 int utf8DecodeCodepoint(const char *text, uint32_t *codepoint,
                         size_t *byte_count) {
     const unsigned char *bytes = (const unsigned char *)text;

--- a/src/shared/utf8.c
+++ b/src/shared/utf8.c
@@ -3,7 +3,7 @@
  */
 #include "utf8.h"
 
-/* Decode one UTF-8 codepoint, replacing malformed input without reading past the terminator. */
+/* Decode one codepoint; reject malformed input without reading past the terminator. */
 int utf8DecodeCodepoint(const char *text, uint32_t *codepoint,
                         size_t *byte_count) {
     const unsigned char *bytes = (const unsigned char *)text;
@@ -34,11 +34,12 @@ int utf8DecodeCodepoint(const char *text, uint32_t *codepoint,
         if (bytes[index] == 0 || (bytes[index] & 0xc0) != 0x80) return 0;
         value = (value << 6) | (bytes[index] & 0x3f);
     }
-    if ((length == 2 && value < 0x80) ||
+    const bool overlongEncoding = (length == 2 && value < 0x80) ||
         (length == 3 && value < 0x800) ||
-        (length == 4 && value < 0x10000) ||
-        value > 0x10ffff ||
-        (value >= 0xd800 && value <= 0xdfff)) {
+        (length == 4 && value < 0x10000);
+    const bool surrogate = value >= 0xd800 && value <= 0xdfff;
+    const bool outsideUnicode = value > 0x10ffff;
+    if (overlongEncoding || surrogate || outsideUnicode) {
         return 0;
     }
 

--- a/src/shared/utf8.h
+++ b/src/shared/utf8.h
@@ -1,0 +1,28 @@
+/*
+ * utf8.h - Small strict UTF-8 decoder shared by input and text rendering.
+ */
+#ifndef F15_UTF8_H
+#define F15_UTF8_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Decode one NUL-terminated UTF-8 sequence.
+ *
+ * Returns non-zero for a valid Unicode scalar value and writes its code point
+ * and byte count. Truncated, overlong, surrogate, and out-of-range sequences
+ * are rejected without reading beyond the first NUL byte.
+ */
+int utf8DecodeCodepoint(const char *text, uint32_t *codepoint,
+                        size_t *byte_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -8,6 +8,7 @@
 #include "sttypes.h"
 #include "const.h"
 #include "gfx.h"
+#include "input.h"
 #include "slot.h"
 #include "comm.h"
 #include "offsets.h"
@@ -31,6 +32,36 @@ void loadHallfame(void);
 void saveHallfame();
 int getJoyKey();
 int readInputKey();
+
+static void redrawPilotSelectorPrompt(int16 *page) {
+    int oldBg = page[3];
+    int oldColor = page[2];
+    int oldFont = page[6];
+    page[3] = 0;
+    clearRect(page, 15, 192, 303, 197);
+    gfx_invalidateTtfTextOverlayRect(15, 190, 303, 199);
+    page[2] = COLOR_LIGHTRED;
+    page[6] = 3;
+    drawStringCentered(page, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
+    page[2] = oldColor;
+    page[6] = oldFont;
+    page[3] = oldBg;
+}
+
+static void redrawPilotNamePrompt(int16 *page) {
+    int oldBg = page[3];
+    int oldColor = page[2];
+    int oldFont = page[6];
+    page[3] = 0;
+    clearRect(page, 15, 192, 303, 197);
+    gfx_invalidateTtfTextOverlayRect(0, 190, SCREEN_MAXX, 199);
+    page[2] = COLOR_LIGHTRED;
+    page[6] = 3;
+    drawStringCentered(page, "ENTER YOUR NAME !", 15, 192, 289);
+    page[2] = oldColor;
+    page[6] = oldFont;
+    page[3] = oldBg;
+}
 
 void pilotSelect(int16 needSplash) {
     int unused;
@@ -90,8 +121,7 @@ void displayPilots(void) {
     do {
         printPilot(pilotIdx);
     } while (++pilotIdx < HALLFAME_SLOTS);
-    screenDesc.color = COLOR_WHITE;
-    drawStringCentered(pageNumPtr, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
+    redrawPilotSelectorPrompt(screenBuf);
     gfx_commitPage();
 }
 
@@ -164,6 +194,8 @@ void processPilotInput() {
             if (doFcbSearch() != 0) {
                 saveHallfame();
             }
+            redrawPilotSelectorPrompt(screenBuf);
+            gfx_commitPage();
             continue;
         case KEYCODE_UPARROW:
             selectedPilotIdx--;
@@ -232,20 +264,21 @@ void pilotToGameData(const uint8 *pilotData) {
 void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
     int blinkToggle;
     int xPos, yPos;
-    int nameLen;
+    int nameLen = 0;
     int cursorX;
     uint16 keyCode;
     int rankWidth;
     blinkToggle = 0;
     xPos = (selectedPilotIdx < PILOTS_PER_COLUMN) ? PILOT_COL_LEFT : PILOT_COL_RIGHT;
     yPos = ((selectedPilotIdx & (PILOTS_PER_COLUMN - 1)) * PILOT_ROW_HEIGHT) + PILOT_TOP_MARGIN;
+    page[2] = COLOR_WHITE;
+    page[6] = 1;
     clearRect(page, xPos, yPos, xPos + PILOT_ENTRY_WIDTH, yPos + 35);
+    gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + PILOT_ENTRY_WIDTH, yPos + 35);
     drawStringAt(page, ranks[0], xPos, yPos);
     xPos += (rankWidth = stringWidth(page, ranks[0]));
     rankWidth = PILOT_ENTRY_WIDTH - rankWidth;
-    screenBuf[3] = 0;
-    clearRect(page, 15, 192, 303, 197);
-    drawStringCentered(pageNumPtr, "\376ENTER YOUR NAME !", 15, 192, 289);
+    redrawPilotNamePrompt(page);
     misc_clearKeyFlags();
     keyCode = KEYCODE_CTRLX;
     do {
@@ -253,30 +286,52 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
         case KEYCODE_CTRLX:
             nameLen = 0;
             pilot->name[0] = '\0';
+            page[2] = COLOR_WHITE;
             clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+            gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
             drawStringAt(page, pilot->name, xPos, yPos);
             cursorX = page[4];
             break;
         case 8: // backspace
             if (nameLen > 0) {
-                nameLen--;
+                do {
+                    nameLen--;
+                } while (nameLen > 0 && (((uint8)pilot->name[nameLen] & 0xc0) == 0x80));
                 pilot->name[nameLen] = '\0';
                 // 2403 - duplicate code block coalesced with above
+                page[2] = COLOR_WHITE;
                 clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+                gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
                 drawStringAt(page, pilot->name, xPos, yPos);
                 cursorX = page[4];
             }
             break;
         default:
-            if (keyCode >= 0x20 && keyCode <= 0x7f && nameLen < a && stringWidth(page, pilot->name) <= 144) {
-                pilot->name[nameLen++] = keyCode;
-                pilot->name[nameLen] = '\0';
-                clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
-                drawStringAt(page, pilot->name, xPos, yPos);
-                cursorX = page[4];
+            {
+                char utf8[8];
+                int utf8Len = input_readMenuTextUtf8(utf8, sizeof(utf8));
+                if (utf8Len == 1 && (uint8)utf8[0] >= 0x20 && (uint8)utf8[0] < 0x80) {
+                    input_discardNextAsciiKey((uint8)utf8[0]);
+                }
+                if (utf8Len == 0 && keyCode >= 0x20 && keyCode <= 0x7f) {
+                    utf8[0] = (char)keyCode;
+                    utf8[1] = '\0';
+                    utf8Len = 1;
+                }
+                if (utf8Len > 0 && nameLen + utf8Len < a && stringWidth(page, pilot->name) <= 144) {
+                    memcpy(&pilot->name[nameLen], utf8, (size_t)utf8Len);
+                    nameLen += utf8Len;
+                    pilot->name[nameLen] = '\0';
+                    page[2] = COLOR_WHITE;
+                    clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+                    gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
+                    drawStringAt(page, pilot->name, xPos, yPos);
+                    cursorX = page[4];
+                }
             }
             break;
         }
+        redrawPilotNamePrompt(page);
         gfx_commitPage();
         while (getJoyKey() == 0) {
             waitMdaCgaStatus(3);
@@ -284,6 +339,7 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
                             pilotNameInputColors[blinkToggle], pilotNameInputColors[blinkToggle ^ 1]);
             blinkToggle ^= 1;
             page[3] = pilotNameInputColors[blinkToggle];
+            redrawPilotNamePrompt(page);
             gfx_commitPage();
         }
         keyCode = readInputKey();
@@ -293,6 +349,7 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
         if (keyCode == KEYCODE_ENTER) {
             screenBuf[3] = 0;
             clearRect(page, 15, 192, 303, 197);
+            gfx_invalidateTtfTextOverlayRect(0, 188, SCREEN_MAXX, SCREEN_MAXY);
             return;
         }
     } while (true);
@@ -332,7 +389,7 @@ int getJoyKey() {
         restoreCbreakHandler();
         exit(0);
     }
-    return misc_checkKeyBuf() == 0;
+    return misc_checkKeyBuf() == 0 || input_menuTextWaiting();
 }
 
 /* ---- merged from stinkey.c ---- */
@@ -347,7 +404,7 @@ int readInputKey() {
             goto checkKey;
         }
     }
-    key = misc_getKey();
+    key = input_menuTextWaiting() ? 0 : misc_getKey();
 checkKey:
     if (key == KEYCODE_ALTQ || cbreakHit != 0) {
         cleanup();

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -310,7 +310,7 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
             break;
         default:
             {
-                char utf8[8];
+                char utf8[8]{};
                 int utf8Len = input_readMenuTextUtf8(utf8, sizeof(utf8));
                 if (utf8Len == 1 && (uint8)utf8[0] >= 0x20 && (uint8)utf8[0] < 0x80) {
                     input_discardNextAsciiKey((uint8)utf8[0]);

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -8,7 +8,6 @@
 #include "sttypes.h"
 #include "const.h"
 #include "gfx.h"
-#include "input.h"
 #include "slot.h"
 #include "comm.h"
 #include "offsets.h"
@@ -32,38 +31,6 @@ void loadHallfame(void);
 void saveHallfame();
 int getJoyKey();
 int readInputKey();
-
-/* Restore the pilot-selection prompt after transient name editing. */
-static void redrawPilotSelectorPrompt(int16 *page) {
-    int oldBg = page[3];
-    int oldColor = page[2];
-    int oldFont = page[6];
-    page[3] = 0;
-    clearRect(page, 15, 192, 303, 197);
-    gfx_invalidateTtfTextOverlayRect(15, 190, 303, 199);
-    page[2] = COLOR_LIGHTRED;
-    page[6] = 3;
-    drawStringCentered(page, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
-    page[2] = oldColor;
-    page[6] = oldFont;
-    page[3] = oldBg;
-}
-
-/* Redraw the name-entry prompt and current UTF-8 pilot name without stale overlays. */
-static void redrawPilotNamePrompt(int16 *page) {
-    int oldBg = page[3];
-    int oldColor = page[2];
-    int oldFont = page[6];
-    page[3] = 0;
-    clearRect(page, 15, 192, 303, 197);
-    gfx_invalidateTtfTextOverlayRect(0, 190, SCREEN_MAXX, 199);
-    page[2] = COLOR_LIGHTRED;
-    page[6] = 3;
-    drawStringCentered(page, "ENTER YOUR NAME !", 15, 192, 289);
-    page[2] = oldColor;
-    page[6] = oldFont;
-    page[3] = oldBg;
-}
 
 void pilotSelect(int16 needSplash) {
     int unused;
@@ -123,7 +90,8 @@ void displayPilots(void) {
     do {
         printPilot(pilotIdx);
     } while (++pilotIdx < HALLFAME_SLOTS);
-    redrawPilotSelectorPrompt(screenBuf);
+    screenDesc.color = COLOR_WHITE;
+    drawStringCentered(pageNumPtr, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
     gfx_commitPage();
 }
 
@@ -196,8 +164,6 @@ void processPilotInput() {
             if (doFcbSearch() != 0) {
                 saveHallfame();
             }
-            redrawPilotSelectorPrompt(screenBuf);
-            gfx_commitPage();
             continue;
         case KEYCODE_UPARROW:
             selectedPilotIdx--;
@@ -266,21 +232,20 @@ void pilotToGameData(const uint8 *pilotData) {
 void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
     int blinkToggle;
     int xPos, yPos;
-    int nameLen = 0;
+    int nameLen;
     int cursorX;
     uint16 keyCode;
     int rankWidth;
     blinkToggle = 0;
     xPos = (selectedPilotIdx < PILOTS_PER_COLUMN) ? PILOT_COL_LEFT : PILOT_COL_RIGHT;
     yPos = ((selectedPilotIdx & (PILOTS_PER_COLUMN - 1)) * PILOT_ROW_HEIGHT) + PILOT_TOP_MARGIN;
-    page[2] = COLOR_WHITE;
-    page[6] = 1;
     clearRect(page, xPos, yPos, xPos + PILOT_ENTRY_WIDTH, yPos + 35);
-    gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + PILOT_ENTRY_WIDTH, yPos + 35);
     drawStringAt(page, ranks[0], xPos, yPos);
     xPos += (rankWidth = stringWidth(page, ranks[0]));
     rankWidth = PILOT_ENTRY_WIDTH - rankWidth;
-    redrawPilotNamePrompt(page);
+    screenBuf[3] = 0;
+    clearRect(page, 15, 192, 303, 197);
+    drawStringCentered(pageNumPtr, "\376ENTER YOUR NAME !", 15, 192, 289);
     misc_clearKeyFlags();
     keyCode = KEYCODE_CTRLX;
     do {
@@ -288,52 +253,30 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
         case KEYCODE_CTRLX:
             nameLen = 0;
             pilot->name[0] = '\0';
-            page[2] = COLOR_WHITE;
             clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
-            gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
             drawStringAt(page, pilot->name, xPos, yPos);
             cursorX = page[4];
             break;
         case 8: // backspace
             if (nameLen > 0) {
-                do {
-                    nameLen--;
-                } while (nameLen > 0 && (((uint8)pilot->name[nameLen] & 0xc0) == 0x80));
+                nameLen--;
                 pilot->name[nameLen] = '\0';
                 // 2403 - duplicate code block coalesced with above
-                page[2] = COLOR_WHITE;
                 clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
-                gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
                 drawStringAt(page, pilot->name, xPos, yPos);
                 cursorX = page[4];
             }
             break;
         default:
-            {
-                char utf8[8]{};
-                int utf8Len = input_readMenuTextUtf8(utf8, sizeof(utf8));
-                if (utf8Len == 1 && (uint8)utf8[0] >= 0x20 && (uint8)utf8[0] < 0x80) {
-                    input_discardNextAsciiKey((uint8)utf8[0]);
-                }
-                if (utf8Len == 0 && keyCode >= 0x20 && keyCode <= 0x7f) {
-                    utf8[0] = (char)keyCode;
-                    utf8[1] = '\0';
-                    utf8Len = 1;
-                }
-                if (utf8Len > 0 && nameLen + utf8Len < a && stringWidth(page, pilot->name) <= 144) {
-                    memcpy(&pilot->name[nameLen], utf8, (size_t)utf8Len);
-                    nameLen += utf8Len;
-                    pilot->name[nameLen] = '\0';
-                    page[2] = COLOR_WHITE;
-                    clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
-                    gfx_invalidateTtfTextOverlayRect(xPos, yPos - 2, xPos + rankWidth, yPos + c + 8);
-                    drawStringAt(page, pilot->name, xPos, yPos);
-                    cursorX = page[4];
-                }
+            if (keyCode >= 0x20 && keyCode <= 0x7f && nameLen < a && stringWidth(page, pilot->name) <= 144) {
+                pilot->name[nameLen++] = keyCode;
+                pilot->name[nameLen] = '\0';
+                clearRect(page, xPos, yPos, xPos + rankWidth, yPos + c);
+                drawStringAt(page, pilot->name, xPos, yPos);
+                cursorX = page[4];
             }
             break;
         }
-        redrawPilotNamePrompt(page);
         gfx_commitPage();
         while (getJoyKey() == 0) {
             waitMdaCgaStatus(3);
@@ -341,7 +284,6 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
                             pilotNameInputColors[blinkToggle], pilotNameInputColors[blinkToggle ^ 1]);
             blinkToggle ^= 1;
             page[3] = pilotNameInputColors[blinkToggle];
-            redrawPilotNamePrompt(page);
             gfx_commitPage();
         }
         keyCode = readInputKey();
@@ -351,7 +293,6 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
         if (keyCode == KEYCODE_ENTER) {
             screenBuf[3] = 0;
             clearRect(page, 15, 192, 303, 197);
-            gfx_invalidateTtfTextOverlayRect(0, 188, SCREEN_MAXX, SCREEN_MAXY);
             return;
         }
     } while (true);
@@ -391,7 +332,7 @@ int getJoyKey() {
         restoreCbreakHandler();
         exit(0);
     }
-    return misc_checkKeyBuf() == 0 || input_menuTextWaiting();
+    return misc_checkKeyBuf() == 0;
 }
 
 /* ---- merged from stinkey.c ---- */
@@ -406,7 +347,7 @@ int readInputKey() {
             goto checkKey;
         }
     }
-    key = input_menuTextWaiting() ? 0 : misc_getKey();
+    key = misc_getKey();
 checkKey:
     if (key == KEYCODE_ALTQ || cbreakHit != 0) {
         cleanup();

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -33,6 +33,7 @@ void saveHallfame();
 int getJoyKey();
 int readInputKey();
 
+/* Restore the pilot-selection prompt after transient name editing. */
 static void redrawPilotSelectorPrompt(int16 *page) {
     int oldBg = page[3];
     int oldColor = page[2];
@@ -48,6 +49,7 @@ static void redrawPilotSelectorPrompt(int16 *page) {
     page[3] = oldBg;
 }
 
+/* Redraw the name-entry prompt and current UTF-8 pilot name without stale overlays. */
 static void redrawPilotNamePrompt(int16 *page) {
     int oldBg = page[3];
     int oldColor = page[2];

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -310,9 +310,6 @@ void pilotNameInput(int16 *page, int a, int b, int c, struct Pilot *pilot) {
             {
                 char utf8[8];
                 int utf8Len = input_readMenuTextUtf8(utf8, sizeof(utf8));
-                if (utf8Len == 1 && (uint8)utf8[0] >= 0x20 && (uint8)utf8[0] < 0x80) {
-                    input_discardNextAsciiKey((uint8)utf8[0]);
-                }
                 if (utf8Len == 0 && keyCode >= 0x20 && keyCode <= 0x7f) {
                     utf8[0] = (char)keyCode;
                     utf8[1] = '\0';
@@ -389,7 +386,7 @@ int getJoyKey() {
         restoreCbreakHandler();
         exit(0);
     }
-    return misc_checkKeyBuf() == 0 || input_menuTextWaiting();
+    return misc_checkKeyBuf() == 0;
 }
 
 /* ---- merged from stinkey.c ---- */
@@ -404,7 +401,7 @@ int readInputKey() {
             goto checkKey;
         }
     }
-    key = input_menuTextWaiting() ? 0 : misc_getKey();
+    key = misc_getKey();
 checkKey:
     if (key == KEYCODE_ALTQ || cbreakHit != 0) {
         cleanup();

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -1,0 +1,67 @@
+#include "shared/asset_path.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+} // namespace
+
+int main() {
+    const auto testRoot =
+        std::filesystem::temp_directory_path() / "f15se2-ex-asset-path-tests";
+    std::filesystem::remove_all(testRoot);
+    std::filesystem::create_directories(testRoot / "Fonts");
+    std::ofstream(testRoot / "WALL.PNG", std::ios::binary) << "png";
+    std::ofstream(testRoot / "Fonts" / "FONT_1.BDF", std::ios::binary) << "bdf";
+
+    char path[1024] = {};
+    setReplacementRoot("");
+    require(!findAssetReplacement("WALL.png", path, sizeof(path)),
+            "lookup is disabled without an explicit replacement root");
+
+    setReplacementRoot(testRoot.string());
+    require(findAssetReplacement("wall.png", path, sizeof(path)),
+            "lookup matches DOS-style uppercase names");
+    require(std::filesystem::path(path).filename() == "WALL.PNG",
+            "lookup returns the actual filesystem spelling");
+
+    require(findAssetReplacement("fonts/font_1.bdf", path, sizeof(path)),
+            "lookup matches every nested path component case-insensitively");
+    require(!findAssetReplacement("../WALL.PNG", path, sizeof(path)),
+            "lookup rejects parent traversal");
+    require(!findAssetReplacement(testRoot.string().c_str(), path, sizeof(path)),
+            "lookup rejects absolute paths");
+
+    char shortPath[2] = {'x', '\0'};
+    require(!findAssetReplacement("WALL.PNG", shortPath, sizeof(shortPath)),
+            "lookup rejects an undersized output buffer");
+    require(shortPath[0] == '\0', "failed lookup clears the output buffer");
+    require(!findAssetReplacement("missing.png", path, sizeof(path)),
+            "lookup rejects missing files");
+    require(path[0] == '\0', "missing lookup clears the output buffer");
+
+    setReplacementRoot("");
+    std::filesystem::remove_all(testRoot);
+    std::cout << "asset_path_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/asset_path_behavior_tests.cpp
+++ b/tests/asset_path_behavior_tests.cpp
@@ -60,6 +60,39 @@ int main() {
             "lookup rejects missing files");
     require(path[0] == '\0', "missing lookup clears the output buffer");
 
+    require(!findAssetReplacement("Fonts", path, sizeof(path)),
+            "a directory cannot replace a file");
+    require(!findAssetReplacement(nullptr, path, sizeof(path)),
+            "null input is rejected");
+    require(!findAssetReplacement("WALL.PNG", nullptr, sizeof(path)),
+            "null output is rejected");
+
+#if !defined(_WIN32)
+    /* Windows hosts need privileges for symlinks; exercise boundary behavior
+     * on POSIX, including a sibling whose name shares the root prefix. */
+    const auto outside = std::filesystem::path(testRoot.string() + "-outside");
+    std::filesystem::create_directories(outside);
+    std::ofstream(outside / "OUT.PNG", std::ios::binary) << "outside";
+    std::filesystem::create_symlink(outside / "OUT.PNG", testRoot / "ESCAPE.PNG");
+    std::filesystem::create_directory_symlink(outside, testRoot / "ESCAPE");
+    std::filesystem::create_symlink(testRoot / "WALL.PNG", testRoot / "ALIAS.PNG");
+    require(!findAssetReplacement("escape.png", path, sizeof(path)),
+            "a file symlink cannot escape the root");
+    require(!findAssetReplacement("escape/out.png", path, sizeof(path)),
+            "a directory symlink cannot escape the root");
+    require(findAssetReplacement("alias.png", path, sizeof(path)),
+            "symlinks within the root remain usable");
+    std::filesystem::remove_all(outside);
+#endif
+
+    /* Only case-sensitive filesystems can hold both spellings. */
+    if (!std::filesystem::exists(testRoot / "wall.png")) {
+        std::ofstream(testRoot / "wall.png", std::ios::binary) << "duplicate";
+        require(!findAssetReplacement("wall.png", path, sizeof(path)),
+                "ambiguous DOS spellings are rejected");
+        require(path[0] == '\0', "ambiguous lookup clears the output buffer");
+    }
+
     setReplacementRoot("");
     std::filesystem::remove_all(testRoot);
     std::cout << "asset_path_behavior_tests passed\n";

--- a/tests/bitmap_font_full_validation_tests.cpp
+++ b/tests/bitmap_font_full_validation_tests.cpp
@@ -1,0 +1,74 @@
+#include "gfx_impl.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#if !defined(F15_CONVERTED_ASSETS)
+#define F15_CONVERTED_ASSETS ""
+#endif
+
+namespace {
+
+void require(bool condition, const std::string &message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::filesystem::path *root) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root ? root->string().c_str() : "");
+#else
+    if (root) setenv("F15_REPLACEMENT_ROOT", root->string().c_str(), 1);
+    else unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+}
+
+} // namespace
+
+int main() {
+    const std::filesystem::path convertedRoot = F15_CONVERTED_ASSETS;
+    const int fontIds[] = {0, 1, 3, 4, 5};
+
+    setReplacementRoot(&convertedRoot);
+    for (int fontId : fontIds) {
+        uint8 legacyBitmap[96 * 32] = {};
+        uint8 replacementBitmap[96 * 32] = {};
+        uint8 legacyWidths[96] = {};
+        uint8 replacementWidths[96] = {};
+        int legacyHeight = 0;
+        int legacyMaxWidth = 0;
+        int replacementHeight = 0;
+        int replacementMaxWidth = 0;
+
+        require(gfx_testCopyBuiltinFont(
+                    (uint16)fontId, legacyBitmap, sizeof(legacyBitmap),
+                    legacyWidths, sizeof(legacyWidths),
+                    &legacyHeight, &legacyMaxWidth),
+                "cannot read built-in font_" + std::to_string(fontId));
+        require(gfx_testCopyEffectiveFont(
+                    (uint16)fontId, replacementBitmap,
+                    sizeof(replacementBitmap), replacementWidths,
+                    sizeof(replacementWidths), &replacementHeight,
+                    &replacementMaxWidth),
+                "cannot load replacement font_" + std::to_string(fontId));
+        require(replacementHeight == legacyHeight &&
+                    replacementMaxWidth == legacyMaxWidth,
+                "font metrics differ for font_" + std::to_string(fontId));
+        require(std::memcmp(
+                    replacementWidths, legacyWidths, sizeof(legacyWidths)) == 0,
+                "glyph widths differ for font_" + std::to_string(fontId));
+        require(std::memcmp(replacementBitmap, legacyBitmap,
+                            (size_t)legacyHeight * 96u) == 0,
+                "glyph rows differ for font_" + std::to_string(fontId));
+    }
+
+    setReplacementRoot(nullptr);
+    std::cout << "bitmap_font_full_validation_tests compared "
+              << sizeof(fontIds) / sizeof(fontIds[0]) << " font slots\n";
+    return 0;
+}

--- a/tests/bitmap_font_replacement_behavior_tests.cpp
+++ b/tests/bitmap_font_replacement_behavior_tests.cpp
@@ -1,0 +1,95 @@
+#include "shared/bitmap_font_replacement.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void setReplacementRoot(const std::string &value) {
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", value.c_str());
+#else
+    if (value.empty()) unsetenv("F15_REPLACEMENT_ROOT");
+    else setenv("F15_REPLACEMENT_ROOT", value.c_str(), 1);
+#endif
+}
+
+void writeBdf(const std::filesystem::path &path, bool complete) {
+    std::ofstream out(path);
+    out << "STARTFONT 2.1\n";
+    const int glyph_count = complete ? 96 : 95;
+    for (int index = 0; index < glyph_count; ++index) {
+        out << "STARTCHAR glyph\nENCODING " << 32 + index
+            << "\nDWIDTH " << 1 + index % 8
+            << " 0\nBBX 8 2 0 0\nBITMAP\n"
+            << (index == 0 ? "80\n40\n" : "00\n00\n")
+            << "ENDCHAR\n";
+    }
+    out << "ENDFONT\n";
+}
+
+void writePng(const std::filesystem::path &path) {
+    SDL_Surface *surface =
+        SDL_CreateSurface(16 * 9 - 1, 6 * 3 - 1, SDL_PIXELFORMAT_RGBA32);
+    require(surface != nullptr, "font PNG test surface is created");
+    SDL_FillSurfaceRect(surface, nullptr, 0);
+    require(SDL_WriteSurfacePixel(surface, 0, 0, 255, 255, 255, 255),
+            "font PNG test pixel is written");
+    require(SDL_SavePNG(surface, path.string().c_str()),
+            "font PNG test atlas is saved");
+    SDL_DestroySurface(surface);
+}
+
+} // namespace
+
+int main() {
+    const auto root =
+        std::filesystem::temp_directory_path() / "f15se2-ex-font-tests";
+    const auto fonts = root / "fonts";
+    const auto bdf = fonts / "font_1.bdf";
+    const auto png = fonts / "font_1.png";
+    const uint8_t original_widths[96] = {4};
+    BitmapFontReplacement replacement = {};
+
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(fonts);
+    setReplacementRoot(root.string());
+    writeBdf(bdf, true);
+
+    require(bitmapFontReplacementGet(1, 8, 2, original_widths, &replacement),
+            "complete BDF loads");
+    require(replacement.bitmaps[0] == 0x80
+            && replacement.bitmaps[1] == 0x40,
+            "BDF bitmap rows retain their legacy byte layout");
+    require(replacement.widths[0] == 1 && replacement.widths[7] == 8,
+            "BDF advance widths replace the legacy table");
+
+    bitmapFontReplacementShutdown();
+    writeBdf(bdf, false);
+    writePng(png);
+    replacement = {};
+    require(bitmapFontReplacementGet(1, 8, 2, original_widths, &replacement),
+            "valid PNG is used when BDF is incomplete");
+    require(replacement.bitmaps[0] == 0x80,
+            "PNG atlas is converted to the legacy glyph-row layout");
+    require(replacement.widths[0] == original_widths[0],
+            "PNG atlas preserves original advance widths");
+
+    bitmapFontReplacementShutdown();
+    setReplacementRoot("");
+    std::filesystem::remove_all(root);
+    std::cout << "bitmap_font_replacement_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/input_behavior_tests.cpp
+++ b/tests/input_behavior_tests.cpp
@@ -2,6 +2,7 @@
 #include "egdata.h"
 #include "eginput.h"
 #include "headless.h"
+#include "input.h"
 
 #include <SDL3/SDL.h>
 
@@ -123,6 +124,13 @@ void pushKey(SDL_Scancode scancode, SDL_Keymod modifiers = SDL_KMOD_NONE) {
 void pushMouseMotion() {
     SDL_Event event = {};
     event.type = SDL_EVENT_MOUSE_MOTION;
+    SDL_PushEvent(&event);
+}
+
+void pushText(const char *text) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_TEXT_INPUT;
+    event.text.text = text;
     SDL_PushEvent(&event);
 }
 
@@ -284,6 +292,46 @@ int main() {
     }
     require(readCount == kRingStoredCapacity,
             "key ring drops overflow after its one-empty-slot capacity");
+
+    input_setMode(INPUT_MODE_MENU);
+    input_ringReset();
+    pushText("\xd0\xba"); /* U+043A CYRILLIC SMALL LETTER KA */
+    char utf8[8] = {};
+    require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 2,
+            "menu text input preserves a two-byte UTF-8 character");
+    require(SDL_strcmp(utf8, "\xd0\xba") == 0,
+            "menu text ring returns the original UTF-8 bytes");
+    require(!input_menuTextWaiting(),
+            "reading a menu text character consumes exactly one ring entry");
+
+    input_ringReset();
+    pushText("a");
+    require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 1 &&
+                SDL_strcmp(utf8, "a") == 0,
+            "ASCII text is available through the UTF-8 menu ring");
+    input_discardNextAsciiKey((uint8)'a');
+    require(!input_keyWaiting(),
+            "pilot-name handling can discard the duplicate BIOS ASCII event");
+
+    input_setMode(INPUT_MODE_FLIGHT);
+    input_ringReset();
+    pushText("\xd0\xba");
+    input_pumpEvents();
+    require(!input_menuTextWaiting(),
+            "flight mode ignores composed text events");
+
+    input_setMode(INPUT_MODE_MENU);
+    input_ringReset();
+    pushText("\xd0"); /* truncated two-byte sequence */
+    input_pumpEvents();
+    require(!input_menuTextWaiting(),
+            "menu text input rejects a truncated UTF-8 sequence");
+
+    input_ringReset();
+    pushText("\xc0\x80"); /* overlong encoding of NUL */
+    input_pumpEvents();
+    require(!input_menuTextWaiting(),
+            "menu text input rejects an overlong UTF-8 sequence");
 
     restoreInt9Handler();
     SDL_Quit();

--- a/tests/input_behavior_tests.cpp
+++ b/tests/input_behavior_tests.cpp
@@ -2,7 +2,6 @@
 #include "egdata.h"
 #include "eginput.h"
 #include "headless.h"
-#include "input.h"
 
 #include <SDL3/SDL.h>
 
@@ -124,13 +123,6 @@ void pushKey(SDL_Scancode scancode, SDL_Keymod modifiers = SDL_KMOD_NONE) {
 void pushMouseMotion() {
     SDL_Event event = {};
     event.type = SDL_EVENT_MOUSE_MOTION;
-    SDL_PushEvent(&event);
-}
-
-void pushText(const char *text) {
-    SDL_Event event = {};
-    event.type = SDL_EVENT_TEXT_INPUT;
-    event.text.text = text;
     SDL_PushEvent(&event);
 }
 
@@ -292,46 +284,6 @@ int main() {
     }
     require(readCount == kRingStoredCapacity,
             "key ring drops overflow after its one-empty-slot capacity");
-
-    input_setMode(INPUT_MODE_MENU);
-    input_ringReset();
-    pushText("\xd0\xba"); /* U+043A CYRILLIC SMALL LETTER KA */
-    char utf8[8] = {};
-    require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 2,
-            "menu text input preserves a two-byte UTF-8 character");
-    require(SDL_strcmp(utf8, "\xd0\xba") == 0,
-            "menu text ring returns the original UTF-8 bytes");
-    require(!input_menuTextWaiting(),
-            "reading a menu text character consumes exactly one ring entry");
-
-    input_ringReset();
-    pushText("a");
-    require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 1 &&
-                SDL_strcmp(utf8, "a") == 0,
-            "ASCII text is available through the UTF-8 menu ring");
-    input_discardNextAsciiKey((uint8)'a');
-    require(!input_keyWaiting(),
-            "pilot-name handling can discard the duplicate BIOS ASCII event");
-
-    input_setMode(INPUT_MODE_FLIGHT);
-    input_ringReset();
-    pushText("\xd0\xba");
-    input_pumpEvents();
-    require(!input_menuTextWaiting(),
-            "flight mode ignores composed text events");
-
-    input_setMode(INPUT_MODE_MENU);
-    input_ringReset();
-    pushText("\xd0"); /* truncated two-byte sequence */
-    input_pumpEvents();
-    require(!input_menuTextWaiting(),
-            "menu text input rejects a truncated UTF-8 sequence");
-
-    input_ringReset();
-    pushText("\xc0\x80"); /* overlong encoding of NUL */
-    input_pumpEvents();
-    require(!input_menuTextWaiting(),
-            "menu text input rejects an overlong UTF-8 sequence");
 
     restoreInt9Handler();
     SDL_Quit();

--- a/tests/input_behavior_tests.cpp
+++ b/tests/input_behavior_tests.cpp
@@ -297,40 +297,71 @@ int main() {
     input_ringReset();
     pushText("\xd0\xba"); /* U+043A CYRILLIC SMALL LETTER KA */
     char utf8[8] = {};
+    require(input_readKey() == 0, "Unicode text occupies one ordered key entry");
+    require(input_readMenuTextUtf8(utf8, 2) == 0 && utf8[0] == '\0',
+            "a short buffer cannot split a UTF-8 character");
     require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 2,
             "menu text input preserves a two-byte UTF-8 character");
     require(SDL_strcmp(utf8, "\xd0\xba") == 0,
             "menu text ring returns the original UTF-8 bytes");
-    require(!input_menuTextWaiting(),
-            "reading a menu text character consumes exactly one ring entry");
+    require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 0,
+            "text from a popped entry is returned only once");
 
     input_ringReset();
     pushText("a");
+    require(input_readKey() == 'a', "ASCII text keeps its legacy key word");
     require(input_readMenuTextUtf8(utf8, sizeof(utf8)) == 1 &&
                 SDL_strcmp(utf8, "a") == 0,
             "ASCII text is available through the UTF-8 menu ring");
-    input_discardNextAsciiKey((uint8)'a');
     require(!input_keyWaiting(),
-            "pilot-name handling can discard the duplicate BIOS ASCII event");
+            "ASCII text does not leave a duplicate key event");
+
+    input_ringReset();
+    pushText("a");
+    SDL_Event backspace = {};
+    backspace.type = SDL_EVENT_KEY_DOWN;
+    backspace.key.scancode = SDL_SCANCODE_BACKSPACE;
+    backspace.key.key = SDLK_BACKSPACE;
+    backspace.key.down = true;
+    SDL_PushEvent(&backspace);
+    pushText("\xd0\xba");
+    require(input_readKey() == 'a' &&
+                input_readMenuTextUtf8(utf8, sizeof(utf8)) == 1,
+            "typing before Backspace is delivered first");
+    require((input_readKey() & 0xff) == 8 &&
+                input_readMenuTextUtf8(utf8, sizeof(utf8)) == 0,
+            "Backspace is not overtaken by later text");
+    require(input_readKey() == 0 &&
+                input_readMenuTextUtf8(utf8, sizeof(utf8)) == 2,
+            "Unicode after Backspace stays after it");
+
+    input_ringReset();
+    pushText("a");
+    SDL_Event escape = backspace;
+    escape.key.scancode = SDL_SCANCODE_ESCAPE;
+    escape.key.key = SDLK_ESCAPE;
+    SDL_PushEvent(&escape);
+    require(input_readKey() == 'a' && (input_readKey() & 0xff) == 27,
+            "menus can ignore text without blocking a subsequent Escape");
 
     input_setMode(INPUT_MODE_FLIGHT);
     input_ringReset();
     pushText("\xd0\xba");
     input_pumpEvents();
-    require(!input_menuTextWaiting(),
+    require(!input_keyWaiting(),
             "flight mode ignores composed text events");
 
     input_setMode(INPUT_MODE_MENU);
     input_ringReset();
     pushText("\xd0"); /* truncated two-byte sequence */
     input_pumpEvents();
-    require(!input_menuTextWaiting(),
+    require(!input_keyWaiting(),
             "menu text input rejects a truncated UTF-8 sequence");
 
     input_ringReset();
     pushText("\xc0\x80"); /* overlong encoding of NUL */
     input_pumpEvents();
-    require(!input_menuTextWaiting(),
+    require(!input_keyWaiting(),
             "menu text input rejects an overlong UTF-8 sequence");
 
     restoreInt9Handler();

--- a/tests/shared_picimpl_behavior_tests.cpp
+++ b/tests/shared_picimpl_behavior_tests.cpp
@@ -18,6 +18,10 @@ void picBlit(SDL_IOStream *handle, int pageIndex);
 
 uint8 picDecodedRowBuf[320] = {};
 
+/* The isolated PIC decoder test does not link gfx_impl.c. Production builds
+ * always resolve this hook to the real retained-text overlay cleanup. */
+void gfx_clearTtfTextOverlay(void) {}
+
 namespace {
 
 // Behavior-sensitive constants are named here or explained at the use site.

--- a/tests/ttf_font_behavior_tests.cpp
+++ b/tests/ttf_font_behavior_tests.cpp
@@ -1,0 +1,75 @@
+#include "gfx.h"
+#include "gfx_impl.h"
+#include "headless.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    const fs::path root =
+        fs::temp_directory_path() / "f15se2-ex-ttf-font-test";
+    const fs::path fontDirectory = root / "fonts";
+    const fs::path replacement = fontDirectory / "font_4.ttf";
+
+    fs::remove_all(root);
+    fs::create_directories(fontDirectory);
+    fs::copy_file(F15_TEST_TTF_PATH, replacement,
+                  fs::copy_options::overwrite_existing);
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", root.string().c_str());
+#else
+    setenv("F15_REPLACEMENT_ROOT", root.string().c_str(), 1);
+#endif
+
+    test_headless_init();
+    gfx_videoInit();
+    gfx_setMode13();
+
+    const int asciiAdvance = gfx_getGlyphAdvance('n', 4);
+    const int cyrillicAdvance = gfx_getGlyphAdvance(0x041f, 4);
+    const int lineAdvance =
+        gfx_getStringAdvanceUtf8(
+            "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82", 4);
+    require(asciiAdvance > 0 && cyrillicAdvance == asciiAdvance,
+            "TTF replacement supplies compatible Cyrillic and ASCII metrics");
+    require(lineAdvance > cyrillicAdvance,
+            "TTF replacement measures a complete UTF-8 Cyrillic line");
+
+    int16 params[7] = {};
+    params[0] = 0;
+    params[2] = 15;
+    params[4] = 20;
+    params[5] = 20;
+    params[6] = 4;
+    gfx_drawString(params, "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82");
+    require(params[4] == 20 + lineAdvance,
+            "TTF overlay submission uses the same line metric as layout");
+    gfx_repaint();
+    gfx_invalidateTtfTextOverlayRect(0, 0, 319, 199);
+    gfx_clearTtfTextOverlay();
+    gfx_videoShutdown();
+
+#if defined(_WIN32)
+    _putenv_s("F15_REPLACEMENT_ROOT", "");
+#else
+    unsetenv("F15_REPLACEMENT_ROOT");
+#endif
+    fs::remove_all(root);
+    std::cout << "ttf_font_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/ttf_font_behavior_tests.cpp
+++ b/tests/ttf_font_behavior_tests.cpp
@@ -5,6 +5,7 @@
 #include <SDL3/SDL.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 
@@ -40,6 +41,17 @@ int main() {
     gfx_videoInit();
     gfx_setMode13();
 
+    // A first draw must activate the override without a preceding measurement.
+    SDL_Surface *page = gfx_getCurPageSurface();
+    const size_t pageSize = (size_t)page->pitch * page->h;
+    std::memset(page->pixels, 0, pageSize);
+    int16 firstDraw[7] = {0, 0, 15, 0, 20, 20, 4};
+    gfx_drawString(firstDraw, "A");
+    const auto *pixels = static_cast<const unsigned char *>(page->pixels);
+    for (size_t i = 0; i < pageSize; ++i) {
+        require(pixels[i] == 0, "first TTF draw is an overlay, not bitmap text");
+    }
+
     const int asciiAdvance = gfx_getGlyphAdvance('n', 4);
     const int cyrillicAdvance = gfx_getGlyphAdvance(0x041f, 4);
     const int lineAdvance =
@@ -49,6 +61,8 @@ int main() {
             "TTF replacement supplies compatible Cyrillic and ASCII metrics");
     require(lineAdvance > cyrillicAdvance,
             "TTF replacement measures a complete UTF-8 Cyrillic line");
+    require(gfx_getGlyphAdvance(0xe9, 4) > 0 && gfx_setFont(0xe9, 4) == 0,
+            "Unicode Latin-1 glyphs and legacy color bytes remain distinct");
 
     int16 params[7] = {};
     params[0] = 0;

--- a/tests/utf8_behavior_tests.cpp
+++ b/tests/utf8_behavior_tests.cpp
@@ -1,0 +1,62 @@
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+extern "C" {
+#include "shared/utf8.h"
+}
+
+static int failures;
+
+static void expectDecode(const char *text, uint32_t expectedCodepoint,
+                         size_t expectedBytes) {
+    uint32_t codepoint = 0;
+    size_t byteCount = 0;
+
+    if (!utf8DecodeCodepoint(text, &codepoint, &byteCount) ||
+        codepoint != expectedCodepoint || byteCount != expectedBytes) {
+        std::fprintf(stderr,
+                     "decode failed: expected U+%04x/%zu, got U+%04x/%zu\n",
+                     expectedCodepoint, expectedBytes, codepoint, byteCount);
+        ++failures;
+    }
+}
+
+static void expectReject(const char *text) {
+    uint32_t codepoint = 0;
+    size_t byteCount = 0;
+
+    if (utf8DecodeCodepoint(text, &codepoint, &byteCount)) {
+        std::fprintf(stderr, "invalid UTF-8 decoded as U+%04x/%zu\n",
+                     codepoint, byteCount);
+        ++failures;
+    }
+}
+
+int main() {
+    expectDecode("A", 0x41, 1);
+    expectDecode("\xd0\xba", 0x043a, 2);
+    expectDecode("\xe2\x82\xac", 0x20ac, 3);
+    expectDecode("\xf0\x9f\x9b\xa9", 0x1f6e9, 4);
+
+    expectReject("");
+    expectReject("\xc0\xaf");          /* Overlong two-byte encoding. */
+    expectReject("\xe0\x80\xaf");      /* Overlong three-byte encoding. */
+    expectReject("\xed\xa0\x80");      /* UTF-16 surrogate U+D800. */
+    expectReject("\xf4\x90\x80\x80");  /* Beyond Unicode U+10FFFF. */
+    expectReject("\xe2\x82");          /* Truncated sequence. */
+    expectReject("\x80");              /* Continuation without a lead byte. */
+
+    {
+        uint32_t codepoint = 0;
+        size_t byteCount = 0;
+        if (utf8DecodeCodepoint(nullptr, &codepoint, &byteCount) ||
+            utf8DecodeCodepoint("A", nullptr, &byteCount) ||
+            utf8DecodeCodepoint("A", &codepoint, nullptr)) {
+            std::fprintf(stderr, "null argument was accepted\n");
+            ++failures;
+        }
+    }
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- accepts SDL UTF-8 text input instead of reducing entered names to single-byte key values
- edits pilot names by UTF-8 codepoint so backspace and length limits cannot split a multibyte character
- measures and redraws edited names through the vector-font string metrics introduced by #34
- adds focused coverage for UTF-8 text events and pilot-name input behavior

## Why

The vector-font renderer can display Unicode glyphs, but the legacy pilot-name editor still treated input as one byte per character. Non-ASCII input was therefore blank, truncated, or damaged during editing.

## Dependency and review order

- Depends on #34.
- Review and merge #34 first.
- Until #34 merges, GitHub includes the dependent vector-font commits in this PR's comparison. After #34 merges, this PR reduces to one commit changing four files.

## Developer impact

Existing ASCII input remains supported. Pilot names can additionally contain UTF-8 text when the selected TTF/OTF replacement provides the required glyphs.

## Validation

- the combined vector-font and UTF-8 input branch passed the full local CTest suite before the review split
- focused UTF-8 decoder, SDL text-input, and pilot-name behavior tests are included
- fresh GitHub CI will validate the rebased draft branch

Split from #34 to keep vector-font rendering and text-entry behavior independently reviewable.
