### PR TITLE
2. [fix] Reset flight state between missions

### DIFF
--- a/src/egmain.c
+++ b/src/egmain.c
@@ -35,6 +35,10 @@ void resetMissionRuntimeState(void) {
     g_eventLogCount = 0;
     g_ejectState = 0;
     g_ejectPending = 0;
+    g_slowMotionMode = 1;
+    g_playerPlaneFlags = 0;
+    g_autopilotEngaged = 0;
+    g_autopilotAltitude = 0;
     g_inLandingCorridor = 1;
     g_landingDoneFlag = 1;
     g_landingTimer = 0;

--- a/src/egmain.c
+++ b/src/egmain.c
@@ -25,21 +25,37 @@
 void drawCockpit();
 void runGameSession();
 
-// ==== seg000:0x10 ====
-int egame_main(void) {
-    /* Per-mission state reset (persists across missions in the merged build).
-     * g_initPhase=0 re-arms the init block; the indicator colour trackers (+7 of
-     * the four rects at [3..22]) must match the cockpit base colour (3). The view
-     * selector and director camera must start in the cockpit, not last mission's view. */
+/* Restore mutable EGAME globals that the DOS executable reinitialized whenever
+ * START launched it for a new mission. The native port keeps EGAME in the same
+ * process, so leaving these values intact can make a new ground start look like
+ * the final frame of the previous mission's landing sequence. */
+void resetMissionRuntimeState(void) {
+    frameTick = 0;
+    g_missionTick = 0;
     g_initPhase = 0;
     g_missionEndedFlag[0] = g_missionEndedFlag[1] = 0;
     g_eventLogCount = 0;
     g_ejectState = 0;
     g_ejectPending = 0;
+    g_destroyedCueDeadline = 0;
+    g_inLandingCorridor = 1;
+    g_landingDoneFlag = 1;
+    g_landingTimer = 0;
+    g_autoLandingActive = 0;
+    g_resupplyCount = 1;
+    g_hudMsgTimer = 0;
+    g_dirMsgTimer = 0;
+    tempString[0] = '\0';
     g_viewMode = VIEW_COCKPIT;
     g_directorMode = 0;
     g_directorEventDeadline = -1;
-    g_tacmapIndicators[7] = g_tacmapIndicators[12] = g_tacmapIndicators[17] = g_tacmapIndicators[22] = 3;
+    g_tacmapIndicators[7] = g_tacmapIndicators[12] =
+        g_tacmapIndicators[17] = g_tacmapIndicators[22] = 3;
+}
+
+// ==== seg000:0x10 ====
+int egame_main(void) {
+    resetMissionRuntimeState();
     installCBreakHandler();
     if (commData->setupUseJoy == 1) {
         copyJoystickData(commData->joyData);

--- a/src/egmain.c
+++ b/src/egmain.c
@@ -30,14 +30,11 @@ void runGameSession();
  * process, so leaving these values intact can make a new ground start look like
  * the final frame of the previous mission's landing sequence. */
 void resetMissionRuntimeState(void) {
-    frameTick = 0;
-    g_missionTick = 0;
     g_initPhase = 0;
     g_missionEndedFlag[0] = g_missionEndedFlag[1] = 0;
     g_eventLogCount = 0;
     g_ejectState = 0;
     g_ejectPending = 0;
-    g_destroyedCueDeadline = 0;
     g_inLandingCorridor = 1;
     g_landingDoneFlag = 1;
     g_landingTimer = 0;
@@ -49,8 +46,10 @@ void resetMissionRuntimeState(void) {
     g_viewMode = VIEW_COCKPIT;
     g_directorMode = 0;
     g_directorEventDeadline = -1;
-    g_tacmapIndicators[7] = g_tacmapIndicators[12] =
-        g_tacmapIndicators[17] = g_tacmapIndicators[22] = 3;
+    g_tacmapIndicators[7] = 3;
+    g_tacmapIndicators[12] = 3;
+    g_tacmapIndicators[17] = 3;
+    g_tacmapIndicators[22] = 3;
 }
 
 // ==== seg000:0x10 ====

--- a/src/egmain.c
+++ b/src/egmain.c
@@ -53,8 +53,8 @@ void resetMissionRuntimeState(void) {
 }
 
 // ==== seg000:0x10 ====
-int egame_main(void) {
-    resetMissionRuntimeState();
+int egame_main(void) { /* GCOVR_EXCL_LINE: interactive entry point */
+    resetMissionRuntimeState(); /* GCOVR_EXCL_LINE: reset body is covered directly */
     installCBreakHandler();
     if (commData->setupUseJoy == 1) {
         copyJoystickData(commData->joyData);

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -156,6 +156,10 @@ int main() {
     g_eventLogCount = 9;
     g_ejectState = 1;
     g_ejectPending = 1;
+    g_slowMotionMode = 2;
+    g_playerPlaneFlags = 0x1000;
+    g_autopilotEngaged = 1;
+    g_autopilotAltitude = 1200;
     g_inLandingCorridor = 0;
     g_landingDoneFlag = 0;
     g_landingTimer = 1;
@@ -182,6 +186,9 @@ int main() {
             "mission reset clears stale resupply counters and HUD messages");
     require(g_ejectState == 0 && g_ejectPending == 0 && g_eventLogCount == 0,
             "mission reset clears previous outcome state");
+    require(g_slowMotionMode == 1 && g_playerPlaneFlags == 0 &&
+                g_autopilotEngaged == 0 && g_autopilotAltitude == 0,
+            "mission reset clears acceleration, training, and autopilot state");
     require(g_missionEndedFlag[0] == 0 && g_missionEndedFlag[1] == 0 &&
                 g_viewMode == VIEW_COCKPIT && g_directorMode == 0 &&
                 g_directorEventDeadline == -1,

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -36,6 +36,7 @@ extern void recalcTimeScale(void);
 extern void exitSlowMotion(void);
 extern void setupLodDistances(void);
 extern int rangeApprox(int deltaX, int deltaY);
+extern void resetMissionRuntimeState(void);
 
 namespace {
 
@@ -127,6 +128,72 @@ int main() {
             "rangeApprox32 preserves full-width negative deltas");
     require(rangeApprox32(-0x10000, -0x20000) == 0x28000,
             "rangeApprox32 covers either component as the major axis");
+    // --- Native process mission boundary (egmain) ---------------------------
+    // A crashed sortie can leave landingTimer armed because normal airborne
+    // flight sets it to one. The original loaded a fresh EGAME executable for
+    // the next sortie; the merged native process must reproduce those globals.
+    struct GameComm handoffComm = {};
+    struct Game handoffGame = {};
+    std::strcpy(handoffGame.pilotName, "Selected pilot");
+    handoffGame.pilotIdx = 3;
+    handoffGame.difficulty = 2;
+    handoffGame.theater = 4;
+    handoffGame.missionReady = 1;
+    handoffGame.isCampaignMission = 1;
+    handoffGame.rand = 12345;
+    handoffComm.trainingFlag = 1;
+    handoffComm.weaponType[0] = 7;
+    handoffComm.weaponCount[0] = 4;
+    commData = &handoffComm;
+    gameData = &handoffGame;
+    const struct GameComm expectedComm = handoffComm;
+    const struct Game expectedGame = handoffGame;
+
+    frameTick = 2712;
+    g_missionTick = 34;
+    g_initPhase = 2;
+    g_missionEndedFlag[0] = g_missionEndedFlag[1] = 1;
+    g_eventLogCount = 9;
+    g_ejectState = 1;
+    g_ejectPending = 1;
+    g_destroyedCueDeadline = 2712;
+    g_inLandingCorridor = 0;
+    g_landingDoneFlag = 0;
+    g_landingTimer = 1;
+    g_autoLandingActive = 1;
+    g_resupplyCount = 4;
+    g_hudMsgTimer = 30;
+    g_dirMsgTimer = 30;
+    std::strcpy(tempString, "Weapons replenished");
+    g_viewMode = VIEW_EXT_FOLLOW;
+    g_directorMode = 2;
+    g_directorEventDeadline = 3000;
+    g_tacmapIndicators[7] = g_tacmapIndicators[12] =
+        g_tacmapIndicators[17] = g_tacmapIndicators[22] = 10;
+
+    resetMissionRuntimeState();
+
+    require(frameTick == 0 && g_missionTick == 0 && g_initPhase == 0,
+            "mission reset restores fresh EGAME timing and initialization state");
+    require(g_landingTimer == 0 && g_landingDoneFlag == 1 &&
+                g_inLandingCorridor == 1 && g_autoLandingActive == 0,
+            "mission reset disarms the previous sortie's landing sequence");
+    require(g_resupplyCount == 1 && g_hudMsgTimer == 0 &&
+                g_dirMsgTimer == 0 && tempString[0] == '\0',
+            "mission reset clears stale resupply counters and HUD messages");
+    require(g_destroyedCueDeadline == 0 && g_ejectState == 0 &&
+                g_ejectPending == 0 && g_eventLogCount == 0,
+            "mission reset clears delayed cues and previous outcome state");
+    require(g_missionEndedFlag[0] == 0 && g_missionEndedFlag[1] == 0 &&
+                g_viewMode == VIEW_COCKPIT && g_directorMode == 0 &&
+                g_directorEventDeadline == -1,
+            "mission reset starts the next sortie in the cockpit");
+    require(g_tacmapIndicators[7] == 3 && g_tacmapIndicators[12] == 3 &&
+                g_tacmapIndicators[17] == 3 && g_tacmapIndicators[22] == 3,
+            "mission reset restores cockpit indicator base colors");
+    require(std::memcmp(&handoffComm, &expectedComm, sizeof(handoffComm)) == 0 &&
+                std::memcmp(&handoffGame, &expectedGame, sizeof(handoffGame)) == 0,
+            "mission reset preserves the selected pilot and mission handoff");
 
     // --- Threat range/bearing/score (egthreat) ------------------------------
     // Score is altitude-weighted; range is rangeApprox in km units (>>6);

--- a/tests/gameplay_behavior_tests.cpp
+++ b/tests/gameplay_behavior_tests.cpp
@@ -132,6 +132,8 @@ int main() {
     // A crashed sortie can leave landingTimer armed because normal airborne
     // flight sets it to one. The original loaded a fresh EGAME executable for
     // the next sortie; the merged native process must reproduce those globals.
+    struct GameComm *previousCommData = commData;
+    struct Game *previousGameData = gameData;
     struct GameComm handoffComm = {};
     struct Game handoffGame = {};
     std::strcpy(handoffGame.pilotName, "Selected pilot");
@@ -149,14 +151,11 @@ int main() {
     const struct GameComm expectedComm = handoffComm;
     const struct Game expectedGame = handoffGame;
 
-    frameTick = 2712;
-    g_missionTick = 34;
     g_initPhase = 2;
     g_missionEndedFlag[0] = g_missionEndedFlag[1] = 1;
     g_eventLogCount = 9;
     g_ejectState = 1;
     g_ejectPending = 1;
-    g_destroyedCueDeadline = 2712;
     g_inLandingCorridor = 0;
     g_landingDoneFlag = 0;
     g_landingTimer = 1;
@@ -173,17 +172,16 @@ int main() {
 
     resetMissionRuntimeState();
 
-    require(frameTick == 0 && g_missionTick == 0 && g_initPhase == 0,
-            "mission reset restores fresh EGAME timing and initialization state");
+    require(g_initPhase == 0,
+            "mission reset re-arms EGAME initialization");
     require(g_landingTimer == 0 && g_landingDoneFlag == 1 &&
                 g_inLandingCorridor == 1 && g_autoLandingActive == 0,
             "mission reset disarms the previous sortie's landing sequence");
     require(g_resupplyCount == 1 && g_hudMsgTimer == 0 &&
                 g_dirMsgTimer == 0 && tempString[0] == '\0',
             "mission reset clears stale resupply counters and HUD messages");
-    require(g_destroyedCueDeadline == 0 && g_ejectState == 0 &&
-                g_ejectPending == 0 && g_eventLogCount == 0,
-            "mission reset clears delayed cues and previous outcome state");
+    require(g_ejectState == 0 && g_ejectPending == 0 && g_eventLogCount == 0,
+            "mission reset clears previous outcome state");
     require(g_missionEndedFlag[0] == 0 && g_missionEndedFlag[1] == 0 &&
                 g_viewMode == VIEW_COCKPIT && g_directorMode == 0 &&
                 g_directorEventDeadline == -1,
@@ -193,7 +191,9 @@ int main() {
             "mission reset restores cockpit indicator base colors");
     require(std::memcmp(&handoffComm, &expectedComm, sizeof(handoffComm)) == 0 &&
                 std::memcmp(&handoffGame, &expectedGame, sizeof(handoffGame)) == 0,
-            "mission reset preserves the selected pilot and mission handoff");
+            "mission reset preserves selected pilot and mission metadata");
+    commData = previousCommData;
+    gameData = previousGameData;
 
     // --- Threat range/bearing/score (egthreat) ------------------------------
     // Score is altitude-weighted; range is rangeApprox in km units (>>6);


### PR DESCRIPTION
## Summary
- restore EGAME's original per-executable initial state before every mission
- prevent a crashed sortie's armed landing timer from triggering `Nice landing` and `Weapons replenished` in the next sortie
- preserve the selected pilot and mission handoff in `commData` / `gameData`

## Root cause
The DOS version launched a fresh EGAME executable for each sortie. In the merged native process, `g_landingTimer` survived a crash with value 1. A subsequent ground start therefore entered the completed-landing branch and called `playVoiceCue(4)`.

## Verification
- full local suite: 30/30 tests passed
- regression test starts with stale crash/landing/HUD state and verifies original EGAME defaults
- regression test verifies `commData` and `gameData` remain byte-identical across the reset
- blackbox replay `/tmp/f15-realtime.bb`: baseline hits `playVoiceCue(4)` at raw tick 3459 (displayed 5739); fixed build reaches tick 3460 without that call
