### PR TITLE
3. [fix] Fix tracking camera vertical flip

### DIFF
--- a/src/egflight.c
+++ b/src/egflight.c
@@ -780,9 +780,25 @@ static int32 eyeFromQ8(long q8, int16 *frac) {
     return (int32)(q8 >> 8);
 }
 
+void computeTrackingCameraAngles(int32 targetX, int32 targetY, int16 targetAlt,
+                                 int32 viewX, int32 viewY, int16 viewAlt,
+                                 int16 *heading, int16 *pitch) {
+    enum { WORLD_Y_EXTENT = 0x100000 };
+    int32 dx = targetX - viewX;
+    /* Target Y is a world coordinate, while viewY is the renderer's inverted
+     * coordinate. Convert them to the same space before taking the delta. */
+    int32 dy = targetY - (WORLD_Y_EXTENT - viewY);
+    int32 range = rangeApprox32(dx, dy);
+
+    /* Fine world deltas exceed int16 on normal maps. computeBearing32 scales
+     * both components equally, preserving the angle without truncation. */
+    *heading = computeBearing32(dx, -dy);
+    *pitch = -computeBearing32((int32)targetAlt - viewAlt, range);
+}
+
 // something to do with view switching?
 void renderFrame() {
-    int16 camDist, savedCamDist, range, camOffset, dx, dy, tmp;
+    int16 camDist, savedCamDist, camOffset, tmp;
     g_camEyeX = g_viewTargetX = g_ViewX;
     g_camEyeY = g_ViewY;
     g_viewTargetY = 0x100000 - g_ViewY;
@@ -903,23 +919,9 @@ void renderFrame() {
             if (g_autopilotEngaged != 0 && g_directorEventDeadline == -1) camDist = 6;
         }
         if (g_directorMode == 0) camDist = savedCamDist;
-        /* Derive the tracking-camera heading and pitch from FINE world coords —
-         * both the fine target position and the fine player position (g_ViewX/Y),
-         * not the coarse map coords (g_viewX_/g_viewY_) which step 32 fine units
-         * at a time and made the whole world "earthquake" around a tracked target.
-         * computeBearing is scale-invariant, so the angles are identical to the
-         * original coarse formula but with ~32x less quantization jitter. range is
-         * computed inline (rangeApprox would saturate its 0x7fff cap on fine
-         * deltas) and kept in the same scale as the altitude delta so the pitch
-         * ratio is unchanged. */
-        dx = (int)(g_viewTargetX - g_ViewX);
-        dy = (int)(g_viewTargetY - g_ViewY);
-        {
-            int adx = dx < 0 ? -dx : dx, ady = dy < 0 ? -dy : dy;
-            range = adx > ady ? adx + (ady >> 1) : ady + (adx >> 1);
-        }
-        g_viewHeading = computeBearing(dx, -dy);
-        g_viewPitch = -computeBearing(g_viewTargetAlt - g_viewZ, range);
+        computeTrackingCameraAngles((int32)g_viewTargetX, (int32)g_viewTargetY,
+                                    g_viewTargetAlt, g_ViewX, g_ViewY, g_viewZ,
+                                    &g_viewHeading, &g_viewPitch);
         g_viewRoll = 0;
         camOffset = cosMul(g_viewPitch, 0x18 << camDist);
         if (g_viewTargetObj & 0x60 || g_directorMode != 0) {

--- a/src/egflight.h
+++ b/src/egflight.h
@@ -3,6 +3,9 @@
 /* public interface of egflight.c */
 
 int16 isqrt(int16 value);
+void computeTrackingCameraAngles(int32 targetX, int32 targetY, int16 targetAlt,
+                                 int32 viewX, int32 viewY, int16 viewAlt,
+                                 int16 *heading, int16 *pitch);
 void UpdateThrottleState(void);
 void drawFuelGauge(void);
 

--- a/src/egmath.c
+++ b/src/egmath.c
@@ -184,7 +184,7 @@ static int roundToInt(float v) {
 
 /* Fast 2D distance approximation (rangeApprox) at full 32-bit width: no int16
  * truncation and no 0x7FFF cap, so it can feed a bearing off FINE world deltas. */
-static int32 rangeApprox32(int32 dx, int32 dy) {
+int32 rangeApprox32(int32 dx, int32 dy) {
     if (dx < 0) dx = -dx;
     if (dy < 0) dy = -dy;
     return dx > dy ? dx + (dy >> 1) : dy + (dx >> 1);
@@ -196,7 +196,7 @@ static int32 rangeApprox32(int32 dx, int32 dy) {
  * units the original fed it — those coarse deltas requantize every render frame
  * under the sim/render decouple, so the tracked model shivered; the fine deltas
  * vary smoothly, so it steps at most one pixel at a time. */
-static int bearingFromFine(int32 deltaX, int32 deltaY) {
+int16 computeBearing32(int32 deltaX, int32 deltaY) {
     int32 m = (deltaX < 0 ? -deltaX : deltaX) | (deltaY < 0 ? -deltaY : deltaY);
     int sh = 0;
     while ((m >> sh) > 0x3fff) sh++;
@@ -245,8 +245,8 @@ void drawTargetView(int shapeId, int32 worldX, int32 worldY, int altitude, int o
         relZ = (int)(dzFine >> 5);
         /* Bearing/pitch off the fine deltas so the tracked model glides; the range
          * (model size / tracking scale) keeps the original coarse magnitude. */
-        bearing = bearingFromFine(dxFine, -dyFine);
-        pitch = bearingFromFine(dzFine, rangeApprox32(dxFine, dyFine));
+        bearing = computeBearing32(dxFine, -dyFine);
+        pitch = computeBearing32(dzFine, rangeApprox32(dxFine, dyFine));
         range = rangeApprox(relZ, rangeApprox(relX, relY));
 
         if (mode == 1) {

--- a/src/egmath.h
+++ b/src/egmath.h
@@ -13,7 +13,10 @@ int shapeDataOffset(int shapeId);
 int16 clampRange(int16 value, int16 minVal, int16 maxVal);
 int egClampValue(int value, int minVal, int maxVal);
 int16 computeBearing(int16 deltaX, int16 deltaY);
+/* Full-width counterpart to computeBearing: scales both components equally
+ * into the original int16 domain, preserving their angular ratio. */
 int16 computeBearing32(int32 deltaX, int32 deltaY);
+/* Full-width counterpart to rangeApprox for fine world-coordinate deltas. */
 int32 rangeApprox32(int32 deltaX, int32 deltaY);
 int16 cosMul(int16 angle, int16 value);
 long sinMulQ8(int angle, int value);

--- a/src/egmath.h
+++ b/src/egmath.h
@@ -13,6 +13,8 @@ int shapeDataOffset(int shapeId);
 int16 clampRange(int16 value, int16 minVal, int16 maxVal);
 int egClampValue(int value, int minVal, int maxVal);
 int16 computeBearing(int16 deltaX, int16 deltaY);
+int16 computeBearing32(int32 deltaX, int32 deltaY);
+int32 rangeApprox32(int32 deltaX, int32 deltaY);
 int16 cosMul(int16 angle, int16 value);
 long sinMulQ8(int angle, int value);
 long cosMulQ8(int angle, int value);

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -5,6 +5,7 @@
 // state (threat scoring, SAM acquisition, target/mission bookkeeping, replay
 // log, director scheduling, wreck physics, timing/LOD math).
 #include "egdata.h"
+#include "egflight.h"
 #include "egkeys.h"
 #include "egmath.h"
 #include "inttype.h"
@@ -103,6 +104,22 @@ void resetGameplayState() {
 
 int main() {
     test_headless_init();
+
+    // --- Tracking-camera fine-coordinate conversion ------------------------
+    // These values are from a blackbox frame that formerly flipped vertically:
+    // target Y is world-space, while g_ViewY is renderer-inverted. Mixing them
+    // also overflowed computeBearing's int16 input and produced a near-180 pitch.
+    int16 cameraHeading = 0;
+    int16 cameraPitch = 0;
+    computeTrackingCameraAngles(612536, 311380, 2111,
+                                614019, 737929, 1513,
+                                &cameraHeading, &cameraPitch);
+    require(cameraHeading == computeBearing(-1483, -733),
+            "tracking camera converts inverted view Y before computing heading");
+    require(cameraPitch == -computeBearing(598, 1849),
+            "tracking camera preserves the fine altitude/range ratio");
+    require(cameraPitch > -0x4000 && cameraPitch < 0x4000,
+            "tracking camera pitch does not trigger a false 180-degree flip");
 
     // --- Threat range/bearing/score (egthreat) ------------------------------
     // Score is altitude-weighted; range is rangeApprox in km units (>>6);

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -120,6 +120,13 @@ int main() {
             "tracking camera preserves the fine altitude/range ratio");
     require(cameraPitch > -0x4000 && cameraPitch < 0x4000,
             "tracking camera pitch does not trigger a false 180-degree flip");
+    require(computeBearing32(0x20000, 0x10000) ==
+                computeBearing(0x2000, 0x1000),
+            "computeBearing32 equally scales vectors that exceed int16");
+    require(rangeApprox32(-0x20000, -0x10000) == 0x28000,
+            "rangeApprox32 preserves full-width negative deltas");
+    require(rangeApprox32(-0x10000, -0x20000) == 0x28000,
+            "rangeApprox32 covers either component as the major axis");
 
     // --- Threat range/bearing/score (egthreat) ------------------------------
     // Score is altitude-weighted; range is rangeApprox in km units (>>6);


### PR DESCRIPTION
## Summary

- keep tracking-camera calculations in fine world coordinates without truncating them to 16 bits
- convert the renderer-inverted player Y coordinate before comparing it with target world Y
- expose the existing 32-bit range/bearing helpers for the tracking-camera path
- add a regression test using coordinates captured at the failing blackbox frame

## Root cause

The smooth tracking-camera path passed fine coordinates, often hundreds of thousands of units, through `int16` locals and `computeBearing(int16, int16)`. It also subtracted target world Y directly from the renderer-inverted `g_ViewY` value. Near the recorded failure this produced a pitch close to 180 degrees, so the normal gimbal correction rotated heading and roll by 180 degrees and displayed the external view upside down.

## Validation

- `ctest --test-dir build --output-on-failure`: 30/30 tests passed
- replayed `/tmp/f15-realtime.bb` around tick 2100 using the deterministic-blackbox branch
- before: `heading=-32330, pitch=-172, roll=-32768`
- after: `heading=11585, pitch=-3285, roll=0`

The replay changes camera/render hashes as expected because the corrected camera orientation differs from the recorded buggy orientation.
