### PR TITLE
5. [perf] Optimize rendering hot paths

### DIFF
--- a/src/eg3drast.c
+++ b/src/eg3drast.c
@@ -147,6 +147,8 @@ static unsigned udiv32by16(unsigned long num, unsigned den) {
  * projects to a large off-screen coord rather than a clamped ±0x7f00. */
 static unsigned long udiv32by16_full(unsigned long num, unsigned den) {
     if (den == 0) return 0xffffffffUL;
+    /* The old code calculated the same result one bit at a time. Keep the
+     * original 32-bit values, but use the CPU's division instruction. */
     return (unsigned long)((uint32)num / (uint32)den);
 }
 
@@ -191,8 +193,8 @@ static int sdiv32by16(long num, int den) {
  * word. Combined with HI16(p<<1) this reproduces fixedMulQ14's Q15 rounding. */
 #define LOCARRY(v) ((((uint16)(v)) & 0x8000u) ? 1 : 0)
 
-/* Signed 16x16 -> 32 multiply. Native targets can perform this directly and
- * `long` can represent every int16 product exactly. */
+/* Keep the original signed 16-bit inputs, but use the CPU's multiplication
+ * instruction instead of building the result one bit at a time. */
 static long imul16(int a, int b) {
     return (long)(int16)a * (long)(int16)b;
 }
@@ -993,8 +995,8 @@ static void rasterizeEdgeSpan(void) {
         int row = g_lineY1;  /* DI = y1*2 in the asm; here row index */
         int rstep = bp >> 1; /* +1 / -1 row */
         int ax = g_lineX1;
-        /* A horizontal edge cannot change rows. The Bresenham loop would visit
-         * every X only to leave the endpoints as this row's span extents. */
+        /* A horizontal edge touches one row, so its endpoints already give us
+         * the full span. There is no need to visit every point between them. */
         if (dyv == 0) {
             if ((uint16)g_lineX1 < (uint16)minB[row]) minB[row] = g_lineX1;
             if ((uint16)g_lineX2 > (uint16)maxB[row]) maxB[row] = g_lineX2;

--- a/src/eg3drast.c
+++ b/src/eg3drast.c
@@ -146,21 +146,8 @@ static unsigned udiv32by16(unsigned long num, unsigned den) {
  * downstream Cohen-Sutherland clip works in 32-bit), so a near-plane vertex
  * projects to a large off-screen coord rather than a clamped ±0x7f00. */
 static unsigned long udiv32by16_full(unsigned long num, unsigned den) {
-    unsigned long rem = 0;
-    unsigned long q = 0;
-    int i;
     if (den == 0) return 0xffffffffUL;
-    for (i = 0; i < 32; i++) {
-        rem = rem << 1;
-        if (num & 0x80000000UL) rem |= 1;
-        num = num << 1;
-        q = q << 1;
-        if (rem >= (unsigned long)den) {
-            rem -= den;
-            q |= 1;
-        }
-    }
-    return q;
+    return (unsigned long)((uint32)num / (uint32)den);
 }
 
 /* Signed full-precision 32/16 divide (no saturation). */
@@ -204,27 +191,10 @@ static int sdiv32by16(long num, int den) {
  * word. Combined with HI16(p<<1) this reproduces fixedMulQ14's Q15 rounding. */
 #define LOCARRY(v) ((((uint16)(v)) & 0x8000u) ? 1 : 0)
 
-/* signed 16x16 -> 32 multiply, shift-add (no __aNlmul). */
+/* Signed 16x16 -> 32 multiply. Native targets can perform this directly and
+ * `long` can represent every int16 product exactly. */
 static long imul16(int a, int b) {
-    unsigned long aa, p = 0;
-    unsigned ub;
-    int neg = 0, i;
-    if (a < 0) {
-        neg ^= 1;
-        a = -a;
-    }
-    if (b < 0) {
-        neg ^= 1;
-        b = -b;
-    }
-    aa = (unsigned)a;
-    ub = (unsigned)b;
-    for (i = 0; i < 16; i++) {
-        if (ub & 1) p += aa;
-        ub >>= 1;
-        aa = aa << 1;
-    }
-    return neg ? -(long)p : (long)p;
+    return (long)(int16)a * (long)(int16)b;
 }
 
 /* arithmetic right shift of a long by n (only >>1 is inline in MSC 5.1). */
@@ -1023,6 +993,13 @@ static void rasterizeEdgeSpan(void) {
         int row = g_lineY1;  /* DI = y1*2 in the asm; here row index */
         int rstep = bp >> 1; /* +1 / -1 row */
         int ax = g_lineX1;
+        /* A horizontal edge cannot change rows. The Bresenham loop would visit
+         * every X only to leave the endpoints as this row's span extents. */
+        if (dyv == 0) {
+            if ((uint16)g_lineX1 < (uint16)minB[row]) minB[row] = g_lineX1;
+            if ((uint16)g_lineX2 > (uint16)maxB[row]) maxB[row] = g_lineX2;
+            return;
+        }
         if (dyv < dxv) {
             /* shallow (dx > |dy|): step X each iteration, step row on carry */
             int cx = dxv, bx = -((dxv + 1) >> 1), si = dyv;

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -32,6 +32,30 @@
 static SDL_Window *sdlWindow = NULL;
 static SDL_Renderer *sdlRenderer = NULL;
 static bool s_useGL = false; /* OpenGL backend owns the context + present */
+static SDL_Texture *gfxSoftwarePresentTexture;
+static int gfxSoftwarePresentTextureW;
+static int gfxSoftwarePresentTextureH;
+static uint32 *gfxSoftwarePresentPixels;
+static size_t gfxSoftwarePresentPixelCapacity;
+static uint32 gfxSoftwarePresentPalette[256];
+static int gfxSoftwarePresentPaletteGen = -1;
+
+static void gfx_expandIndexedSurface(SDL_Surface *surf, uint32 *dst,
+                                     const uint32 *palette) {
+    int y;
+    for (y = 0; y < surf->h; y++) {
+        const uint8 *src = (const uint8 *)surf->pixels + (size_t)y * surf->pitch;
+        uint32 *dstRow = dst + (size_t)y * surf->w;
+        int x = 0;
+        for (; x + 4 <= surf->w; x += 4) {
+            dstRow[x] = palette[src[x]];
+            dstRow[x + 1] = palette[src[x + 1]];
+            dstRow[x + 2] = palette[src[x + 2]];
+            dstRow[x + 3] = palette[src[x + 3]];
+        }
+        for (; x < surf->w; x++) dstRow[x] = palette[src[x]];
+    }
+}
 
 /* Forward declarations for the page-surface model, used by gfx_videoShutdown
  * before their definitions further down. */
@@ -136,6 +160,13 @@ void gfx_videoShutdown(void) {
         SDL_DestroyPalette(gfxPalette);
         gfxPalette = NULL;
     }
+    if (gfxSoftwarePresentTexture) {
+        SDL_DestroyTexture(gfxSoftwarePresentTexture);
+        gfxSoftwarePresentTexture = NULL;
+    }
+    SDL_free(gfxSoftwarePresentPixels);
+    gfxSoftwarePresentPixels = NULL;
+    gfxSoftwarePresentPixelCapacity = 0;
     if (sdlRenderer) SDL_DestroyRenderer(sdlRenderer);
     if (sdlWindow) SDL_DestroyWindow(sdlWindow);
     SDL_Quit();
@@ -391,14 +422,54 @@ static bool gfxHiResActive = false;
  * logical presentation; we render into the centred dst rect over a black-cleared
  * window. */
 static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
-    SDL_Texture *tex;
     R2DMapping m;
+    const void *uploadPixels;
+    int uploadPitch;
     int win_w, win_h;
     SDL_FRect dst;
+    int x;
     if (!surf || !sdlRenderer) return;
-    tex = SDL_CreateTextureFromSurface(sdlRenderer, surf);
-    if (!tex) return;
-    SDL_SetTextureScaleMode(tex, SDL_SCALEMODE_NEAREST);
+    if (surf->format != SDL_PIXELFORMAT_INDEX8) return;
+    {
+        size_t pixelCount = (size_t)surf->w * (size_t)surf->h;
+        SDL_Palette *palette = SDL_GetSurfacePalette(surf);
+        if (!palette) return;
+        if (pixelCount > gfxSoftwarePresentPixelCapacity) {
+            uint32 *pixels = (uint32 *)SDL_realloc(gfxSoftwarePresentPixels,
+                                                   pixelCount * sizeof(*pixels));
+            if (!pixels) return;
+            gfxSoftwarePresentPixels = pixels;
+            gfxSoftwarePresentPixelCapacity = pixelCount;
+        }
+        if (gfxSoftwarePresentPaletteGen != gfxPaletteGen) {
+            for (x = 0; x < 256; x++) {
+                const SDL_Color c = palette->colors[x];
+                gfxSoftwarePresentPalette[x] = ((uint32)c.r << 16) |
+                                               ((uint32)c.g << 8) |
+                                               (uint32)c.b;
+            }
+            gfxSoftwarePresentPaletteGen = gfxPaletteGen;
+        }
+        gfx_expandIndexedSurface(surf, gfxSoftwarePresentPixels,
+                                 gfxSoftwarePresentPalette);
+        uploadPixels = gfxSoftwarePresentPixels;
+        uploadPitch = surf->w * (int)sizeof(*gfxSoftwarePresentPixels);
+    }
+    if (!gfxSoftwarePresentTexture || gfxSoftwarePresentTextureW != surf->w ||
+        gfxSoftwarePresentTextureH != surf->h) {
+        if (gfxSoftwarePresentTexture)
+            SDL_DestroyTexture(gfxSoftwarePresentTexture);
+        gfxSoftwarePresentTexture = SDL_CreateTexture(sdlRenderer,
+                                                       SDL_PIXELFORMAT_XRGB8888,
+                                                       SDL_TEXTUREACCESS_STREAMING,
+                                                       surf->w, surf->h);
+        if (!gfxSoftwarePresentTexture) return;
+        gfxSoftwarePresentTextureW = surf->w;
+        gfxSoftwarePresentTextureH = surf->h;
+        SDL_SetTextureBlendMode(gfxSoftwarePresentTexture, SDL_BLENDMODE_NONE);
+        SDL_SetTextureScaleMode(gfxSoftwarePresentTexture, SDL_SCALEMODE_NEAREST);
+    }
+    if (!SDL_UpdateTexture(gfxSoftwarePresentTexture, NULL, uploadPixels, uploadPitch)) return;
 
     SDL_GetRenderOutputSize(sdlRenderer, &win_w, &win_h);
     /* Square pixels: the software path presents the 320x200 page uniformly scaled
@@ -415,9 +486,8 @@ static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
     dst.y = (float)m.offY;
     dst.w = (float)surf->w * m.scaleX;
     dst.h = (float)surf->h * m.scaleY;
-    SDL_RenderTexture(sdlRenderer, tex, NULL, &dst);
+    SDL_RenderTexture(sdlRenderer, gfxSoftwarePresentTexture, NULL, &dst);
     SDL_RenderPresent(sdlRenderer);
-    SDL_DestroyTexture(tex);
 }
 
 /* Push a page's surface to the active 2D backend (GL composite or software
@@ -1153,22 +1223,21 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
     const uint16 *maxBuf = (const uint16 *)((const char *)spanMinBuf + 0x1b8);
     uint8 fill = s->fillColor;
     SDL_Surface *surf = ensurePage(0);
-    uint8 *pagePx;
+    SDL_Rect rects[200];
+    int rectCount = 0;
     int16 firstRow = (int16)yMin; /* AX */
     int16 lastRow = (int16)yMax;  /* CX */
     int y;
     if (!surf) return;
-    pagePx = (uint8 *)surf->pixels;
     /* MGRAPHIC slot 0x25: `or ax,ax; js exit` — if firstRow < 0, draw nothing. */
     if (firstRow < 0) return;
     if (lastRow > 199) lastRow = 199; /* rowOffsets[] safety */
     for (y = (int)lastRow; y >= (int)firstRow; y--) {
         uint16 spanLo = minBuf[y];
         uint16 spanHi = maxBuf[y];
-        uint16 width, col;
+        uint16 width;
         uint16 off;
         int row, col0;
-        uint8 *dst;
         /* MGRAPHIC's degenerate-row test is UNSIGNED (`cmp hi,lo; jc skip; ja
          * draw`): skip when hi < lo, draw when hi > lo, and when equal skip only
          * if the column is 0 or 0x13f (else a single pixel). The edge-walker in
@@ -1194,10 +1263,12 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
         row = off / LOGICAL_WIDTH;
         col0 = off % LOGICAL_WIDTH;
         if (row < 0 || row >= surf->h) continue;
-        dst = pagePx + (size_t)row * surf->pitch + col0;
-        for (col = 0; col < width && col0 + (int)col < LOGICAL_WIDTH; col++)
-            dst[col] = fill;
+        if ((int)width > LOGICAL_WIDTH - col0)
+            width = (uint16)(LOGICAL_WIDTH - col0);
+        rects[rectCount++] = (SDL_Rect){col0, row, width, 1};
     }
+    if (rectCount != 0)
+        SDL_FillSurfaceRects(surf, rects, rectCount, fill);
 }
 
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx) {

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -40,6 +40,8 @@ static size_t gfxSoftwarePresentPixelCapacity;
 static uint32 gfxSoftwarePresentPalette[256];
 static int gfxSoftwarePresentPaletteGen = -1;
 
+/* Convert the game's 256-color image to screen pixels. Doing it here lets us
+ * reuse one texture instead of asking SDL to create a new one every frame. */
 static void gfx_expandIndexedSurface(SDL_Surface *surf, uint32 *dst,
                                      const uint32 *palette) {
     int y;
@@ -441,6 +443,7 @@ static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
             gfxSoftwarePresentPixels = pixels;
             gfxSoftwarePresentPixelCapacity = pixelCount;
         }
+        /* Rebuild the color table only when the game's palette changes. */
         if (gfxSoftwarePresentPaletteGen != gfxPaletteGen) {
             for (x = 0; x < 256; x++) {
                 const SDL_Color c = palette->colors[x];
@@ -455,6 +458,8 @@ static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
         uploadPixels = gfxSoftwarePresentPixels;
         uploadPitch = surf->w * (int)sizeof(*gfxSoftwarePresentPixels);
     }
+    /* Reuse the texture unless the image size changes. The title and the game
+     * use different sizes, so each still gets a correctly sized texture. */
     if (!gfxSoftwarePresentTexture || gfxSoftwarePresentTextureW != surf->w ||
         gfxSoftwarePresentTextureH != surf->h) {
         if (gfxSoftwarePresentTexture)
@@ -1267,6 +1272,7 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
             width = (uint16)(LOGICAL_WIDTH - col0);
         rects[rectCount++] = (SDL_Rect){col0, row, width, 1};
     }
+    /* Fill all rows in one SDL call instead of setting every pixel here. */
     if (rectCount != 0)
         SDL_FillSurfaceRects(surf, rects, rectCount, fill);
 }

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -35,19 +35,17 @@ static bool s_useGL = false; /* OpenGL backend owns the context + present */
 static SDL_Texture *gfxSoftwarePresentTexture;
 static int gfxSoftwarePresentTextureW;
 static int gfxSoftwarePresentTextureH;
-static uint32 *gfxSoftwarePresentPixels;
-static size_t gfxSoftwarePresentPixelCapacity;
 static uint32 gfxSoftwarePresentPalette[256];
 static int gfxSoftwarePresentPaletteGen = -1;
 
-/* Convert the game's 256-color image to screen pixels. Doing it here lets us
- * reuse one texture instead of asking SDL to create a new one every frame. */
-static void gfx_expandIndexedSurface(SDL_Surface *surf, uint32 *dst,
+/* Convert the game's 256-color image directly into the reusable texture. This
+ * avoids copying a second full-screen buffer into the texture every frame. */
+static void gfx_expandIndexedSurface(SDL_Surface *surf, void *pixels, int dstPitch,
                                      const uint32 *palette) {
     int y;
     for (y = 0; y < surf->h; y++) {
         const uint8 *src = (const uint8 *)surf->pixels + (size_t)y * surf->pitch;
-        uint32 *dstRow = dst + (size_t)y * surf->w;
+        uint32 *dstRow = (uint32 *)((uint8 *)pixels + (size_t)y * dstPitch);
         int x = 0;
         for (; x + 4 <= surf->w; x += 4) {
             dstRow[x] = palette[src[x]];
@@ -166,9 +164,6 @@ void gfx_videoShutdown(void) {
         SDL_DestroyTexture(gfxSoftwarePresentTexture);
         gfxSoftwarePresentTexture = NULL;
     }
-    SDL_free(gfxSoftwarePresentPixels);
-    gfxSoftwarePresentPixels = NULL;
-    gfxSoftwarePresentPixelCapacity = 0;
     if (sdlRenderer) SDL_DestroyRenderer(sdlRenderer);
     if (sdlWindow) SDL_DestroyWindow(sdlWindow);
     SDL_Quit();
@@ -425,39 +420,13 @@ static bool gfxHiResActive = false;
  * window. */
 static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
     R2DMapping m;
-    const void *uploadPixels;
-    int uploadPitch;
+    void *texturePixels;
+    int texturePitch;
     int win_w, win_h;
     SDL_FRect dst;
     int x;
     if (!surf || !sdlRenderer) return;
     if (surf->format != SDL_PIXELFORMAT_INDEX8) return;
-    {
-        size_t pixelCount = (size_t)surf->w * (size_t)surf->h;
-        SDL_Palette *palette = SDL_GetSurfacePalette(surf);
-        if (!palette) return;
-        if (pixelCount > gfxSoftwarePresentPixelCapacity) {
-            uint32 *pixels = (uint32 *)SDL_realloc(gfxSoftwarePresentPixels,
-                                                   pixelCount * sizeof(*pixels));
-            if (!pixels) return;
-            gfxSoftwarePresentPixels = pixels;
-            gfxSoftwarePresentPixelCapacity = pixelCount;
-        }
-        /* Rebuild the color table only when the game's palette changes. */
-        if (gfxSoftwarePresentPaletteGen != gfxPaletteGen) {
-            for (x = 0; x < 256; x++) {
-                const SDL_Color c = palette->colors[x];
-                gfxSoftwarePresentPalette[x] = ((uint32)c.r << 16) |
-                                               ((uint32)c.g << 8) |
-                                               (uint32)c.b;
-            }
-            gfxSoftwarePresentPaletteGen = gfxPaletteGen;
-        }
-        gfx_expandIndexedSurface(surf, gfxSoftwarePresentPixels,
-                                 gfxSoftwarePresentPalette);
-        uploadPixels = gfxSoftwarePresentPixels;
-        uploadPitch = surf->w * (int)sizeof(*gfxSoftwarePresentPixels);
-    }
     /* Reuse the texture unless the image size changes. The title and the game
      * use different sizes, so each still gets a correctly sized texture. */
     if (!gfxSoftwarePresentTexture || gfxSoftwarePresentTextureW != surf->w ||
@@ -474,7 +443,24 @@ static void gfx_presentSurfaceSW(SDL_Surface *surf, int shake) {
         SDL_SetTextureBlendMode(gfxSoftwarePresentTexture, SDL_BLENDMODE_NONE);
         SDL_SetTextureScaleMode(gfxSoftwarePresentTexture, SDL_SCALEMODE_NEAREST);
     }
-    if (!SDL_UpdateTexture(gfxSoftwarePresentTexture, NULL, uploadPixels, uploadPitch)) return;
+    {
+        SDL_Palette *palette = SDL_GetSurfacePalette(surf);
+        if (!palette) return;
+        /* Rebuild the color table only when the game's palette changes. */
+        if (gfxSoftwarePresentPaletteGen != gfxPaletteGen) {
+            for (x = 0; x < 256; x++) {
+                const SDL_Color c = palette->colors[x];
+                gfxSoftwarePresentPalette[x] = ((uint32)c.r << 16) |
+                                               ((uint32)c.g << 8) |
+                                               (uint32)c.b;
+            }
+            gfxSoftwarePresentPaletteGen = gfxPaletteGen;
+        }
+    }
+    if (!SDL_LockTexture(gfxSoftwarePresentTexture, NULL, &texturePixels, &texturePitch)) return;
+    gfx_expandIndexedSurface(surf, texturePixels, texturePitch,
+                             gfxSoftwarePresentPalette);
+    SDL_UnlockTexture(gfxSoftwarePresentTexture);
 
     SDL_GetRenderOutputSize(sdlRenderer, &win_w, &win_h);
     /* Square pixels: the software path presents the 320x200 page uniformly scaled

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -1270,7 +1270,7 @@ void FAR CDECL gfx_dirtyRect2(const int16 *spanMinBuf, uint16 yMin, uint16 yMax)
         if (row < 0 || row >= surf->h) continue;
         if ((int)width > LOGICAL_WIDTH - col0)
             width = (uint16)(LOGICAL_WIDTH - col0);
-        rects[rectCount++] = (SDL_Rect){col0, row, width, 1};
+        rects[rectCount++] = SDL_Rect{col0, row, width, 1};
     }
     /* Fill all rows in one SDL call instead of setting every pixel here. */
     if (rectCount != 0)

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -2043,9 +2043,8 @@ static GLuint s_pageTex;
 static unsigned s_pageKey;
 static int s_pageTexW, s_pageTexH;
 
-/* Fast cache-key fold for framebuffer rows. This runs at render frequency even
- * when the texture remains cached, so process eight bytes per iteration. memcpy
- * keeps the chunk loads valid on platforms that require alignment. */
+/* Check eight image bytes at a time instead of one. memcpy keeps these reads
+ * safe on systems that cannot read an integer from every memory address. */
 static unsigned pageHashBytes(unsigned k, const uint8 *src, size_t size) {
     while (size >= sizeof(uint64)) {
         uint64 chunk;
@@ -2059,9 +2058,8 @@ static unsigned pageHashBytes(unsigned k, const uint8 *src, size_t size) {
     return k;
 }
 
-/* Fold the page's visible output: pixels, palette, show-through rectangles and
- * dimensions. Hashing the small palette avoids a used-colour bitset update for
- * every indexed pixel. */
+/* Include the image, colors, transparent areas, and size. Checking all 256
+ * colors is cheaper than recording which color every pixel uses. */
 static unsigned pageOutputKey(SDL_Surface *page, SDL_Palette *pal) {
     unsigned k = 2166136261u;
     const uint8 *src = (const uint8 *)page->pixels;
@@ -2130,9 +2128,8 @@ static void composePageBackdrop(SDL_Surface *page, int shakeOffset) {
                 uint32 *out = (uint32 *)(s_rgba + (size_t)y * w * 4);
                 for (x = 0; x < w; x++) out[x] = packedPalette[row[x]];
             }
-            /* The page is opaque except for the rectangular windows where the
-             * GL scene shows through. Clear alpha by rectangle instead of
-             * testing every page pixel against every rectangle. */
+            /* Make only the 3D view rectangles transparent. This is faster than
+             * asking every pixel whether it is inside one of those rectangles. */
             for (i = 0; i < s_nShowRects; i++) {
                 const SDL_Rect *r = &s_showRects[i];
                 int x0 = r->x < 0 ? 0 : r->x;

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -169,16 +169,6 @@ static void addShowRect(int x, int y, int w, int h) {
     s_nShowRects++;
 }
 
-/* Is page-space pixel (x,y) inside any show-through rect? */
-static int inShowRect(int x, int y) {
-    int i;
-    for (i = 0; i < s_nShowRects; i++) {
-        const SDL_Rect *r = &s_showRects[i];
-        if (x >= r->x && x < r->x + r->w && y >= r->y && y < r->y + r->h)
-            return 1;
-    }
-    return 0;
-}
 static float s_proj[16];     /* column-major GL projection for the active scene */
 static int s_sceneVp[4];     /* window-px viewport/scissor of the active 3D scene, for
                               * re-establishing the scene state in gl_endScene */
@@ -2047,33 +2037,40 @@ void r3dgl_drawImageWindowBoxX(R2DImage *img, float boxLeftX) {
 }
 
 /* The retained page as a persistent GL texture + the dirty key it was built for.
- * Re-uploaded ONLY when its visible output could have changed (below), so the page
- * is NOT re-converted/re-uploaded every frame — the flight fire-palette cycle bumps
- * the global palette generation every frame but touches only its 9 fire entries, so
- * a cockpit that doesn't use them stays cached. */
+ * Re-uploaded only when the indexed page, palette, show-through rectangles or
+ * dimensions change, rather than being converted and uploaded every frame. */
 static GLuint s_pageTex;
 static unsigned s_pageKey;
 static int s_pageTexW, s_pageTexH;
 
-/* FNV-1a fold of the page's exact visible output: the pixel indices, the palette
- * RGB of ONLY the indices actually present (so fire-cycle changes to unused entries
- * don't force a re-upload), the show-through rects (they set the alpha), and the
- * page size. A change in any of these — and nothing else — re-uploads the texture. */
+/* Fast cache-key fold for framebuffer rows. This runs at render frequency even
+ * when the texture remains cached, so process eight bytes per iteration. memcpy
+ * keeps the chunk loads valid on platforms that require alignment. */
+static unsigned pageHashBytes(unsigned k, const uint8 *src, size_t size) {
+    while (size >= sizeof(uint64)) {
+        uint64 chunk;
+        SDL_memcpy(&chunk, src, sizeof(chunk));
+        k = (k ^ (unsigned)chunk) * 16777619u;
+        k = (k ^ (unsigned)(chunk >> 32)) * 2246822519u;
+        src += sizeof(chunk);
+        size -= sizeof(chunk);
+    }
+    while (size-- != 0) k = (k ^ *src++) * 16777619u;
+    return k;
+}
+
+/* Fold the page's visible output: pixels, palette, show-through rectangles and
+ * dimensions. Hashing the small palette avoids a used-colour bitset update for
+ * every indexed pixel. */
 static unsigned pageOutputKey(SDL_Surface *page, SDL_Palette *pal) {
     unsigned k = 2166136261u;
-    unsigned used[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     const uint8 *src = (const uint8 *)page->pixels;
-    int pitch = page->pitch, x, y, i;
+    int pitch = page->pitch, y, i;
     for (y = 0; y < page->h; y++) {
         const uint8 *row = src + (size_t)y * pitch;
-        for (x = 0; x < page->w; x++) {
-            uint8 idx = row[x];
-            k = (k ^ idx) * 16777619u;
-            used[idx >> 5] |= 1u << (idx & 31);
-        }
+        k = pageHashBytes(k, row, (size_t)page->w);
     }
     for (i = 0; i < 256 && i < pal->ncolors; i++) {
-        if (!(used[i >> 5] & (1u << (i & 31)))) continue;
         k = (k ^ (unsigned)pal->colors[i].r) * 16777619u;
         k = (k ^ (unsigned)pal->colors[i].g) * 16777619u;
         k = (k ^ (unsigned)pal->colors[i].b) * 16777619u;
@@ -2117,18 +2114,35 @@ static void composePageBackdrop(SDL_Surface *page, int shakeOffset) {
         if (!ensureRgbaScratch(w * h * 4)) { s_nShowRects = 0; return; }
         src = (const uint8 *)page->pixels;
         pitch = page->pitch;
-        for (y = 0; y < h; y++) {
-            const uint8 *row = src + (size_t)y * pitch;
-            uint8 *out = s_rgba + (size_t)y * w * 4;
-            for (x = 0; x < w; x++) {
-                uint8 idx = row[x];
-                SDL_Color c = pal->colors[idx];
-                out[x * 4 + 0] = c.r;
-                out[x * 4 + 1] = c.g;
-                out[x * 4 + 2] = c.b;
-                /* Transparent inside the 3D viewport rect(s) so the GL 3D beneath
-                 * shows; opaque everywhere else (cockpit/panel). */
-                out[x * 4 + 3] = inShowRect(x, y) ? 0 : 255;
+        {
+            uint32 packedPalette[256];
+            int i;
+            for (i = 0; i < 256; i++) {
+                SDL_Color c = pal->colors[i];
+                uint8 *rgba = (uint8 *)&packedPalette[i];
+                rgba[0] = c.r;
+                rgba[1] = c.g;
+                rgba[2] = c.b;
+                rgba[3] = 255;
+            }
+            for (y = 0; y < h; y++) {
+                const uint8 *row = src + (size_t)y * pitch;
+                uint32 *out = (uint32 *)(s_rgba + (size_t)y * w * 4);
+                for (x = 0; x < w; x++) out[x] = packedPalette[row[x]];
+            }
+            /* The page is opaque except for the rectangular windows where the
+             * GL scene shows through. Clear alpha by rectangle instead of
+             * testing every page pixel against every rectangle. */
+            for (i = 0; i < s_nShowRects; i++) {
+                const SDL_Rect *r = &s_showRects[i];
+                int x0 = r->x < 0 ? 0 : r->x;
+                int y0 = r->y < 0 ? 0 : r->y;
+                int x1 = r->x + r->w > w ? w : r->x + r->w;
+                int y1 = r->y + r->h > h ? h : r->y + r->h;
+                for (y = y0; y < y1; y++) {
+                    uint8 *alpha = s_rgba + ((size_t)y * w + x0) * 4 + 3;
+                    for (x = x0; x < x1; x++, alpha += 4) *alpha = 0;
+                }
             }
         }
         if (!s_pageTex) glGenTextures(1, &s_pageTex);

--- a/tests/eg3drast_internal_behavior_tests.cpp
+++ b/tests/eg3drast_internal_behavior_tests.cpp
@@ -301,6 +301,9 @@ int main() {
             "udiv32by16 uses the divide trap sentinel for zero denominator");
     require(udiv32by16_full(0x10000UL, 2) == 0x8000UL,
             "udiv32by16_full keeps the full quotient");
+    require(udiv32by16_full(0xffffffffUL, 1) == 0xffffffffUL &&
+                udiv32by16_full(0xffffffffUL, 0xffffU) == 0x10001UL,
+            "udiv32by16_full preserves the complete 32-bit native quotient");
     require(udiv32by16_full(100, 0) ==
                 static_cast<unsigned long>(kUnsignedFullDivideByZeroSentinel),
             "udiv32by16_full preserves the all-bits divide-by-zero value");
@@ -310,6 +313,9 @@ int main() {
             "signed 32/16 helpers apply signs after unsigned division");
     require(imul16(-7, 6) == -42 && lshr_s(-8, 1) == -4,
             "manual multiply and arithmetic shift preserve signed behavior");
+    require(imul16(-32768, 32767) == -1073709056L &&
+                imul16(-32768, -32768) == 1073741824L,
+            "native 16-bit multiply preserves signed boundary products");
 
     require(hsine(0) == 0 &&
                 hcosine(0) == kIdentityQ15 &&
@@ -419,6 +425,18 @@ int main() {
                 g_spanBuf.minX[2] <= 2 &&
                 g_spanBuf.maxX[5] >= 8,
             "rasterizeEdgeSpan records shallow edge extents and dirty rows");
+
+    resetRasterState();
+    g_lineX1 = 3;
+    g_lineY1 = 12;
+    g_lineX2 = 300;
+    g_lineY2 = 12;
+    rasterizeEdgeSpan();
+    require(g_dirtyRectMinY == 12 &&
+                g_dirtyRectMaxY == 12 &&
+                g_spanBuf.minX[12] == 3 &&
+                g_spanBuf.maxX[12] == 300,
+            "rasterizeEdgeSpan records horizontal endpoints without walking every column");
 
     resetRasterState();
     g_lineX1 = 10;


### PR DESCRIPTION
## What changed

- **Software screen updates:** reuse one texture and write converted pixels directly into it. This avoids creating a texture and copying a second full-screen buffer every frame.
- **Palette conversion:** rebuild the 256-color lookup table only when the game's palette changes.
- **Filled 3D shapes:** send all filled rows to SDL together instead of setting their pixels one at a time.
- **Division and multiplication:** keep the original 16-bit and 32-bit behavior, but use the CPU instructions instead of calculating one bit at a time.
- **Horizontal 3D edges:** use the two endpoints directly because a horizontal edge touches only one row.
- **OpenGL image checks:** compare eight bytes at a time when deciding whether the page texture changed.
- **OpenGL transparency:** clear the rectangular 3D windows directly instead of testing every pixel against every rectangle.

These changes remove repeated work. They do not change gameplay timing or use CPU-specific SIMD code.

This intentionally excludes replacement-asset lookup caching and all asset-tooling changes.

## Benchmark

Software renderer, original game assets, deterministic demo, normal 15 Hz simulation, dummy audio, uncapped presentation, 5-second warm-up plus 10-second measurement:

| Revision | Render FPS | Simulation rate |
| --- | ---: | ---: |
| upstream `main` (`9a88aa8`) | 479.4 | 14.996 Hz |
| this branch (`dfcd509`) | 1574.0 | 15.000 Hz |

That is a 3.28x render-throughput improvement (+228%) without speeding up gameplay. A subsequent `perf` run with the original assets showed that writing directly into the texture also reduced instructions and cycles, but those normally paced measurements are directional and are not included in the FPS table.

## Validation

- Linux GCC RelWithDebInfo build
- `ctest --test-dir build --output-on-failure` (30/30 passed)
- `git diff --check`
