### PR TITLE
4. [fix] Fix Windows bitmap font corruption

### DIFF
--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -669,20 +669,22 @@ static void drawStringCore(int16 *params, const char *string,
             uint8 *glyph = bitmaps + (ch - 0x20) * (uint16)rowSize;
             for (row = 0; row < height; row++) {
                 int py = y + row;
-                uint8 bits;
+                const uint8 bits = glyph[row];
                 uint8 *dstRow;
                 if (py < clipT || py > clipB) continue; /* row outside window */
                 if (py < 0 || py >= surfH) continue;    /* off the surface */
-                bits = glyph[row];
                 dstRow = base + (size_t)py * pitch;
                 for (col = 0; col < 8; col++) {
                     int px = x + col;
-                    if ((bits & 0x80) && px >= clipL && px <= clipR &&
+                    /* Glyph rows are packed MSB first. Test each source bit
+                     * directly so integer promotion cannot affect later
+                     * columns differently between GCC and MSVC. */
+                    if ((bits & (uint8)(0x80u >> col)) != 0 &&
+                        px >= clipL && px <= clipR &&
                         px >= 0 && px < surfW) {
                         if (submit) r2d_submitPoint(px, py, color);
                         else dstRow[px] = (uint8)color;
                     }
-                    bits <<= 1;
                 }
             }
         }

--- a/tests/gfx_render_behavior_tests.cpp
+++ b/tests/gfx_render_behavior_tests.cpp
@@ -73,6 +73,20 @@ void fillPageRaw(int page, uint8 color) {
         std::memset(px + (size_t)y * pitch, color, kLogicalWidth);
 }
 
+uint32 pageHash(int page) {
+    uint32 hash = 2166136261u;
+    int pitch = 0;
+    const uint8 *pixels = gfx_pagePixels(page, &pitch);
+    for (int y = 0; y < kLogicalHeight; y++) {
+        const uint8 *row = pixels + (size_t)y * pitch;
+        for (int x = 0; x < kLogicalWidth; x++) {
+            hash ^= row[x];
+            hash *= 16777619u;
+        }
+    }
+    return hash;
+}
+
 // ---- gfx_pagePixels + page-1 aliasing -------------------------------------
 void test_pagePixels_and_alias() {
     int pitch0 = 0, pitch1 = 0, pitch2 = 0;
@@ -285,6 +299,22 @@ void test_setFont() {
     require(w > 0 && w <= 32, "a proportional font returns a positive bounded advance");
 }
 
+// ---- Bitmap glyph rasterization -------------------------------------------
+void test_drawStringBitmapBits() {
+    static const uint32 kFont1AGoldenHash = 0x1f66d074u;
+    int16 params[11] = {};
+    params[0] = 2;
+    params[2] = 7;
+    params[4] = 10;
+    params[5] = 20;
+    params[6] = 1;
+
+    fillPageRaw(2, 0);
+    gfx_drawString(params, "A");
+    require(pageHash(2) == kFont1AGoldenHash,
+            "font rasterization consumes each packed glyph bit exactly once");
+}
+
 // ---- gfx_calcRowAddr / gfx_getRowOffset / blitOffset round-trip -----------
 void test_rowAddrAndBlitOffset() {
     require(gfx_getRowOffset(0) == 0 && gfx_getRowOffset(5) == 5 * kLogicalWidth,
@@ -395,6 +425,7 @@ int main() {
     test_drawLine();
     test_dirtyRect2();
     test_setFont();
+    test_drawStringBitmapBits();
     test_rowAddrAndBlitOffset();
     test_dacPalette();
     test_goldenComposedScene();


### PR DESCRIPTION
## What changed

- Rasterize packed bitmap-font rows with an explicit per-column MSB mask instead of repeatedly left-shifting an 8-bit temporary.
- Add a pixel-exact `gfx_drawString` regression test using a real font-1 glyph.

## Why

The Windows MSVC build rendered extra pixels after glyph edges, corrupting text from the pilot-selection screen onward. Linux and Windows used identical font data and draw parameters, but the repeated promoted shift assignment produced different framebuffer output under MSVC.

The explicit mask preserves the original packed MSB-first font format and produces identical indexed framebuffer output on GCC and MSVC.

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (30/30 passed)
- Compared all pilot-screen font data and page hashes between Linux and MSVC/Wine; all 17 text draws match after the fix.
