### PR TITLE
1. [fix] Fix briefing joystick cancel action

### DIFF
--- a/src/stmissn.c
+++ b/src/stmissn.c
@@ -459,7 +459,7 @@ printMissionAgain:
 }
 
 int16 pollMenuInput() {
-    uint16 key;
+    uint16 key = 0;
     char repeatHold;
     int joy1;
     int joy0;
@@ -500,6 +500,8 @@ int16 pollMenuInput() {
         key = misc_getKey();
     } else if (joy0 == 1) {
         key = KEYCODE_ENTER;
+    } else if (joy1 == 1) {
+        key = KEYCODE_ESC;
     } else if (joyAxes[1] < JOY_DEADZONE_LO) {
         key = KEYCODE_UPARROW;
         joyRepeatFlag = 1;


### PR DESCRIPTION
## What changed

- Map the second joystick button to Escape in the briefing menu.
- Initialize the returned key so every input path has a defined result.

## Why

Static analysis identified stability issue.
The input loop stopped waiting when either joystick button was pressed, but only the first button assigned an action. Pressing the second button therefore returned an undefined menu action instead of cancelling, unlike the equivalent briefing input code.

## Checks

- Full build completed successfully.
- All 30 CTest tests pass.
- `git diff --check` passes.
