### PR TITLE
[review: small] Fix attitude ratio signs on unsigned-char platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,11 @@ add_behavior_test(original_behavior_tests LINK_CORE)
 add_behavior_test(utility_behavior_tests LINK_CORE)
 add_behavior_test(end_runtime_behavior_tests LINK_CORE)
 add_behavior_test(geometry_behavior_tests LINK_CORE)
+add_behavior_test(signed_ratio_behavior_tests LINK_CORE SOURCES ${SRC_DIR}/egflight.c)
+# Compile the real attitude helper with ARM-like char signedness on desktop CI.
+target_compile_options(signed_ratio_behavior_tests PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-funsigned-char>
+    $<$<CXX_COMPILER_ID:MSVC>:/J>)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)

--- a/src/egflight.c
+++ b/src/egflight.c
@@ -694,8 +694,9 @@ void rebuildOrientation() {
 }
 
 uint16 signedRatio16(int16 numerator, int16 denominator) { /* Original: IntDiv(A,B). Divide two signed 15-bit fractions. */
-    char numeratorSign = 1;
-    char denominatorSign = 1;
+    /* Plain char is unsigned on Android ARM; sign factors must preserve -1. */
+    int numeratorSign = 1;
+    int denominatorSign = 1;
     int32 absNumerator;
     int32 absDenominator;
 

--- a/tests/signed_ratio_behavior_tests.cpp
+++ b/tests/signed_ratio_behavior_tests.cpp
@@ -1,0 +1,28 @@
+#include "inttype.h"
+
+#include <cstdint>
+#include <iostream>
+
+extern uint16 signedRatio16(int16 numerator, int16 denominator);
+
+int main() {
+    // Sweep every numerator with positive and negative divisors, including
+    // boundary values. Non-power-of-two inputs expose multiplication by 255
+    // instead of -1; simple half/quarter ratios can accidentally still pass.
+    const int divisors[] = {-32768, -32767, -12345, -1, 1, 12345, 32767};
+    for (int denominator : divisors) {
+        for (int numerator = -32768; numerator <= 32767; ++numerator) {
+            const uint16 expected = static_cast<uint16>(
+                (static_cast<std::int64_t>(numerator) * 32768) / denominator);
+            const uint16 actual = signedRatio16(
+                static_cast<int16>(numerator), static_cast<int16>(denominator));
+            if (actual != expected) {
+                std::cerr << "signedRatio16(" << numerator << ", "
+                          << denominator << "): expected " << expected
+                          << ", got " << actual << '\n';
+                return 1;
+            }
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Plain char is unsigned on Android ARM, so the sign factors in signedRatio16 become 255 instead of -1. This corrupts matrix-to-angle decoding used by autopilot. Use int for the two factors; leave the arithmetic unchanged.

The on-device reproducer returned -7144 instead of -1000 for (-1000, 32767). With the fix, all 65,535 tested numerators passed. The in-game recording showed a 55.7-degree roll jump while the phone was nearly stationary; an updated APK still needs an in-game retest.

Adds a test compiling the real egflight.c with unsigned char and checking all int16 numerators against seven signed divisors. All 31 local tests pass.