### PR TITLE
[review: medium] 6. [feat] Add gameplay options menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(F15SE2_SOURCES
 
     # Shared gfx-slot / timer / misc / pic / overlay basics
     ${SRC_DIR}/input.c
+    ${SRC_DIR}/game_options.c
     ${SRC_DIR}/shared/miscimpl.c
     ${SRC_DIR}/shared/ovlimpl.c
     ${SRC_DIR}/shared/picimpl.c
@@ -118,6 +119,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/stmain.c
     ${SRC_DIR}/stinit.c
     ${SRC_DIR}/stmissn.c
+    ${SRC_DIR}/stoptions.c
     ${SRC_DIR}/stsprit.c
     ${SRC_DIR}/strand.c
     ${SRC_DIR}/stpilot.c
@@ -463,6 +465,8 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
+add_behavior_test(game_options_behavior_tests LINK_CORE)
+add_behavior_test(stoptions_behavior_tests LINK_CORE)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)
 add_behavior_test(view_behavior_tests LINK_CORE)
 add_behavior_test(egsys_internal_behavior_tests LINK_CORE)

--- a/src/egcombat.c
+++ b/src/egcombat.c
@@ -2,6 +2,7 @@
 #include "eg3dmap.h"
 #include "egcode.h"
 #include "egcombat.h"
+#include "game_options.h"
 #include "egdata.h"
 #include "egframe.h"
 #include "egkeys.h"
@@ -641,6 +642,7 @@ int16 markTargetReached(int16 targetIdx) {
 extern int16 randomRange(int16);
 void bombTarget(void) {
     int16 hit;
+    if (gameOptionsEnabled(GAME_OPTION_NO_DAMAGE)) return;
     if (!(g_playerPlaneFlags & 0x1000) && g_autopilotEngaged != -1) {
         hit = 0;
         goto check;
@@ -678,7 +680,8 @@ void fireMissile() {
     if (spec == 0) return;
     if (spec == -1) return;
 
-    missleSpec[missileSpecIndex].ammo--;
+    if (!gameOptionsEnabled(GAME_OPTION_INFINITE_WEAPONS))
+        missleSpec[missileSpecIndex].ammo--;
 
     if (g_hudVisible != 0) {
         setDrawColor(COLOR_BLACK);

--- a/src/egflight.c
+++ b/src/egflight.c
@@ -2,6 +2,7 @@
 #include "egcode.h"
 #include "egdata.h"
 #include "egflight.h"
+#include "game_options.h"
 #include "egframe.h"
 #include "egkeys.h"
 #include "egmath.h"
@@ -401,7 +402,8 @@ switch_break:
     if (g_setThrust < g_thrust) g_thrust = g_setThrust;
 
     if ((((uint16)frameTick) % ((uint16)(g_frameRateScaling << 1))) == 0 && g_setThrust != 0 && g_autopilotEngaged == 0) {
-        g_fuelRemaining -= ((g_setThrust * g_setThrust) / 750) + 2;
+        if (!gameOptionsEnabled(GAME_OPTION_INFINITE_FUEL))
+            g_fuelRemaining -= ((g_setThrust * g_setThrust) / 750) + 2;
         drawFuelGauge();
     }
 
@@ -575,10 +577,11 @@ switch_break:
             makeSound(12, 2);
             // temp_bx = g_closestThreatIndex << 4;
 
-            if (((((g_planeTable.planes[g_closestThreatIndex].flags & 0x200) ? 0x100 : 0x80) < ((int16)(-g_climbRate * g_missionStatus) / 2))) ||
+            if (!gameOptionsEnabled(GAME_OPTION_NO_DAMAGE) &&
+                (((((g_planeTable.planes[g_closestThreatIndex].flags & 0x200) ? 0x100 : 0x80) < ((int16)(-g_climbRate * g_missionStatus) / 2))) ||
                 ((gameData->unk4 != 0 &&
                   (((g_playerPlaneFlags & 1) != 0) ||
-                   (((int16)abs(g_ourRoll)) > (int16)((0x30 / (g_missionStatus + 1)) << 8)))))) {
+                   (((int16)abs(g_ourRoll)) > (int16)((0x30 / (g_missionStatus + 1)) << 8))))))) {
                 makeSound(0, 2);
                 waitFrameSync(60);
                 finalizeMission(5);

--- a/src/egframe.c
+++ b/src/egframe.c
@@ -6,6 +6,7 @@
 #include "egdata.h"
 #include "egflight.h"
 #include "egframe.h"
+#include "game_options.h"
 #include "worldxfer.h"
 #include "egkeys.h"
 #include "egmath.h"
@@ -279,7 +280,8 @@ skip_target_section:
             g_attackRangeY = 0x3c0;
             if (g_viewZ == 0x80 && g_knots > 0x50) {
                 if ((uint16)(g_viewY_ - g_planeTable.planes[g_closestThreatIndex].mapY) * g_northSouthSign >= 0x10 && (uint16)(g_viewY_ - g_planeTable.planes[g_closestThreatIndex].mapY) * g_northSouthSign <= 0x14) {
-                    if (abs((int16)(g_ourHead - ((1 - g_northSouthSign) << 0xe))) < 0x2000) {
+                    if (!gameOptionsEnabled(GAME_OPTION_NO_DAMAGE) &&
+                        abs((int16)(g_ourHead - ((1 - g_northSouthSign) << 0xe))) < 0x2000) {
                         g_autoCrashDive = 1;
                         makeSound(22, 2);
                     }
@@ -355,7 +357,8 @@ skip_target_section:
 skip_autopilot:
     if (g_inLandingCorridor == 0) {
         if (g_viewZ == 0) {
-            if ((gameData->unk4 != 0 || g_gunHits > 4 || g_fuelRemaining == 0) &&
+            if (!gameOptionsEnabled(GAME_OPTION_NO_DAMAGE) &&
+                (gameData->unk4 != 0 || g_gunHits > 4 || g_fuelRemaining == 0) &&
                 g_ejectState == 0 && g_knots > 50) {
                 makeSound(0, 2);
                 setDrawColor(COLOR_BLACK);
@@ -369,7 +372,8 @@ skip_autopilot:
     }
 
     if (g_savedPosVisible != 0 && (g_viewMode & 0x80) == 0) {
-        if (gameData->unk4 != 0 && g_altitude != 0) {
+        if (!gameOptionsEnabled(GAME_OPTION_NO_DAMAGE) &&
+            gameData->unk4 != 0 && g_altitude != 0) {
             makeSound(0, 2);
             gfx_waitRetrace();
             waitFrameSync(120);
@@ -435,7 +439,8 @@ void countermeasures(int16 eventType) {
     int16 i, slot;
 
     slot = -1;
-    if ((g_eventTimers[eventType])-- <= 0) {
+    if (!gameOptionsEnabled(GAME_OPTION_INFINITE_WEAPONS) &&
+        (g_eventTimers[eventType])-- <= 0) {
         g_eventTimers[eventType] = 0;
         hudMessage("Stores exhausted");
     } else {
@@ -500,7 +505,8 @@ void updateBulletsAndFire(void) {
     if (!firing) goto no_fire;
     if (g_gunAmmo <= 0) goto no_fire;
     if (g_ejectState != 0) goto no_fire;
-    g_gunAmmo = clampRange(g_gunAmmo - 40 / g_frameRateScaling, 0, 1000);
+    if (!gameOptionsEnabled(GAME_OPTION_INFINITE_WEAPONS))
+        g_gunAmmo = clampRange(g_gunAmmo - 40 / g_frameRateScaling, 0, 1000);
     makeSound(4, 2);
     /* Round leaves the barrel along the airframe axis plus the M61's dispersion
      * cone; magnitude in fine units per step (the original 186 coarse/s). */

--- a/src/game_options.c
+++ b/src/game_options.c
@@ -1,0 +1,33 @@
+#include "game_options.h"
+
+/*
+ * Process-local settings deliberately live outside the legacy communication
+ * blocks and save files. This avoids changing reconstructed data layouts while
+ * keeping the selected options active across front-end and flight phases.
+ */
+static bool g_options[GAME_OPTION_COUNT];
+
+/* Return whether one optional gameplay assist is currently enabled. */
+bool gameOptionsEnabled(enum GameOption option) {
+    return option >= 0 && option < GAME_OPTION_COUNT && g_options[option];
+}
+
+/* Set one optional gameplay assist without changing the other settings. */
+void gameOptionsSet(enum GameOption option, bool enabled) {
+    if (option >= 0 && option < GAME_OPTION_COUNT) g_options[option] = enabled;
+}
+
+/* Toggle one optional gameplay assist and return its new state. */
+bool gameOptionsToggle(enum GameOption option) {
+    bool enabled = !gameOptionsEnabled(option);
+    gameOptionsSet(option, enabled);
+    return enabled;
+}
+
+/* Restore original gameplay by disabling every optional assist. */
+void gameOptionsReset(void) {
+    int option;
+    for (option = 0; option < GAME_OPTION_COUNT; option++) {
+        g_options[option] = false;
+    }
+}

--- a/src/game_options.c
+++ b/src/game_options.c
@@ -27,8 +27,7 @@ bool gameOptionsToggle(enum GameOption option) {
 
 /* Restore original gameplay by disabling every optional assist. */
 void gameOptionsReset(void) {
-    int option;
-    for (option = 0; option < GAME_OPTION_COUNT; option++) {
+    for (int option = 0; option < GAME_OPTION_COUNT; option++) {
         g_options[option] = false;
     }
 }

--- a/src/game_options.c
+++ b/src/game_options.c
@@ -19,6 +19,7 @@ void gameOptionsSet(enum GameOption option, bool enabled) {
 
 /* Toggle one optional gameplay assist and return its new state. */
 bool gameOptionsToggle(enum GameOption option) {
+    if (option < 0 || option >= GAME_OPTION_COUNT) return false;
     bool enabled = !gameOptionsEnabled(option);
     gameOptionsSet(option, enabled);
     return enabled;

--- a/src/game_options.h
+++ b/src/game_options.h
@@ -1,0 +1,29 @@
+#ifndef F15_SE2_GAME_OPTIONS
+#define F15_SE2_GAME_OPTIONS
+
+#include <stdbool.h>
+
+/*
+ * Optional gameplay assists. All values default to disabled so an untouched
+ * installation behaves exactly like the original game.
+ */
+enum GameOption {
+    GAME_OPTION_INFINITE_WEAPONS,
+    GAME_OPTION_INFINITE_FUEL,
+    GAME_OPTION_NO_DAMAGE,
+    GAME_OPTION_COUNT
+};
+
+/* Return whether one optional gameplay assist is currently enabled. */
+bool gameOptionsEnabled(enum GameOption option);
+
+/* Set one optional gameplay assist without changing the other settings. */
+void gameOptionsSet(enum GameOption option, bool enabled);
+
+/* Toggle one optional gameplay assist and return its new state. */
+bool gameOptionsToggle(enum GameOption option);
+
+/* Restore original gameplay by disabling every optional assist. */
+void gameOptionsReset(void);
+
+#endif /* F15_SE2_GAME_OPTIONS */

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -32,6 +32,13 @@ void gfx_repaint(void);
  * page's legacy sprites). Pass NULL to restore the plain page re-present. */
 void gfx_setRepaintHook(void (*hook)(void));
 
+/*
+ * Convert SDL window coordinates to the logical 320x200 page using the active
+ * renderer's presentation mapping. Returns false for points in letterboxing.
+ */
+bool gfx_windowToLogical(float windowX, float windowY, int windowWidth,
+                         int windowHeight, int *logicalX, int *logicalY);
+
 /* SDL text input (IME composition) is only needed for pilot-name entry in the
  * menus; the input pump disables it in flight so a desktop IME can't
  * intercept/delay editing keys it treats specially (Backspace above all). */

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -500,6 +500,28 @@ void FAR CDECL gfx_flipPage(void) {
 static void (*g_repaintHook)(void);
 void gfx_setRepaintHook(void (*hook)(void)) { g_repaintHook = hook; }
 
+/*
+ * Keep pointer hit testing on the exact mapping used to present the active
+ * backend. OpenGL corrects the DOS page to 4:3, while software mode preserves
+ * square source pixels across the available window.
+ */
+bool gfx_windowToLogical(float windowX, float windowY, int windowWidth,
+                         int windowHeight, int *logicalX, int *logicalY) {
+    R2DMapping mapping;
+    int x;
+    int y;
+
+    if (windowWidth <= 0 || windowHeight <= 0) return false;
+    r2d_computeMapping(LOGICAL_WIDTH, LOGICAL_HEIGHT, windowWidth, windowHeight,
+                       s_useGL ? 0 : 1, &mapping);
+    x = (int)((windowX - mapping.offX) / mapping.scaleX);
+    y = (int)((windowY - mapping.offY) / mapping.scaleY);
+    if (x < 0 || x >= LOGICAL_WIDTH || y < 0 || y >= LOGICAL_HEIGHT) return false;
+    if (logicalX) *logicalX = x;
+    if (logicalY) *logicalY = y;
+    return true;
+}
+
 /* Re-present the current visible frame (page 0, or the hi-res title surface).
  * gfx_presentPage already redirects to the hi-res path when the title is up. */
 void gfx_repaint(void) {

--- a/src/input.c
+++ b/src/input.c
@@ -40,6 +40,9 @@ static void (*g_quitHandler)(void) = NULL;
  * stick keeps working as before; a key press flips it to the keyboard and stick
  * activity flips it back (see input_preferGamepad / noteGamepadActivity). */
 static bool g_lastWasGamepad = true;
+static bool g_menuClickPending = false;
+static int g_menuClickX = 0;
+static int g_menuClickY = 0;
 
 void input_setMode(InputMode mode) {
     /* Leaving text input on during flight lets a desktop IME intercept editing
@@ -71,8 +74,28 @@ static void ringPush(uint16 word) {
 
 void input_ringReset(void) {
     ringHead = ringTail = 0;
+    g_menuClickPending = false;
     g_joyRawX = 0x80;
     g_joyRawY = 0x80;
+}
+
+/* Consume one menu click after its synthetic key wakes a legacy menu loop. */
+bool input_takeMenuClick(int *x, int *y) {
+    if (!g_menuClickPending) return false;
+    if (x) *x = g_menuClickX;
+    if (y) *y = g_menuClickY;
+    g_menuClickPending = false;
+    return true;
+}
+
+/* Convert a click through the active renderer's exact presentation mapping. */
+static bool menuPointFromWindow(const SDL_MouseButtonEvent *button, int *x, int *y) {
+    SDL_Window *window = SDL_GetWindowFromID(button->windowID);
+    int width;
+    int height;
+
+    if (!window || !SDL_GetWindowSize(window, &width, &height)) return false;
+    return gfx_windowToLogical(button->x, button->y, width, height, x, y);
 }
 
 bool input_keyWaiting(void) {
@@ -759,6 +782,15 @@ void input_pumpEvents(void) {
                     unsigned char c = (unsigned char)*p;
                     if (c >= 0x20 && c < 0x80) ringPush(c);
                 }
+            }
+            break;
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
+            if (g_mode == INPUT_MODE_MENU &&
+                ev.button.button == SDL_BUTTON_LEFT &&
+                menuPointFromWindow(&ev.button, &g_menuClickX, &g_menuClickY)) {
+                g_lastWasGamepad = false;
+                g_menuClickPending = true;
+                ringPush(INPUT_MENU_MOUSE_CLICK);
             }
             break;
         default:

--- a/src/input.h
+++ b/src/input.h
@@ -35,6 +35,15 @@ bool input_preferGamepad(void);
  * controls for the current mode. Every key-wait loop funnels through this. */
 void input_pumpEvents(void);
 
+/* Synthetic BIOS-style word queued for a left click in menu mode. */
+#define INPUT_MENU_MOUSE_CLICK 0x7f00
+
+/*
+ * Consume the most recent menu click in logical 320x200 coordinates.
+ * Returns false when no unconsumed click is available.
+ */
+bool input_takeMenuClick(int *x, int *y);
+
 /* --- BIOS-style key ring (AH = scan code, AL = ASCII), shared by all phases - */
 void input_ringReset(void);  /* drop any queued keys, recentre stick */
 bool input_keyWaiting(void); /* true when a key word is queued */

--- a/src/stmissn.h
+++ b/src/stmissn.h
@@ -5,6 +5,7 @@
 
 void clearKeybuf(void);
 void waitMdaCgaStatus(int16 iter);
+void drawLine(const int16 *pageNum, int x1, int y1, int x2, int y2, int color);
 void showPic640(const char *filename);
 void missionSelect(void);
 int16 askRepeatMission(void);

--- a/src/stoptions.c
+++ b/src/stoptions.c
@@ -1,0 +1,217 @@
+/*
+ * stoptions.c - optional gameplay settings on the pilot-selection screen.
+ *
+ * This module owns the entire new screen so the reconstructed menu routines
+ * need only draw one gear and call one function. The underlying pilot screen is
+ * captured and restored exactly, including the selected user's name.
+ */
+#include "stoptions.h"
+
+#include "const.h"
+#include "game_options.h"
+#include "gfx.h"
+#include "input.h"
+#include "shared/common.h"
+#include "stcode.h"
+#include "stdata.h"
+#include "stmissn.h"
+#include "stpilot.h"
+
+#include <stdio.h>
+#include <string.h>
+
+enum {
+    GEAR_LEFT = 302,
+    GEAR_TOP = 183,
+    GEAR_RIGHT = 318,
+    GEAR_BOTTOM = 198,
+    PANEL_LEFT = 42,
+    PANEL_TOP = 42,
+    PANEL_RIGHT = 277,
+    PANEL_BOTTOM = 157,
+    OPTION_FIRST_Y = 70,
+    OPTION_ROW_HEIGHT = 15
+};
+
+static const char *const g_optionLabels[GAME_OPTION_COUNT] = {
+    "INFINITE AMMO / STORES",
+    "INFINITE FUEL",
+    "NO DAMAGE / CRASH"
+};
+
+static const char *g_activePilotName;
+static int g_activeSelection;
+
+/* Draw an unboxed native-resolution cog that remains legible at 320x200. */
+void stOptionsDrawGear(int16 *page) {
+    clearRect(page, GEAR_LEFT, GEAR_TOP, GEAR_RIGHT, GEAR_BOTTOM);
+    drawLine(page, 307, 186, 313, 186, COLOR_WHITE);
+    drawLine(page, 313, 186, 316, 189, COLOR_WHITE);
+    drawLine(page, 316, 189, 316, 193, COLOR_WHITE);
+    drawLine(page, 316, 193, 313, 196, COLOR_WHITE);
+    drawLine(page, 313, 196, 307, 196, COLOR_WHITE);
+    drawLine(page, 307, 196, 304, 193, COLOR_WHITE);
+    drawLine(page, 304, 193, 304, 189, COLOR_WHITE);
+    drawLine(page, 304, 189, 307, 186, COLOR_WHITE);
+
+    drawLine(page, 309, 188, 311, 188, COLOR_LIGHTGRAY);
+    drawLine(page, 311, 188, 314, 190, COLOR_LIGHTGRAY);
+    drawLine(page, 314, 190, 314, 192, COLOR_LIGHTGRAY);
+    drawLine(page, 314, 192, 312, 194, COLOR_LIGHTGRAY);
+    drawLine(page, 312, 194, 308, 194, COLOR_LIGHTGRAY);
+    drawLine(page, 308, 194, 306, 192, COLOR_LIGHTGRAY);
+    drawLine(page, 306, 192, 306, 190, COLOR_LIGHTGRAY);
+    drawLine(page, 306, 190, 309, 188, COLOR_LIGHTGRAY);
+
+    drawLine(page, 309, 184, 311, 186, COLOR_WHITE);
+    drawLine(page, 314, 187, 317, 186, COLOR_WHITE);
+    drawLine(page, 316, 190, 318, 191, COLOR_WHITE);
+    drawLine(page, 314, 195, 317, 196, COLOR_WHITE);
+    drawLine(page, 309, 196, 311, 198, COLOR_WHITE);
+    drawLine(page, 303, 196, 306, 195, COLOR_WHITE);
+    drawLine(page, 302, 191, 304, 190, COLOR_WHITE);
+    drawLine(page, 303, 186, 306, 187, COLOR_WHITE);
+}
+
+/* Return whether one logical 320x200 point is inside the settings gear. */
+int stOptionsGearHit(int x, int y) {
+    return x >= GEAR_LEFT && x <= GEAR_RIGHT &&
+           y >= GEAR_TOP && y <= GEAR_BOTTOM;
+}
+
+/* Draw the modal with the compact font so later options fit without scrolling. */
+static void drawOptionsPanel(const char *pilotName, int selected) {
+    char title[48];
+    int option;
+    int oldColor = screenBuf[2];
+    int oldFont = screenBuf[6];
+
+    clearRect(screenBuf, PANEL_LEFT, PANEL_TOP, PANEL_RIGHT, PANEL_BOTTOM);
+    drawLine(screenBuf, PANEL_LEFT, PANEL_TOP, PANEL_RIGHT, PANEL_TOP, COLOR_LIGHTGRAY);
+    drawLine(screenBuf, PANEL_RIGHT, PANEL_TOP, PANEL_RIGHT, PANEL_BOTTOM, COLOR_LIGHTGRAY);
+    drawLine(screenBuf, PANEL_RIGHT, PANEL_BOTTOM, PANEL_LEFT, PANEL_BOTTOM, COLOR_LIGHTGRAY);
+    drawLine(screenBuf, PANEL_LEFT, PANEL_BOTTOM, PANEL_LEFT, PANEL_TOP, COLOR_LIGHTGRAY);
+
+    screenBuf[6] = FONT_SMALL;
+    screenBuf[2] = COLOR_WHITE;
+    snprintf(title, sizeof(title), "OPTIONS - %s", pilotName && *pilotName ? pilotName : "PILOT");
+    drawStringCentered(screenBuf, title, PANEL_LEFT, 51, PANEL_RIGHT);
+
+    for (option = 0; option < GAME_OPTION_COUNT; option++) {
+        int y = OPTION_FIRST_Y + option * OPTION_ROW_HEIGHT;
+        screenBuf[2] = option == selected ? COLOR_WHITE : COLOR_LIGHTGRAY;
+        drawStringAt(screenBuf, option == selected ? ">" : " ", 55, y);
+        drawStringAt(screenBuf, g_optionLabels[option], 67, y);
+        screenBuf[2] = gameOptionsEnabled((enum GameOption)option)
+                           ? COLOR_LIGHTGREEN
+                           : COLOR_LIGHTRED;
+        drawStringAt(screenBuf,
+                     gameOptionsEnabled((enum GameOption)option) ? "ON" : "OFF",
+                     238, y);
+    }
+
+    screenBuf[2] = COLOR_LIGHTGRAY;
+    drawStringCentered(screenBuf, "ARROWS SELECT  SPACE/CLICK TOGGLE  ESC CLOSE",
+                       PANEL_LEFT, 143, PANEL_RIGHT);
+    screenBuf[2] = oldColor;
+    screenBuf[6] = oldFont;
+    gfx_commitPage();
+}
+
+/*
+ * Reproduce the modal after expose, resize, or fullscreen events. The GL menu
+ * path submits some primitives immediately, so presenting the retained pilot
+ * page alone would otherwise make the modal appear to vanish.
+ */
+static void repaintOptionsPanel(void) {
+    drawOptionsPanel(g_activePilotName, g_activeSelection);
+}
+
+/* Return the option row under a logical point, or -1 outside all rows. */
+static int optionAtPoint(int x, int y) {
+    int option;
+    if (x < PANEL_LEFT || x > PANEL_RIGHT) return -1;
+    for (option = 0; option < GAME_OPTION_COUNT; option++) {
+        int rowY = OPTION_FIRST_Y + option * OPTION_ROW_HEIGHT;
+        if (y >= rowY - 3 && y <= rowY + 8) return option;
+    }
+    return -1;
+}
+
+/* Show the modal gameplay-options screen over the selected pilot background. */
+void stOptionsShow(const char *pilotName) {
+    struct R2DImage *background;
+    int selected = 0;
+    int done = 0;
+
+    background = gfx_allocImage(LOGICAL_WIDTH, LOGICAL_HEIGHT);
+    if (background) {
+        gfx_captureToImage(background, screenBuf[0], 0, 0, 0, 0,
+                           LOGICAL_WIDTH, LOGICAL_HEIGHT);
+    }
+
+    g_activePilotName = pilotName;
+    g_activeSelection = selected;
+    gfx_setRepaintHook(repaintOptionsPanel);
+    drawOptionsPanel(pilotName, selected);
+    while (!done) {
+        int key = pollMenuInput();
+        switch (key) {
+        case KEYCODE_UPARROW:
+            selected = (selected + GAME_OPTION_COUNT - 1) % GAME_OPTION_COUNT;
+            g_activeSelection = selected;
+            drawOptionsPanel(pilotName, selected);
+            break;
+        case KEYCODE_DNARROW:
+            selected = (selected + 1) % GAME_OPTION_COUNT;
+            g_activeSelection = selected;
+            drawOptionsPanel(pilotName, selected);
+            break;
+        case KEYCODE_LEFTARROW:
+            gameOptionsSet((enum GameOption)selected, false);
+            drawOptionsPanel(pilotName, selected);
+            break;
+        case KEYCODE_RIGHTARROW:
+            gameOptionsSet((enum GameOption)selected, true);
+            drawOptionsPanel(pilotName, selected);
+            break;
+        case KEYCODE_ENTER:
+        case ' ':
+            gameOptionsToggle((enum GameOption)selected);
+            drawOptionsPanel(pilotName, selected);
+            break;
+        case INPUT_MENU_MOUSE_CLICK: {
+            int x;
+            int y;
+            int option;
+            if (!input_takeMenuClick(&x, &y)) break;
+            if (stOptionsGearHit(x, y)) {
+                done = 1;
+                break;
+            }
+            option = optionAtPoint(x, y);
+            if (option >= 0) {
+                selected = option;
+                g_activeSelection = selected;
+                gameOptionsToggle((enum GameOption)selected);
+                drawOptionsPanel(pilotName, selected);
+            }
+            break;
+        }
+        case KEYCODE_ESC:
+            done = 1;
+            break;
+        }
+    }
+
+    gfx_setRepaintHook(NULL);
+    g_activePilotName = NULL;
+    if (background) {
+        gfx_restoreFromImage(background, screenBuf[0], 0, 0, 0, 0,
+                             LOGICAL_WIDTH, LOGICAL_HEIGHT);
+        gfx_freeImage(background);
+    } else {
+        displayPilots();
+    }
+    gfx_commitPage();
+}

--- a/src/stoptions.c
+++ b/src/stoptions.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
+/* All menu coordinates and hit padding are logical 320x200 pixels. */
 enum {
     GEAR_LEFT = 302,
     GEAR_TOP = 183,
@@ -30,7 +31,14 @@ enum {
     PANEL_RIGHT = 277,
     PANEL_BOTTOM = 157,
     OPTION_FIRST_Y = 70,
-    OPTION_ROW_HEIGHT = 15
+    OPTION_ROW_HEIGHT = 15,
+    OPTION_HIT_ABOVE = 3,
+    OPTION_HIT_BELOW = 8,
+    TITLE_Y = 51,
+    SELECTION_X = 55,
+    LABEL_X = 67,
+    VALUE_X = 238,
+    HELP_Y = 143
 };
 
 static const char *const g_optionLabels[GAME_OPTION_COUNT] = {
@@ -81,8 +89,7 @@ int stOptionsGearHit(int x, int y) {
 
 /* Draw the modal with the compact font so later options fit without scrolling. */
 static void drawOptionsPanel(const char *pilotName, int selected) {
-    char title[48];
-    int option;
+    char title[48] = {0};
     int oldColor = screenBuf[2];
     int oldFont = screenBuf[6];
 
@@ -95,24 +102,21 @@ static void drawOptionsPanel(const char *pilotName, int selected) {
     screenBuf[6] = FONT_SMALL;
     screenBuf[2] = COLOR_WHITE;
     snprintf(title, sizeof(title), "OPTIONS - %s", pilotName && *pilotName ? pilotName : "PILOT");
-    drawStringCentered(screenBuf, title, PANEL_LEFT, 51, PANEL_RIGHT);
+    drawStringCentered(screenBuf, title, PANEL_LEFT, TITLE_Y, PANEL_RIGHT);
 
-    for (option = 0; option < GAME_OPTION_COUNT; option++) {
+    for (int option = 0; option < GAME_OPTION_COUNT; option++) {
         int y = OPTION_FIRST_Y + option * OPTION_ROW_HEIGHT;
+        const bool enabled = gameOptionsEnabled((enum GameOption)option);
         screenBuf[2] = option == selected ? COLOR_WHITE : COLOR_LIGHTGRAY;
-        drawStringAt(screenBuf, option == selected ? ">" : " ", 55, y);
-        drawStringAt(screenBuf, g_optionLabels[option], 67, y);
-        screenBuf[2] = gameOptionsEnabled((enum GameOption)option)
-                           ? COLOR_LIGHTGREEN
-                           : COLOR_LIGHTRED;
-        drawStringAt(screenBuf,
-                     gameOptionsEnabled((enum GameOption)option) ? "ON" : "OFF",
-                     238, y);
+        drawStringAt(screenBuf, option == selected ? ">" : " ", SELECTION_X, y);
+        drawStringAt(screenBuf, g_optionLabels[option], LABEL_X, y);
+        screenBuf[2] = enabled ? COLOR_LIGHTGREEN : COLOR_LIGHTRED;
+        drawStringAt(screenBuf, enabled ? "ON" : "OFF", VALUE_X, y);
     }
 
     screenBuf[2] = COLOR_LIGHTGRAY;
     drawStringCentered(screenBuf, "ARROWS SELECT  SPACE/CLICK TOGGLE  ESC CLOSE",
-                       PANEL_LEFT, 143, PANEL_RIGHT);
+                       PANEL_LEFT, HELP_Y, PANEL_RIGHT);
     screenBuf[2] = oldColor;
     screenBuf[6] = oldFont;
     gfx_commitPage();
@@ -129,22 +133,22 @@ static void repaintOptionsPanel(void) {
 
 /* Return the option row under a logical point, or -1 outside all rows. */
 static int optionAtPoint(int x, int y) {
-    int option;
     if (x < PANEL_LEFT || x > PANEL_RIGHT) return -1;
-    for (option = 0; option < GAME_OPTION_COUNT; option++) {
+    for (int option = 0; option < GAME_OPTION_COUNT; option++) {
         int rowY = OPTION_FIRST_Y + option * OPTION_ROW_HEIGHT;
-        if (y >= rowY - 3 && y <= rowY + 8) return option;
+        const bool insideRow = y >= rowY - OPTION_HIT_ABOVE &&
+                               y <= rowY + OPTION_HIT_BELOW;
+        if (insideRow) return option;
     }
     return -1;
 }
 
 /* Show the modal gameplay-options screen over the selected pilot background. */
 void stOptionsShow(const char *pilotName) {
-    struct R2DImage *background;
+    struct R2DImage *background = gfx_allocImage(LOGICAL_WIDTH, LOGICAL_HEIGHT);
     int selected = 0;
     int done = 0;
 
-    background = gfx_allocImage(LOGICAL_WIDTH, LOGICAL_HEIGHT);
     if (background) {
         gfx_captureToImage(background, screenBuf[0], 0, 0, 0, 0,
                            LOGICAL_WIDTH, LOGICAL_HEIGHT);
@@ -159,48 +163,43 @@ void stOptionsShow(const char *pilotName) {
         switch (key) {
         case KEYCODE_UPARROW:
             selected = (selected + GAME_OPTION_COUNT - 1) % GAME_OPTION_COUNT;
-            g_activeSelection = selected;
-            drawOptionsPanel(pilotName, selected);
             break;
         case KEYCODE_DNARROW:
             selected = (selected + 1) % GAME_OPTION_COUNT;
-            g_activeSelection = selected;
-            drawOptionsPanel(pilotName, selected);
             break;
         case KEYCODE_LEFTARROW:
             gameOptionsSet((enum GameOption)selected, false);
-            drawOptionsPanel(pilotName, selected);
             break;
         case KEYCODE_RIGHTARROW:
             gameOptionsSet((enum GameOption)selected, true);
-            drawOptionsPanel(pilotName, selected);
             break;
         case KEYCODE_ENTER:
         case ' ':
             gameOptionsToggle((enum GameOption)selected);
-            drawOptionsPanel(pilotName, selected);
             break;
         case INPUT_MENU_MOUSE_CLICK: {
-            int x;
-            int y;
-            int option;
-            if (!input_takeMenuClick(&x, &y)) break;
+            int x = 0;
+            int y = 0;
+            if (!input_takeMenuClick(&x, &y)) continue;
             if (stOptionsGearHit(x, y)) {
                 done = 1;
                 break;
             }
-            option = optionAtPoint(x, y);
-            if (option >= 0) {
-                selected = option;
-                g_activeSelection = selected;
-                gameOptionsToggle((enum GameOption)selected);
-                drawOptionsPanel(pilotName, selected);
-            }
+            const int option = optionAtPoint(x, y);
+            if (option < 0) continue;
+            selected = option;
+            gameOptionsToggle((enum GameOption)selected);
             break;
         }
         case KEYCODE_ESC:
             done = 1;
             break;
+        default:
+            continue;
+        }
+        if (!done) {
+            g_activeSelection = selected;
+            drawOptionsPanel(pilotName, selected);
         }
     }
 

--- a/src/stoptions.h
+++ b/src/stoptions.h
@@ -1,0 +1,15 @@
+#ifndef F15_SE2_STOPTIONS
+#define F15_SE2_STOPTIONS
+
+#include "inttype.h"
+
+/* Draw the settings gear in the bottom-right corner of the pilot screen. */
+void stOptionsDrawGear(int16 *page);
+
+/* Return whether one logical 320x200 point is inside the settings gear. */
+int stOptionsGearHit(int x, int y);
+
+/* Show the modal gameplay-options screen over the selected pilot background. */
+void stOptionsShow(const char *pilotName);
+
+#endif /* F15_SE2_STOPTIONS */

--- a/src/stpilot.c
+++ b/src/stpilot.c
@@ -3,11 +3,13 @@
 #include "stdata.h"
 #include "stgen.h"
 #include "stmissn.h"
+#include "stoptions.h"
 #include "stpilot.h"
 #include "stsprit.h"
 #include "sttypes.h"
 #include "const.h"
 #include "gfx.h"
+#include "input.h"
 #include "slot.h"
 #include "comm.h"
 #include "offsets.h"
@@ -92,6 +94,7 @@ void displayPilots(void) {
     } while (++pilotIdx < HALLFAME_SLOTS);
     screenDesc.color = COLOR_WHITE;
     drawStringCentered(pageNumPtr, "Use SELECTOR to choose pilot,  ESC to enter new pilot.", 0, 192, 320);
+    stOptionsDrawGear(screenBuf);
     gfx_commitPage();
 }
 
@@ -185,6 +188,18 @@ void processPilotInput() {
             xPos = (selectedPilotIdx < PILOTS_PER_COLUMN) ? PILOT_COL_LEFT : PILOT_COL_RIGHT;
             yPos = ((selectedPilotIdx & (PILOTS_PER_COLUMN - 1)) * PILOT_ROW_HEIGHT) + PILOT_TOP_MARGIN;
             gfx_switchColor(screenBuf, xPos, yPos, xPos + PILOT_ENTRY_WIDTH, yPos + PILOT_NAME_HEIGHT, COLOR_LIGHTGRAY, COLOR_WHITE);
+            break;
+        case INPUT_MENU_MOUSE_CLICK: {
+            int mouseX;
+            int mouseY;
+            if (input_takeMenuClick(&mouseX, &mouseY) &&
+                stOptionsGearHit(mouseX, mouseY)) {
+                pilotSelectFlag = 0;
+                stOptionsShow(hallfameBuf[selectedPilotIdx].name);
+                pilotSelectFlag = 1;
+            }
+            break;
+        }
         }
 }
 

--- a/src/stpilot.h
+++ b/src/stpilot.h
@@ -4,6 +4,7 @@
 #include "inttype.h"
 
 void pilotSelect(int16 ps_needSplash);
+void displayPilots(void);
 void blinkPilot();
 
 #endif /* F15_SE2_STPILOT */

--- a/tests/game_options_behavior_tests.cpp
+++ b/tests/game_options_behavior_tests.cpp
@@ -1,0 +1,50 @@
+#include "game_options.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+/* Stop immediately with a useful message when an option-state contract fails. */
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main() {
+    gameOptionsReset();
+    for (int option = 0; option < GAME_OPTION_COUNT; option++) {
+        require(!gameOptionsEnabled((enum GameOption)option),
+                "all gameplay options preserve current behavior by default");
+    }
+
+    require(gameOptionsToggle(GAME_OPTION_INFINITE_WEAPONS),
+            "toggle enables infinite weapons");
+    require(gameOptionsEnabled(GAME_OPTION_INFINITE_WEAPONS),
+            "infinite weapons remains enabled");
+    require(!gameOptionsEnabled(GAME_OPTION_INFINITE_FUEL),
+            "changing weapons does not change fuel");
+    require(!gameOptionsToggle(GAME_OPTION_INFINITE_WEAPONS),
+            "second toggle disables infinite weapons");
+
+    gameOptionsSet(GAME_OPTION_INFINITE_FUEL, true);
+    gameOptionsSet(GAME_OPTION_NO_DAMAGE, true);
+    require(gameOptionsEnabled(GAME_OPTION_INFINITE_FUEL) &&
+                gameOptionsEnabled(GAME_OPTION_NO_DAMAGE),
+            "fuel and damage assists can be enabled independently");
+
+    gameOptionsReset();
+    require(!gameOptionsEnabled(GAME_OPTION_INFINITE_FUEL) &&
+                !gameOptionsEnabled(GAME_OPTION_NO_DAMAGE),
+            "reset restores original gameplay settings");
+    require(!gameOptionsEnabled((enum GameOption)-1) &&
+                !gameOptionsEnabled(GAME_OPTION_COUNT),
+            "out-of-range option queries are safely disabled");
+
+    std::cout << "game_options_behavior_tests passed\n";
+    return 0;
+}

--- a/tests/game_options_behavior_tests.cpp
+++ b/tests/game_options_behavior_tests.cpp
@@ -44,6 +44,9 @@ int main() {
     require(!gameOptionsEnabled((enum GameOption)-1) &&
                 !gameOptionsEnabled(GAME_OPTION_COUNT),
             "out-of-range option queries are safely disabled");
+    require(!gameOptionsToggle((enum GameOption)-1) &&
+                !gameOptionsToggle(GAME_OPTION_COUNT),
+            "invalid toggles cannot report an enabled option");
 
     std::cout << "game_options_behavior_tests passed\n";
     return 0;

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -7,6 +7,8 @@
 #include "egdata.h"
 #include "egkeys.h"
 #include "egmath.h"
+#include "egframe.h"
+#include "game_options.h"
 #include "inttype.h"
 #include "struct.h"
 #include "comm.h"
@@ -49,6 +51,7 @@ void require(bool condition, const char *message) {
 // per mission; the merged process does not, so each case starts from a clean
 // slate.)
 void resetGameplayState() {
+    gameOptionsReset();
     std::memset(&g_planeTable, 0, sizeof(g_planeTable));
     std::memset(g_projectiles, 0, sizeof(struct Projectile) * 12);
     std::memset(g_targetSlots, 0, sizeof(struct TargetSlot) * 2);
@@ -103,6 +106,33 @@ void resetGameplayState() {
 
 int main() {
     test_headless_init();
+
+    // --- countermeasure stores (egframe) ------------------------------------
+    resetGameplayState();
+    g_eventTimers[1] = 3;
+    countermeasures(1);
+    require(g_eventTimers[1] == 2,
+            "countermeasures consumes one flare with normal options");
+
+    resetGameplayState();
+    g_eventTimers[2] = 3;
+    countermeasures(2);
+    require(g_eventTimers[2] == 2,
+            "countermeasures consumes one chaff with normal options");
+
+    resetGameplayState();
+    gameOptionsSet(GAME_OPTION_INFINITE_WEAPONS, true);
+    g_eventTimers[1] = 3;
+    countermeasures(1);
+    require(g_eventTimers[1] == 3,
+            "infinite weapons preserves flare stores");
+
+    resetGameplayState();
+    gameOptionsSet(GAME_OPTION_INFINITE_WEAPONS, true);
+    g_eventTimers[2] = 3;
+    countermeasures(2);
+    require(g_eventTimers[2] == 3,
+            "infinite weapons preserves chaff stores");
 
     // --- Threat range/bearing/score (egthreat) ------------------------------
     // Score is altitude-weighted; range is rangeApprox in km units (>>6);
@@ -336,6 +366,13 @@ int main() {
     finalizeMission(2);
     require(comm.landingType == 1 && comm.bailoutSurvived == 2,
             "finalizeMission records a crash for a nonzero non-eject result");
+
+    resetGameplayState();
+    comm = {};
+    gameOptionsSet(GAME_OPTION_NO_DAMAGE, true);
+    finalizeMission(1);
+    require(g_missionEndedFlag[0] == 1 && comm.bailoutSurvived == 1,
+            "no-damage mode does not intercept explicit mission termination");
 
     resetGameplayState();
     comm = {};

--- a/tests/input_behavior_tests.cpp
+++ b/tests/input_behavior_tests.cpp
@@ -2,6 +2,7 @@
 #include "egdata.h"
 #include "eginput.h"
 #include "headless.h"
+#include "input.h"
 
 #include <SDL3/SDL.h>
 
@@ -91,6 +92,7 @@ enum InputOriginalConstant : int {
     kRingOverflowAttempts = 40,
     kBlockingPushDelayMs = 5,
     kTestFailureExitCode = 1,
+    kMenuMouseClick = INPUT_MENU_MOUSE_CLICK,
 };
 
 void require(bool condition, const char *message) {
@@ -123,6 +125,17 @@ void pushKey(SDL_Scancode scancode, SDL_Keymod modifiers = SDL_KMOD_NONE) {
 void pushMouseMotion() {
     SDL_Event event = {};
     event.type = SDL_EVENT_MOUSE_MOTION;
+    SDL_PushEvent(&event);
+}
+
+void pushMouseClick(SDL_Window *window, float x, float y) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    event.button.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    event.button.windowID = SDL_GetWindowID(window);
+    event.button.button = SDL_BUTTON_LEFT;
+    event.button.x = x;
+    event.button.y = y;
     SDL_PushEvent(&event);
 }
 
@@ -244,6 +257,24 @@ int main() {
     pushMouseMotion();
     require(kbhit() == 0,
             "egReadKey ignores non-key SDL events");
+
+    SDL_Window *menuWindow = SDL_CreateWindow(
+        "input behavior menu", 640, 400, SDL_WINDOW_HIDDEN);
+    require(menuWindow != nullptr, "menu mouse test creates a hidden window");
+    input_setMode(INPUT_MODE_MENU);
+    input_ringReset();
+    pushMouseClick(menuWindow, 620.0f, 380.0f);
+    require(input_keyWaiting() && input_readKey() == kMenuMouseClick,
+            "menu click wakes a legacy key-driven menu loop");
+    int mouseX = 0;
+    int mouseY = 0;
+    require(input_takeMenuClick(&mouseX, &mouseY) &&
+                mouseX == 310 && mouseY == 190,
+            "menu click is exposed in logical 320x200 coordinates");
+    require(!input_takeMenuClick(&mouseX, &mouseY),
+            "menu click is consumed exactly once");
+    SDL_DestroyWindow(menuWindow);
+    resetInputState();
 
     resetInputState();
     std::thread delayedKey([] {

--- a/tests/stoptions_behavior_tests.cpp
+++ b/tests/stoptions_behavior_tests.cpp
@@ -1,0 +1,123 @@
+#include "comm.h"
+#include "game_options.h"
+#include "gfx.h"
+#include "headless.h"
+#include "input.h"
+#include "stdata.h"
+#include "stoptions.h"
+
+#include <SDL3/SDL.h>
+
+#include <cstdlib>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+void pushKey(SDL_Scancode scancode) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = scancode;
+    event.key.key = SDL_GetKeyFromScancode(scancode, SDL_KMOD_NONE, true);
+    SDL_PushEvent(&event);
+}
+
+void pushSpaceText(void) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_TEXT_INPUT;
+    event.text.type = SDL_EVENT_TEXT_INPUT;
+    event.text.text = " ";
+    SDL_PushEvent(&event);
+}
+
+void pushExpose(void) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_WINDOW_EXPOSED;
+    event.window.type = SDL_EVENT_WINDOW_EXPOSED;
+    SDL_PushEvent(&event);
+}
+
+void pushMouseClick(SDL_Window *window, float x, float y) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    event.button.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    event.button.windowID = SDL_GetWindowID(window);
+    event.button.button = SDL_BUTTON_LEFT;
+    event.button.x = x;
+    event.button.y = y;
+    SDL_PushEvent(&event);
+}
+
+} // namespace
+
+int main() {
+    struct GameComm comm = {};
+
+    test_headless_init();
+    commData = &comm;
+    gfx_videoInit();
+    gfx_setMode13();
+    input_setMode(INPUT_MODE_MENU);
+
+    require(stOptionsGearHit(302, 183) && stOptionsGearHit(318, 198),
+            "gear hit target includes both visible corners");
+    require(!stOptionsGearHit(301, 183) && !stOptionsGearHit(318, 199),
+            "gear hit target excludes points outside the icon");
+    stOptionsDrawGear(screenBuf);
+
+    gameOptionsReset();
+    std::thread keyboardInput([] {
+        const SDL_Scancode keys[] = {
+            SDL_SCANCODE_SPACE, SDL_SCANCODE_DOWN, SDL_SCANCODE_RIGHT,
+            SDL_SCANCODE_DOWN, SDL_SCANCODE_SPACE, SDL_SCANCODE_UP,
+            SDL_SCANCODE_LEFT, SDL_SCANCODE_ESCAPE};
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        pushExpose();
+        for (SDL_Scancode key : keys) {
+            if (key == SDL_SCANCODE_SPACE)
+                pushSpaceText();
+            else
+                pushKey(key);
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    });
+    stOptionsShow("TEST PILOT");
+    keyboardInput.join();
+    require(gameOptionsEnabled(GAME_OPTION_INFINITE_WEAPONS),
+            "Space toggles the selected weapons option");
+    require(!gameOptionsEnabled(GAME_OPTION_INFINITE_FUEL),
+            "left arrow disables the selected fuel option");
+    require(gameOptionsEnabled(GAME_OPTION_NO_DAMAGE),
+            "Space toggles the selected no-damage option");
+
+    SDL_Window *mouseWindow = SDL_CreateWindow(
+        "options mouse behavior", 640, 400, SDL_WINDOW_HIDDEN);
+    require(mouseWindow != nullptr, "mouse behavior test creates a hidden window");
+    gameOptionsReset();
+    input_ringReset();
+    std::thread mouseInput([mouseWindow] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        pushMouseClick(mouseWindow, 300.0f, 140.0f);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        pushKey(SDL_SCANCODE_ESCAPE);
+    });
+    stOptionsShow("MOUSE PILOT");
+    mouseInput.join();
+    require(gameOptionsEnabled(GAME_OPTION_INFINITE_WEAPONS),
+            "clicking an option row toggles it");
+    SDL_DestroyWindow(mouseWindow);
+
+    gfx_videoShutdown();
+    std::cout << "stoptions_behavior_tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add a compact gameplay-options overlay to the pilot selection screen, opened from a bottom-right settings cog
- support keyboard and mouse control, including Space/Enter toggles and renderer-correct mouse hit testing
- add optional infinite ammo/stores, infinite fuel, and no-damage/crash assists
- include missiles, gun ammunition, flares, and chaff under infinite stores
- keep every option disabled by default so existing gameplay remains unchanged

## Implementation

The options screen and process-local option state live in new modules. Existing reconstructed routines only receive small guards at the actual fuel, ammunition, damage, and collision paths. Crash immunity is applied at concrete collision call sites rather than intercepting generic mission outcomes, so explicit mission termination still works.

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure`: 32/32 passed
- `cmake --build build-coverage --target coverage`: passed
- new production modules: 97% line coverage combined (`game_options.c` 100%, `stoptions.c` 96%)
- manually verified the OpenGL settings-cog click target and compact options layout
