### PR TITLE
[review: high] Add keyboard and joystick controls mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/log.c
     ${SRC_DIR}/gfx_impl.c
     ${SRC_DIR}/joystick.c
+    ${SRC_DIR}/joystick_setup.c
     ${SRC_DIR}/hdsprite.c
 
     # start
@@ -463,6 +464,8 @@ add_behavior_test(geometry_behavior_tests LINK_CORE)
 add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
+add_behavior_test(joystick_behavior_tests LINK_CORE)
+set_tests_properties(joystick_behavior_tests PROPERTIES TIMEOUT 20)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)
 add_behavior_test(view_behavior_tests LINK_CORE)
 add_behavior_test(egsys_internal_behavior_tests LINK_CORE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/gfx_impl.c
     ${SRC_DIR}/joystick.c
     ${SRC_DIR}/joystick_setup.c
+    ${SRC_DIR}/joystick_mapping.cpp
     ${SRC_DIR}/hdsprite.c
 
     # start

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/joystick_setup.c
     ${SRC_DIR}/joystick_mapping.cpp
     ${SRC_DIR}/controls.cpp
+    ${SRC_DIR}/controls_mapping.cpp
     ${SRC_DIR}/hdsprite.c
 
     # start

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(F15SE2_SOURCES
     ${SRC_DIR}/joystick.c
     ${SRC_DIR}/joystick_setup.c
     ${SRC_DIR}/joystick_mapping.cpp
+    ${SRC_DIR}/controls.cpp
     ${SRC_DIR}/hdsprite.c
 
     # start
@@ -466,6 +467,8 @@ add_behavior_test(file_io_behavior_tests LINK_CORE)
 add_behavior_test(gameplay_behavior_tests LINK_CORE)
 add_behavior_test(input_behavior_tests LINK_CORE)
 add_behavior_test(joystick_behavior_tests LINK_CORE)
+add_behavior_test(controls_behavior_tests LINK_CORE)
+set_tests_properties(controls_behavior_tests PROPERTIES TIMEOUT 20)
 set_tests_properties(joystick_behavior_tests PROPERTIES TIMEOUT 20)
 add_behavior_test(gfx_render_behavior_tests LINK_CORE)
 add_behavior_test(view_behavior_tests LINK_CORE)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Development journal: https://neuviemeporte.github.io/category/f15-se2
 
 The entire game is playable, rendering and input handling is ported to SDL, sound works using Adlib emulation through [Nuked-OPL3](https://github.com/nukeykt/Nuked-OPL3) and joystick/gamepad input is supported (though not configurable right now). Multiple improvements have been implemented including high resolution and widescreen support with some bugs from the original having been fixed too. Work is ongoing to add more features and eliminate bugs.
 
-## Raw joystick controls
+## Controls mapping
 
 Linux/SDL supplies calibrated axis values; no in-game calibration is needed.
 Mapped gamepads retain their existing layout. Other joysticks get these defaults,
@@ -58,15 +58,26 @@ For example, `F15_JOY_CANNON=2 F15_JOY_MISSILE=1 ./build/f15se2-ex --game /path/
 exchanges missile and cannon buttons. These settings apply to the active raw
 joystick, not mapped gamepads.
 
-When a raw joystick is connected at startup, the game shows a button setup
-screen using its original bitmap fonts. Continue is selected initially: press
-any joystick button to save and play. Move the stick up/down or left/right
-to select an action, then press the desired joystick button to assign it.
-Keyboard arrows also select actions. Press the currently assigned button again
-(or Delete) to unassign it; assigning an occupied button swaps the actions.
-Select Continue and press any joystick button, or press Enter/Escape, to save
-and play. If saving fails, the screen reports it; Continue again plays without
-saving. Mapped gamepads retain their existing bindings and skip this screen.
+At startup, Controls Setup shows a scrolling list of flight actions using the
+original bitmap fonts, even without a joystick. Existing keyboard shortcuts are
+the defaults, including modifier chords and arrow/keypad steering. Cycle weapon,
+cycle view, and alternating countermeasures have no keyboard shortcut until assigned.
+
+- Up/down arrows or the stick select an action; left/right arrows select the
+  keyboard or joystick column.
+- In the keyboard column, press Enter, then the desired key or modifier chord.
+  Escape cancels capture. Alt+Enter remains reserved for fullscreen.
+- Press a raw joystick button to assign it to the selected action. Pressing its
+  current assignment again clears it. Assigning an occupied key or button swaps
+  the two actions.
+- Delete clears the selected column. Reset Defaults restores keyboard shortcuts
+  and the active stick's default buttons; Continue saves the result.
+- Continue is selected initially: Enter or any raw joystick button saves and
+  plays. Escape also finishes setup. If saving fails, Continue again plays unsaved.
+
+Mapped gamepads retain their existing flight layout. Menu navigation and
+pilot-name typing are not remapped. Training-only actions still require training
+mode, and legacy calibration remains a no-op with SDL-calibrated devices.
 
 Button mappings are saved per SDL device GUID and control counts in SDL's user
 settings directory (`f15se2-ex/joystick`), not in the game-assets directory.
@@ -75,6 +86,9 @@ Identical devices with the same GUID and counts share a profile. Set
 button numbers (zero disables an action). Loading applies defaults, then saved
 bindings, then explicit environment overrides. Invalid files leave defaults
 unchanged. Throttle-axis selection remains automatic or environment-configured.
+Keyboard bindings use a separate `keyboard.txt` in the same directory and apply
+across devices. The file stores SDL physical scancodes and modifier masks, not
+localized text. Reset Defaults does not change throttle-axis configuration.
 
 In the other menus, move the stick to select, press physical button 1 to
 confirm, or button 2 to go back. These menu controls are independent of the

--- a/README.md
+++ b/README.md
@@ -53,13 +53,22 @@ exchanges missile and cannon buttons. These settings apply to the active raw
 joystick, not mapped gamepads.
 
 When a raw joystick is connected at startup, the game shows a button setup
-screen using its original bitmap fonts. Move the stick up/down or left/right
+screen using its original bitmap fonts. Continue is selected initially: press
+any joystick button to save and play. Move the stick up/down or left/right
 to select an action, then press the desired joystick button to assign it.
-Keyboard arrows also select actions. Delete unassigns an action;
-assigning an occupied button swaps the actions. Press Enter (or Escape)
-to continue to the game. Changes last for
-the current game session; use the environment overrides above for repeatable
-launch settings. Mapped gamepads retain their existing bindings and skip this screen.
+Keyboard arrows also select actions. Press the currently assigned button again
+(or Delete) to unassign it; assigning an occupied button swaps the actions.
+Select Continue and press any joystick button, or press Enter/Escape, to save
+and play. If saving fails, the screen reports it; Continue again plays without
+saving. Mapped gamepads retain their existing bindings and skip this screen.
+
+Button mappings are saved per SDL device GUID and control counts in SDL's user
+settings directory (`f15se2-ex/joystick`), not in the game-assets directory.
+Identical devices with the same GUID and counts share a profile. Set
+`F15_JOY_CONFIG_DIR` to choose another directory. The text format uses one-based
+button numbers (zero disables an action). Loading applies defaults, then saved
+bindings, then explicit environment overrides. Invalid files leave defaults
+unchanged. Throttle-axis selection remains automatic or environment-configured.
 
 In the other menus, move the stick to select, press physical button 1 to
 confirm, or button 2 to go back. These menu controls are independent of the

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ limited to the buttons actually available:
 | 4 | Cycle Sidewinder, medium-range missile, Maverick |
 | 5 | Increase thrust, when no throttle axis is configured |
 | 6 | Decrease thrust, when no throttle axis is configured |
+| 7 | Toggle landing gear |
+| 8 | Toggle autopilot |
+| 9 | Next target |
+| 10 | Cycle cockpit / external follow / dynamic / side views |
 
 On Linux, an axis reported by the driver as throttle is assigned automatically,
 regardless of joystick model. If this metadata is unavailable (including on
@@ -46,7 +50,9 @@ default lever direction. Keyboard controls remain available on smaller sticks.
 
 Button overrides are `F15_JOY_MISSILE`, `F15_JOY_COUNTERMEASURE`,
 `F15_JOY_CANNON`, `F15_JOY_WEAPON`, `F15_JOY_THRUST_UP`, and
-`F15_JOY_THRUST_DOWN`. Values are one-based physical button numbers; `0`
+`F15_JOY_THRUST_DOWN`, `F15_JOY_GEAR`, `F15_JOY_AUTOPILOT`,
+`F15_JOY_TARGET`, and `F15_JOY_VIEW`.
+Values are one-based physical button numbers; `0`
 disables a binding. Assign distinct buttons to avoid overlapping actions.
 For example, `F15_JOY_CANNON=2 F15_JOY_MISSILE=1 ./build/f15se2-ex --game /path/to/game`
 exchanges missile and cannon buttons. These settings apply to the active raw

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ cycle view, and alternating countermeasures have no keyboard shortcut until assi
 - Up/down arrows or the stick select an action; left/right arrows select the
   keyboard or joystick column.
 - In the keyboard column, press Enter, then the desired key or modifier chord.
-  Escape cancels capture. Alt+Enter remains reserved for fullscreen.
+  Escape can also be assigned. Modifier keys alone are not assignments;
+  Alt+Enter remains reserved for fullscreen. Losing window focus cancels capture.
 - Press a raw joystick button to assign it to the selected action. Pressing its
   current assignment again clears it. Assigning an occupied key or button swaps
   the two actions.
@@ -89,6 +90,16 @@ unchanged. Throttle-axis selection remains automatic or environment-configured.
 Keyboard bindings use a separate `keyboard.txt` in the same directory and apply
 across devices. The file stores SDL physical scancodes and modifier masks, not
 localized text. Reset Defaults does not change throttle-axis configuration.
+
+Bluetooth remotes reported by SDL as keyboards use the keyboard column, including
+media keys, Select and Back when delivered as SDL scancodes. Select confirms and
+Back exits in menus; while capturing a binding they are assigned instead.
+Choose Continue to save, then the next startup restores the mapping. Unnamed
+scancodes are displayed as `Key <number>`; events without a scancode are ignored.
+Android TV may reserve Home, Power, volume or vendor-specific buttons before SDL
+receives them. Such buttons cannot be assigned here. Remotes reported as mapped
+gamepads still use the unchanged gamepad layout described above. This desktop PR
+alone does not add an Android build or change Android's event forwarding.
 
 In the other menus, move the stick to select, press physical button 1 to
 confirm, or button 2 to go back. These menu controls are independent of the

--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ limited to the buttons actually available:
 
 | Button | Action |
 | --- | --- |
-| 1 | Fire cannon (unchanged from upstream) |
-| 2 | Fire missile (unchanged from upstream) |
+| 1 | Fire cannon |
+| 2 | Fire missile |
 | 3 | Countermeasures: alternate chaff, flare, one per press |
 | 4 | Cycle Sidewinder, medium-range missile, Maverick |
 | 5 | Increase thrust, when no throttle axis is configured |
 | 6 | Decrease thrust, when no throttle axis is configured |
 
-The Saitek ST200's third axis is recognized as throttle. Other extra axes are
-not guessed: set `F15_JOY_THROTTLE_AXIS=3` to use the third axis, or `0` to
+On Linux, an axis reported by the driver as throttle is assigned automatically,
+regardless of joystick model. If this metadata is unavailable (including on
+other platforms), extra axes are not guessed: set `F15_JOY_THROTTLE_AXIS=3`
+to use the third axis, or `0` to
 disable it. Axes 1/2 remain roll/pitch. Throttle covers 0-100%; keyboard
 afterburner remains available. Set `F15_JOY_THROTTLE_INVERT=0` to reverse the
 default lever direction. Keyboard controls remain available on smaller sticks.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,48 @@ Development journal: https://neuviemeporte.github.io/category/f15-se2
 
 The entire game is playable, rendering and input handling is ported to SDL, sound works using Adlib emulation through [Nuked-OPL3](https://github.com/nukeykt/Nuked-OPL3) and joystick/gamepad input is supported (though not configurable right now). Multiple improvements have been implemented including high resolution and widescreen support with some bugs from the original having been fixed too. Work is ongoing to add more features and eliminate bugs.
 
+## Raw joystick controls
+
+Linux/SDL supplies calibrated axis values; no in-game calibration is needed.
+Mapped gamepads retain their existing layout. Other joysticks get these defaults,
+limited to the buttons actually available:
+
+| Button | Action |
+| --- | --- |
+| 1 | Fire cannon (unchanged from upstream) |
+| 2 | Fire missile (unchanged from upstream) |
+| 3 | Countermeasures: alternate chaff, flare, one per press |
+| 4 | Cycle Sidewinder, medium-range missile, Maverick |
+| 5 | Increase thrust, when no throttle axis is configured |
+| 6 | Decrease thrust, when no throttle axis is configured |
+
+The Saitek ST200's third axis is recognized as throttle. Other extra axes are
+not guessed: set `F15_JOY_THROTTLE_AXIS=3` to use the third axis, or `0` to
+disable it. Axes 1/2 remain roll/pitch. Throttle covers 0-100%; keyboard
+afterburner remains available. Set `F15_JOY_THROTTLE_INVERT=0` to reverse the
+default lever direction. Keyboard controls remain available on smaller sticks.
+
+Button overrides are `F15_JOY_MISSILE`, `F15_JOY_COUNTERMEASURE`,
+`F15_JOY_CANNON`, `F15_JOY_WEAPON`, `F15_JOY_THRUST_UP`, and
+`F15_JOY_THRUST_DOWN`. Values are one-based physical button numbers; `0`
+disables a binding. Assign distinct buttons to avoid overlapping actions.
+For example, `F15_JOY_CANNON=2 F15_JOY_MISSILE=1 ./build/f15se2-ex --game /path/to/game`
+exchanges missile and cannon buttons. These settings apply to the active raw
+joystick, not mapped gamepads.
+
+When a raw joystick is connected at startup, the game shows a button setup
+screen using its original bitmap fonts. Move the stick up/down or left/right
+to select an action, then press the desired joystick button to assign it.
+Keyboard arrows also select actions. Delete unassigns an action;
+assigning an occupied button swaps the actions. Press Enter (or Escape)
+to continue to the game. Changes last for
+the current game session; use the environment overrides above for repeatable
+launch settings. Mapped gamepads retain their existing bindings and skip this screen.
+
+In the other menus, move the stick to select, press physical button 1 to
+confirm, or button 2 to go back. These menu controls are independent of the
+flight assignments. Pilot-name text entry still uses the keyboard.
+
 ## Screenshots
 
 <div align="center">

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -3,8 +3,7 @@
 #include "egkeys.h"
 #include "egtypes.h"
 #include "egdata.h"
-#include "input.h"
-#include <fstream>
+#include "controls_mapping.h"
 
 static const ControlAction actions[RAW_ACTION_COUNT] = {
     {"cannon", "Fire cannon", SDL_SCANCODE_BACKSPACE, SDL_KMOD_NONE, SCAN_BACKSPACE, 0, 0},
@@ -74,8 +73,7 @@ static const ControlAction actions[RAW_ACTION_COUNT] = {
     {"kp_down_right", "Pitch up + right", SDL_SCANCODE_KP_3, SDL_KMOD_NONE, 0, 1, 1}
 };
 
-struct Binding { SDL_Scancode key; SDL_Keymod mod; };
-static Binding bindings[RAW_ACTION_COUNT] = {};
+static ControlBinding bindings[RAW_ACTION_COUNT] = {};
 static bool initialized = false;
 static int capture = -1;
 static bool nextFlare = false;
@@ -111,10 +109,12 @@ void controls_resetKeyboard(void) {
 const ControlAction &controls_action(RawAction action) { return actions[action]; }
 
 /* Only the two cycle actions depend on current game state. */
-Uint16 controls_command(RawAction action, int weapon, int view) {
+Uint16 controls_command(RawAction action, int weapon, int view, bool *countermeasureState) {
     if (action == RAW_COUNTERMEASURE) {
-        nextFlare = !nextFlare;
-        return nextFlare ? SCAN_C : SCAN_F;
+        bool &state = countermeasureState ? *countermeasureState : nextFlare;
+        const Uint16 command = state ? SCAN_F : SCAN_C;
+        state = !state;
+        return command;
     }
     if (action == RAW_WEAPON) return weapon == 0 ? SCAN_M : weapon == 1 ? SCAN_G : SCAN_S;
     if (action == RAW_VIEW) {
@@ -142,7 +142,7 @@ bool controls_bindKey(RawAction action, SDL_Scancode key, SDL_Keymod mod) {
 /* Render physical key names with normalized modifiers, independent of layout. */
 std::string controls_keyName(RawAction action) {
     if (!initialized) controls_resetKeyboard();
-    const Binding b = bindings[action];
+    const ControlBinding b = bindings[action];
     if (!b.key) return "-";
     return std::string(b.mod & SDL_KMOD_ALT ? "Alt+" : "") +
            (b.mod & SDL_KMOD_CTRL ? "Ctrl+" : "") +
@@ -178,51 +178,24 @@ void controls_applyAxes(Uint8 *x, Uint8 *y, bool joystick) {
     }
 }
 
-/* Keyboard mappings are global; raw joystick profiles remain per device. */
-std::string controls_keyboardPath(void) {
-    const char *overrideDir = SDL_getenv("F15_JOY_CONFIG_DIR");
-    char *pref = overrideDir ? nullptr : SDL_GetPrefPath("f15se2-ex", "joystick");
-    const std::string directory = overrideDir ? overrideDir : pref ? pref : "";
-    SDL_free(pref);
-    if (directory.empty() || !SDL_CreateDirectory(directory.c_str())) return {};
-    return directory + "/keyboard.txt";
+/* Export a value snapshot; persistence never accesses live arrays directly. */
+ControlBinding controls_keyboardBinding(RawAction action) {
+    if (!initialized) controls_resetKeyboard();
+    return bindings[action];
 }
 
-/* Parse atomically: invalid bindings never partially replace live controls. */
-bool controls_loadKeyboard(const std::string &path) {
-    std::ifstream file(path);
-    std::string name;
-    int version = 0;
-    Binding candidate[RAW_ACTION_COUNT] = {};
-    if (!(file >> name >> version) || name != "F15_KEYBOARD" || version != 1) return false;
+/* Reject a malformed profile as a unit, retaining current bindings on failure. */
+bool controls_replaceKeyboard(const ControlBinding *candidate) {
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
-        int key = 0, mod = 0;
-        if (!(file >> name >> key >> mod) || name != actions[i].name ||
-            key < 0 || key >= SDL_SCANCODE_COUNT || mod < 0 || mod > 0xffff) return false;
-        const SDL_Scancode sc = (SDL_Scancode)key;
-        const SDL_Keymod km = (SDL_Keymod)mod;
-        if (!validKey(sc, km) || canonical(sc) != sc || modifiers(km) != km || (!key && mod)) return false;
-        candidate[i] = {sc, km};
+        const ControlBinding b = candidate[i];
+        if (!validKey(b.key, b.mod) || canonical(b.key) != b.key ||
+            modifiers(b.mod) != b.mod || (!b.key && b.mod)) return false;
         for (int j = 0; j < i; ++j)
-            if (key && candidate[j].key == sc && candidate[j].mod == km) return false;
+            if (b.key && candidate[j].key == b.key && candidate[j].mod == b.mod) return false;
     }
-    if (file >> name || !file.eof()) return false;
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) bindings[i] = candidate[i];
     initialized = true;
     return true;
-}
-
-/* Replace the saved profile only after writing a complete temporary file. */
-bool controls_saveKeyboard(const std::string &path) {
-    if (!initialized) controls_resetKeyboard();
-    if (path.empty()) return false;
-    std::string data = "F15_KEYBOARD 1\n";
-    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
-        data += std::string(actions[i].name) + " " + std::to_string(bindings[i].key) + " " + std::to_string(bindings[i].mod) + "\n";
-    const std::string temp = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";
-    const bool saved = SDL_SaveFile(temp.c_str(), data.data(), data.size()) && SDL_RenamePath(temp.c_str(), path.c_str());
-    if (!saved) SDL_RemovePath(temp.c_str());
-    return saved;
 }
 
 /* Capture uses the existing event pump, never a competing SDL event loop. */

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -144,9 +144,11 @@ std::string controls_keyName(RawAction action) {
     if (!initialized) controls_resetKeyboard();
     const ControlBinding b = bindings[action];
     if (!b.key) return "-";
+    const char *name = SDL_GetScancodeName(b.key);
+    const std::string keyName = name && *name ? name : "Key " + std::to_string(b.key);
     return std::string(b.mod & SDL_KMOD_ALT ? "Alt+" : "") +
            (b.mod & SDL_KMOD_CTRL ? "Ctrl+" : "") +
-           (b.mod & SDL_KMOD_SHIFT ? "Shift+" : "") + SDL_GetScancodeName(b.key);
+           (b.mod & SDL_KMOD_SHIFT ? "Shift+" : "") + keyName;
 }
 
 /* Translate only flight keys. Suppress displaced defaults instead of leaving
@@ -202,11 +204,11 @@ bool controls_replaceKeyboard(const ControlBinding *candidate) {
 void controls_beginCapture(RawAction action) { capture = action; }
 bool controls_capturing(void) { return capture >= 0; }
 
-/* Escape cancels capture; modifier presses wait for the actual key. */
+/* Remotes can report Escape as a physical button, so capture it like any key.
+ * UNKNOWN is the stored unbound sentinel, not a usable input event. */
 bool controls_captureKey(const SDL_KeyboardEvent &event) {
     if (capture < 0) return false;
-    if (event.repeat) return true;
-    if (event.scancode == SDL_SCANCODE_ESCAPE) capture = -1;
-    else if (controls_bindKey((RawAction)capture, event.scancode, event.mod)) capture = -1;
+    if (event.repeat || event.scancode == SDL_SCANCODE_UNKNOWN) return true;
+    if (controls_bindKey((RawAction)capture, event.scancode, event.mod)) capture = -1;
     return true;
 }

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -1,0 +1,239 @@
+/* Flight bindings translate to existing game commands, not new game logic. */
+#include "controls.h"
+#include "egkeys.h"
+#include "egtypes.h"
+#include "egdata.h"
+#include "input.h"
+#include <fstream>
+
+static const ControlAction actions[RAW_ACTION_COUNT] = {
+    {"cannon", "Fire cannon", SDL_SCANCODE_BACKSPACE, SDL_KMOD_NONE, SCAN_BACKSPACE, 0, 0},
+    {"missile", "Fire missile", SDL_SCANCODE_RETURN, SDL_KMOD_NONE, SCAN_ENTER, 0, 0},
+    {"countermeasure", "Chaff / flare", SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE, 0, 0, 0},
+    {"weapon", "Cycle weapon", SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE, 0, 0, 0},
+    {"thrust_up", "Increase thrust", SDL_SCANCODE_EQUALS, SDL_KMOD_NONE, SCAN_EQUAL, 0, 0},
+    {"thrust_down", "Decrease thrust", SDL_SCANCODE_MINUS, SDL_KMOD_NONE, SCAN_MINUS, 0, 0},
+    {"gear", "Landing gear", SDL_SCANCODE_L, SDL_KMOD_NONE, SCAN_L, 0, 0},
+    {"autopilot", "Autopilot", SDL_SCANCODE_P, SDL_KMOD_NONE, SCAN_P, 0, 0},
+    {"target", "Next target", SDL_SCANCODE_T, SDL_KMOD_NONE, SCAN_T, 0, 0},
+    {"view", "Cycle 3D view", SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE, 0, 0, 0},
+    {"chaff", "Chaff", SDL_SCANCODE_C, SDL_KMOD_NONE, SCAN_C, 0, 0},
+    {"flare", "Flare", SDL_SCANCODE_F, SDL_KMOD_NONE, SCAN_F, 0, 0},
+    {"sidewinder", "Sidewinder", SDL_SCANCODE_S, SDL_KMOD_NONE, SCAN_S, 0, 0},
+    {"medium_missile", "Medium-range missile", SDL_SCANCODE_M, SDL_KMOD_NONE, SCAN_M, 0, 0},
+    {"maverick", "Maverick", SDL_SCANCODE_G, SDL_KMOD_NONE, SCAN_G, 0, 0},
+    {"afterburner", "Afterburner", SDL_SCANCODE_A, SDL_KMOD_NONE, SCAN_A, 0, 0},
+    {"full_thrust", "Full thrust", SDL_SCANCODE_EQUALS, SDL_KMOD_SHIFT, SCAN_SHIFT_EQUAL, 0, 0},
+    {"idle", "Idle thrust", SDL_SCANCODE_MINUS, SDL_KMOD_SHIFT, SCAN_SHIFT_MINUS, 0, 0},
+    {"brake", "Brake", SDL_SCANCODE_B, SDL_KMOD_NONE, SCAN_B, 0, 0},
+    {"radar", "Radar range", SDL_SCANCODE_R, SDL_KMOD_NONE, SCAN_R, 0, 0},
+    {"zoom_in", "Map zoom in", SDL_SCANCODE_Z, SDL_KMOD_NONE, SCAN_Z, 0, 0},
+    {"zoom_out", "Map zoom out", SDL_SCANCODE_X, SDL_KMOD_NONE, SCAN_X, 0, 0},
+    {"director", "Flight director", SDL_SCANCODE_D, SDL_KMOD_NONE, SCAN_D, 0, 0},
+    {"waypoint", "Next waypoint", SDL_SCANCODE_W, SDL_KMOD_NONE, SCAN_W, 0, 0},
+    {"cockpit", "Cockpit view", SDL_SCANCODE_SPACE, SDL_KMOD_NONE, SCAN_SPACEBAR, 0, 0},
+    {"forward", "Forward view", SDL_SCANCODE_F1, SDL_KMOD_NONE, SCAN_F1, 0, 0},
+    {"left_view", "Left view", SDL_SCANCODE_F2, SDL_KMOD_NONE, SCAN_F2, 0, 0},
+    {"right_view", "Right view", SDL_SCANCODE_F3, SDL_KMOD_NONE, SCAN_F3, 0, 0},
+    {"rear", "Rear view", SDL_SCANCODE_F4, SDL_KMOD_NONE, SCAN_F4, 0, 0},
+    {"follow", "External follow", SDL_SCANCODE_F5, SDL_KMOD_NONE, SCAN_F5, 0, 0},
+    {"dynamic", "External dynamic", SDL_SCANCODE_F6, SDL_KMOD_NONE, SCAN_F6, 0, 0},
+    {"side_view", "External side", SDL_SCANCODE_F7, SDL_KMOD_NONE, SCAN_F7, 0, 0},
+    {"missile_view", "Missile view", SDL_SCANCODE_F8, SDL_KMOD_NONE, SCAN_F8, 0, 0},
+    {"external_target", "External target", SDL_SCANCODE_F9, SDL_KMOD_NONE, SCAN_F9, 0, 0},
+    {"target_view", "Target view", SDL_SCANCODE_F10, SDL_KMOD_NONE, SCAN_F10, 0, 0},
+    {"eject", "Eject (press twice)", SDL_SCANCODE_ESCAPE, SDL_KMOD_NONE, SCAN_ESCAPE, 0, 0},
+    {"pause", "Pause", SDL_SCANCODE_P, SDL_KMOD_ALT, SCAN_ALT_P, 0, 0},
+    {"accel", "Time acceleration", SDL_SCANCODE_A, SDL_KMOD_ALT, SCAN_ALT_A, 0, 0},
+    {"sound", "Sound level", SDL_SCANCODE_V, SDL_KMOD_ALT, SCAN_ALT_V, 0, 0},
+    {"detail", "Detail level", SDL_SCANCODE_D, SDL_KMOD_ALT, SCAN_ALT_D, 0, 0},
+    {"sensitivity", "Keyboard sensitivity", SDL_SCANCODE_K, SDL_KMOD_ALT, SCAN_ALT_K, 0, 0},
+    {"night", "Night palette", SDL_SCANCODE_N, SDL_KMOD_ALT, SCAN_ALT_N, 0, 0},
+    {"training", "Training mode", SDL_SCANCODE_T, SDL_KMOD_ALT, SCAN_ALT_T, 0, 0},
+    {"end_mission", "End mission", SDL_SCANCODE_Q, SDL_KMOD_ALT, SCAN_ALT_Q, 0, 0},
+    {"boss", "Hide game / pause", SDL_SCANCODE_B, SDL_KMOD_ALT, SCAN_ALT_B, 0, 0},
+    {"calibrate", "Legacy calibration", SDL_SCANCODE_J, SDL_KMOD_ALT, SCAN_ALT_J, 0, 0},
+    {"memory", "Memory diagnostic", SDL_SCANCODE_M, SDL_KMOD_ALT, SCAN_ALT_M, 0, 0},
+    {"frame_time", "Frame time diagnostic", SDL_SCANCODE_F, SDL_KMOD_ALT, SCAN_ALT_F, 0, 0},
+    {"rearm", "Training: rearm", SDL_SCANCODE_R, SDL_KMOD_ALT, 0x1300, 0, 0},
+    {"map_north", "Training: map north", SDL_SCANCODE_S, SDL_KMOD_ALT, 0x1f00, 0, 0},
+    {"map_south", "Training: map south", SDL_SCANCODE_X, SDL_KMOD_ALT, 0x2d00, 0, 0},
+    {"map_west", "Training: map west", SDL_SCANCODE_Z, SDL_KMOD_ALT, 0x2c00, 0, 0},
+    {"map_east", "Training: map east", SDL_SCANCODE_C, SDL_KMOD_ALT, 0x2e00, 0, 0},
+    {"pitch_down", "Pitch down", SDL_SCANCODE_UP, SDL_KMOD_NONE, 0, 0, -1},
+    {"pitch_up", "Pitch up", SDL_SCANCODE_DOWN, SDL_KMOD_NONE, 0, 0, 1},
+    {"roll_left", "Roll left", SDL_SCANCODE_LEFT, SDL_KMOD_NONE, 0, -1, 0},
+    {"roll_right", "Roll right", SDL_SCANCODE_RIGHT, SDL_KMOD_NONE, 0, 1, 0},
+    {"kp_up", "Pitch down (keypad)", SDL_SCANCODE_KP_8, SDL_KMOD_NONE, 0, 0, -1},
+    {"kp_down", "Pitch up (keypad)", SDL_SCANCODE_KP_2, SDL_KMOD_NONE, 0, 0, 1},
+    {"kp_left", "Roll left (keypad)", SDL_SCANCODE_KP_4, SDL_KMOD_NONE, 0, -1, 0},
+    {"kp_right", "Roll right (keypad)", SDL_SCANCODE_KP_6, SDL_KMOD_NONE, 0, 1, 0},
+    {"kp_up_left", "Pitch down + left", SDL_SCANCODE_KP_7, SDL_KMOD_NONE, 0, -1, -1},
+    {"kp_up_right", "Pitch down + right", SDL_SCANCODE_KP_9, SDL_KMOD_NONE, 0, 1, -1},
+    {"kp_down_left", "Pitch up + left", SDL_SCANCODE_KP_1, SDL_KMOD_NONE, 0, -1, 1},
+    {"kp_down_right", "Pitch up + right", SDL_SCANCODE_KP_3, SDL_KMOD_NONE, 0, 1, 1}
+};
+
+struct Binding { SDL_Scancode key; SDL_Keymod mod; };
+static Binding bindings[RAW_ACTION_COUNT] = {};
+static bool initialized = false;
+static int capture = -1;
+static bool nextFlare = false;
+
+/* Ignore lock keys and collapse left/right modifier variants. */
+static SDL_Keymod modifiers(SDL_Keymod mod) {
+    return (SDL_Keymod)((mod & SDL_KMOD_ALT ? SDL_KMOD_ALT : 0) |
+                       (mod & SDL_KMOD_CTRL ? SDL_KMOD_CTRL : 0) |
+                       (mod & SDL_KMOD_SHIFT ? SDL_KMOD_SHIFT : 0));
+}
+
+/* Keypad Enter is the upstream alias for Return, including saved mappings. */
+static SDL_Scancode canonical(SDL_Scancode key) {
+    return key == SDL_SCANCODE_KP_ENTER ? SDL_SCANCODE_RETURN : key;
+}
+
+/* Reject modifier-only bindings and the window-level fullscreen shortcut. */
+static bool validKey(SDL_Scancode key, SDL_Keymod mod) {
+    return key >= SDL_SCANCODE_UNKNOWN && key < SDL_SCANCODE_COUNT &&
+           !(key >= SDL_SCANCODE_LCTRL && key <= SDL_SCANCODE_RGUI) &&
+           !(key == SDL_SCANCODE_RETURN && (mod & SDL_KMOD_ALT));
+}
+
+/* Defaults are also lazy-initialized for runtime isolation tests. */
+void controls_resetKeyboard(void) {
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) bindings[i] = {actions[i].key, actions[i].modifiers};
+    initialized = true;
+    capture = -1;
+    nextFlare = false;
+}
+
+/* Supply metadata without coupling storage or UI to flight globals. */
+const ControlAction &controls_action(RawAction action) { return actions[action]; }
+
+/* Only the two cycle actions depend on current game state. */
+Uint16 controls_command(RawAction action, int weapon, int view) {
+    if (action == RAW_COUNTERMEASURE) {
+        nextFlare = !nextFlare;
+        return nextFlare ? SCAN_C : SCAN_F;
+    }
+    if (action == RAW_WEAPON) return weapon == 0 ? SCAN_M : weapon == 1 ? SCAN_G : SCAN_S;
+    if (action == RAW_VIEW) {
+        if (view == VIEW_COCKPIT) return SCAN_F5;
+        if (view == VIEW_EXT_FOLLOW) return SCAN_F6;
+        if (view == VIEW_EXT_DYNAMIC) return SCAN_F7;
+        return SCAN_SPACEBAR;
+    }
+    return actions[action].command;
+}
+
+/* Swap conflicts, as joystick assignments do, so one key has one action. */
+bool controls_bindKey(RawAction action, SDL_Scancode key, SDL_Keymod mod) {
+    if (!initialized) controls_resetKeyboard();
+    key = canonical(key);
+    mod = key == SDL_SCANCODE_UNKNOWN ? SDL_KMOD_NONE : modifiers(mod);
+    if (action < 0 || action >= RAW_ACTION_COUNT || !validKey(key, mod)) return false;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
+        if (i != action && key != SDL_SCANCODE_UNKNOWN && bindings[i].key == key && bindings[i].mod == mod)
+            bindings[i] = bindings[action];
+    bindings[action] = {key, mod};
+    return true;
+}
+
+/* Render physical key names with normalized modifiers, independent of layout. */
+std::string controls_keyName(RawAction action) {
+    if (!initialized) controls_resetKeyboard();
+    const Binding b = bindings[action];
+    if (!b.key) return "-";
+    return std::string(b.mod & SDL_KMOD_ALT ? "Alt+" : "") +
+           (b.mod & SDL_KMOD_CTRL ? "Ctrl+" : "") +
+           (b.mod & SDL_KMOD_SHIFT ? "Shift+" : "") + SDL_GetScancodeName(b.key);
+}
+
+/* Translate only flight keys. Suppress displaced defaults instead of leaving
+ * them active as invisible extra bindings; unknown legacy keys still pass. */
+Uint16 controls_translateKey(SDL_Scancode key, SDL_Keymod mod, Uint16 fallback) {
+    if (!initialized) controls_resetKeyboard();
+    key = canonical(key);
+    mod = modifiers(mod);
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
+        if (key && bindings[i].key == key && bindings[i].mod == mod)
+            return controls_command((RawAction)i, missileSpecIndex, g_viewMode);
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
+        if (actions[i].key == key && actions[i].modifiers == mod) return 0;
+    return fallback;
+}
+
+/* Preserve the legacy ordering of arrow/keypad diagonals and held axes. */
+void controls_applyAxes(Uint8 *x, Uint8 *y, bool joystick) {
+    if (!initialized) controls_resetKeyboard();
+    const bool *keys = SDL_GetKeyboardState(nullptr);
+    const SDL_Keymod mod = modifiers(SDL_GetModState());
+    for (int i = RAW_PITCH_DOWN; i < RAW_ACTION_COUNT; ++i) {
+        const bool held = joystick ? joy_actionHeld((RawAction)i) :
+            bindings[i].key && keys[bindings[i].key] &&
+            (bindings[i].mod == mod || (bindings[i].key == actions[i].key && bindings[i].mod == SDL_KMOD_NONE));
+        if (!held) continue;
+        if (actions[i].x) *x = actions[i].x < 0 ? 0x26 : 0xda;
+        if (actions[i].y) *y = actions[i].y < 0 ? 0x26 : 0xda;
+    }
+}
+
+/* Keyboard mappings are global; raw joystick profiles remain per device. */
+std::string controls_keyboardPath(void) {
+    const char *overrideDir = SDL_getenv("F15_JOY_CONFIG_DIR");
+    char *pref = overrideDir ? nullptr : SDL_GetPrefPath("f15se2-ex", "joystick");
+    const std::string directory = overrideDir ? overrideDir : pref ? pref : "";
+    SDL_free(pref);
+    if (directory.empty() || !SDL_CreateDirectory(directory.c_str())) return {};
+    return directory + "/keyboard.txt";
+}
+
+/* Parse atomically: invalid bindings never partially replace live controls. */
+bool controls_loadKeyboard(const std::string &path) {
+    std::ifstream file(path);
+    std::string name;
+    int version = 0;
+    Binding candidate[RAW_ACTION_COUNT] = {};
+    if (!(file >> name >> version) || name != "F15_KEYBOARD" || version != 1) return false;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        int key = 0, mod = 0;
+        if (!(file >> name >> key >> mod) || name != actions[i].name ||
+            key < 0 || key >= SDL_SCANCODE_COUNT || mod < 0 || mod > 0xffff) return false;
+        const SDL_Scancode sc = (SDL_Scancode)key;
+        const SDL_Keymod km = (SDL_Keymod)mod;
+        if (!validKey(sc, km) || canonical(sc) != sc || modifiers(km) != km || (!key && mod)) return false;
+        candidate[i] = {sc, km};
+        for (int j = 0; j < i; ++j)
+            if (key && candidate[j].key == sc && candidate[j].mod == km) return false;
+    }
+    if (file >> name || !file.eof()) return false;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) bindings[i] = candidate[i];
+    initialized = true;
+    return true;
+}
+
+/* Replace the saved profile only after writing a complete temporary file. */
+bool controls_saveKeyboard(const std::string &path) {
+    if (!initialized) controls_resetKeyboard();
+    if (path.empty()) return false;
+    std::string data = "F15_KEYBOARD 1\n";
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
+        data += std::string(actions[i].name) + " " + std::to_string(bindings[i].key) + " " + std::to_string(bindings[i].mod) + "\n";
+    const std::string temp = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";
+    const bool saved = SDL_SaveFile(temp.c_str(), data.data(), data.size()) && SDL_RenamePath(temp.c_str(), path.c_str());
+    if (!saved) SDL_RemovePath(temp.c_str());
+    return saved;
+}
+
+/* Capture uses the existing event pump, never a competing SDL event loop. */
+void controls_beginCapture(RawAction action) { capture = action; }
+bool controls_capturing(void) { return capture >= 0; }
+
+/* Escape cancels capture; modifier presses wait for the actual key. */
+bool controls_captureKey(const SDL_KeyboardEvent &event) {
+    if (capture < 0) return false;
+    if (event.repeat) return true;
+    if (event.scancode == SDL_SCANCODE_ESCAPE) capture = -1;
+    else if (controls_bindKey((RawAction)capture, event.scancode, event.mod)) capture = -1;
+    return true;
+}

--- a/src/controls.h
+++ b/src/controls.h
@@ -1,0 +1,31 @@
+#ifndef F15_CONTROLS_H
+#define F15_CONTROLS_H
+
+#include "joystick.h"
+#include <string>
+
+/* One catalog is shared by setup, persistence and both input devices. Menu
+ * navigation, text entry and the global fullscreen shortcut are not remapped. */
+struct ControlAction {
+    const char *name;
+    const char *label;
+    SDL_Scancode key;
+    SDL_Keymod modifiers;
+    Uint16 command;
+    int x, y;
+};
+const ControlAction &controls_action(RawAction action);
+Uint16 controls_command(RawAction action, int weapon, int view);
+void controls_resetKeyboard(void);
+bool controls_bindKey(RawAction action, SDL_Scancode key, SDL_Keymod modifiers);
+std::string controls_keyName(RawAction action);
+Uint16 controls_translateKey(SDL_Scancode key, SDL_Keymod modifiers, Uint16 fallback);
+void controls_applyAxes(Uint8 *x, Uint8 *y, bool joystick);
+std::string controls_keyboardPath(void);
+bool controls_loadKeyboard(const std::string &path);
+bool controls_saveKeyboard(const std::string &path);
+void controls_beginCapture(RawAction action);
+bool controls_capturing(void);
+bool controls_captureKey(const SDL_KeyboardEvent &event);
+
+#endif

--- a/src/controls.h
+++ b/src/controls.h
@@ -15,7 +15,8 @@ struct ControlAction {
     int x, y;
 };
 const ControlAction &controls_action(RawAction action);
-Uint16 controls_command(RawAction action, int weapon, int view);
+/* Supply device-local state to preserve independent countermeasure sequences. */
+Uint16 controls_command(RawAction action, int weapon, int view, bool *nextFlare = nullptr);
 void controls_resetKeyboard(void);
 bool controls_bindKey(RawAction action, SDL_Scancode key, SDL_Keymod modifiers);
 std::string controls_keyName(RawAction action);

--- a/src/controls_mapping.cpp
+++ b/src/controls_mapping.cpp
@@ -1,0 +1,48 @@
+/* Keyboard profile parsing and storage, independent of the setup screen. */
+#include "controls_mapping.h"
+#include <fstream>
+
+/* Keyboard mappings are global; raw joystick profiles remain per device. */
+std::string controls_keyboardPath(void) {
+    const char *overrideDir = SDL_getenv("F15_JOY_CONFIG_DIR");
+    char *pref = overrideDir ? nullptr : SDL_GetPrefPath("f15se2-ex", "joystick");
+    const std::string directory = overrideDir ? overrideDir : pref ? pref : "";
+    SDL_free(pref);
+    if (directory.empty() || !SDL_CreateDirectory(directory.c_str())) return {};
+    return directory + "/keyboard.txt";
+}
+
+/* Parse atomically: invalid bindings never partially replace live controls. */
+bool controls_loadKeyboard(const std::string &path) {
+    std::ifstream file(path);
+    std::string name;
+    int version = 0;
+    ControlBinding candidate[RAW_ACTION_COUNT] = {};
+    if (!(file >> name >> version) || name != "F15_KEYBOARD" || version != 1) return false;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        int key = 0, mod = 0;
+        if (!(file >> name >> key >> mod) || name != controls_action((RawAction)i).name ||
+            key < 0 || key >= SDL_SCANCODE_COUNT || mod < 0 || mod > 0xffff) return false;
+        const SDL_Scancode sc = (SDL_Scancode)key;
+        const SDL_Keymod km = (SDL_Keymod)mod;
+        candidate[i] = {sc, km};
+    }
+    if (file >> name || !file.eof()) return false;
+    return controls_replaceKeyboard(candidate);
+}
+
+/* Replace the saved profile only after writing a complete temporary file. */
+bool controls_saveKeyboard(const std::string &path) {
+    if (path.empty()) return false;
+    std::string data = "F15_KEYBOARD 1\n";
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        const RawAction action = (RawAction)i;
+        const ControlBinding binding = controls_keyboardBinding(action);
+        data += std::string(controls_action(action).name) + " " + std::to_string(binding.key) + " " + std::to_string(binding.mod) + "\n";
+    }
+    const std::string temp = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";
+    const bool saved = SDL_SaveFile(temp.c_str(), data.data(), data.size()) && SDL_RenamePath(temp.c_str(), path.c_str());
+    if (!saved) SDL_RemovePath(temp.c_str());
+    return saved;
+}
+

--- a/src/controls_mapping.cpp
+++ b/src/controls_mapping.cpp
@@ -2,6 +2,9 @@
 #include "controls_mapping.h"
 #include <fstream>
 
+static const int keyboardProfileVersion = 1;
+static const int supportedModifierBits = SDL_KMOD_ALT | SDL_KMOD_CTRL | SDL_KMOD_SHIFT;
+
 /* Keyboard mappings are global; raw joystick profiles remain per device. */
 std::string controls_keyboardPath(void) {
     const char *overrideDir = SDL_getenv("F15_JOY_CONFIG_DIR");
@@ -18,11 +21,12 @@ bool controls_loadKeyboard(const std::string &path) {
     std::string name;
     int version = 0;
     ControlBinding candidate[RAW_ACTION_COUNT] = {};
-    if (!(file >> name >> version) || name != "F15_KEYBOARD" || version != 1) return false;
+    if (!(file >> name >> version) || name != "F15_KEYBOARD" || version != keyboardProfileVersion) return false;
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
         int key = 0, mod = 0;
         if (!(file >> name >> key >> mod) || name != controls_action((RawAction)i).name ||
-            key < 0 || key >= SDL_SCANCODE_COUNT || mod < 0 || mod > 0xffff) return false;
+            key < SDL_SCANCODE_UNKNOWN || key >= SDL_SCANCODE_COUNT ||
+            mod < 0 || (mod & ~supportedModifierBits) != 0) return false;
         const SDL_Scancode sc = (SDL_Scancode)key;
         const SDL_Keymod km = (SDL_Keymod)mod;
         candidate[i] = {sc, km};
@@ -34,7 +38,7 @@ bool controls_loadKeyboard(const std::string &path) {
 /* Replace the saved profile only after writing a complete temporary file. */
 bool controls_saveKeyboard(const std::string &path) {
     if (path.empty()) return false;
-    std::string data = "F15_KEYBOARD 1\n";
+    std::string data = "F15_KEYBOARD " + std::to_string(keyboardProfileVersion) + "\n";
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
         const RawAction action = (RawAction)i;
         const ControlBinding binding = controls_keyboardBinding(action);
@@ -45,4 +49,3 @@ bool controls_saveKeyboard(const std::string &path) {
     if (!saved) SDL_RemovePath(temp.c_str());
     return saved;
 }
-

--- a/src/controls_mapping.h
+++ b/src/controls_mapping.h
@@ -1,0 +1,15 @@
+#ifndef F15_CONTROLS_MAPPING_H
+#define F15_CONTROLS_MAPPING_H
+
+#include "controls.h"
+
+/* The storage boundary contains values only, not SDL events or game state.
+ * Replacement validates the entire profile before changing any live binding. */
+struct ControlBinding {
+    SDL_Scancode key;
+    SDL_Keymod mod;
+};
+ControlBinding controls_keyboardBinding(RawAction action);
+bool controls_replaceKeyboard(const ControlBinding *candidate);
+
+#endif

--- a/src/egflight.c
+++ b/src/egflight.c
@@ -19,6 +19,7 @@
 #include "comm.h"
 #include "eginput.h"
 #include "input.h"
+#include "joystick.h"
 
 #include <dos.h>
 #include <stdio.h>
@@ -99,6 +100,23 @@ void stepFlightModel(void) {
 
     while (kbhit()) {
         egReadKey(); // Flush keyboard buffer
+    }
+
+    /* Raw-stick commands bypass the keyboard flush above. Reuse the existing
+     * dispatch so keyboard and joystick actions have identical game effects. */
+    if (keyScancode == 0) {
+        keyScancode = joy_flightCommand(missileSpecIndex);
+        if (keyScancode != 0 && g_autopilotEngaged == 1) {
+            g_directorMode = g_autopilotEngaged = g_viewMode = VIEW_COCKPIT;
+        }
+    }
+    {
+        const int throttle = joy_throttleChange();
+        if (throttle >= 0 && g_inputDisabled == 0) {
+            g_setThrust = throttle;
+            UpdateThrottleState();
+            if (throttle > 0) g_playerPlaneFlags &= ~8;
+        }
     }
 
     // Main key dispatch logic

--- a/src/egflight.c
+++ b/src/egflight.c
@@ -105,7 +105,7 @@ void stepFlightModel(void) {
     /* Raw-stick commands bypass the keyboard flush above. Reuse the existing
      * dispatch so keyboard and joystick actions have identical game effects. */
     if (keyScancode == 0) {
-        keyScancode = joy_flightCommand(missileSpecIndex);
+        keyScancode = joy_flightCommand(missileSpecIndex, g_viewMode);
         if (keyScancode != 0 && g_autopilotEngaged == 1) {
             g_directorMode = g_autopilotEngaged = g_viewMode = VIEW_COCKPIT;
         }

--- a/src/f15.c
+++ b/src/f15.c
@@ -106,6 +106,7 @@ int main(int argc, char *argv[]) {
     game_init(showIntro);
     joy_init();
     input_setQuitHandler(app_quit);
+    joy_showSetup();
 
     while (true) {
         int err;

--- a/src/input.c
+++ b/src/input.c
@@ -478,9 +478,11 @@ static void menuKeyDown(const SDL_Event *ev) {
     switch (ev->key.key) {
     case SDLK_RETURN:
     case SDLK_KP_ENTER:
+    case SDLK_SELECT: /* Remote OK/select; capture still receives the original key. */
         ringPush(0x1c00 | KEYCODE_ENTER); /* AL = 0x0d */
         break;
     case SDLK_ESCAPE:
+    case SDLK_AC_BACK: /* Remote Back navigates menus, but is bindable in flight. */
         ringPush(0x0100 | KEYCODE_ESC); /* AL = 0x1b */
         break;
     case SDLK_BACKSPACE:

--- a/src/input.c
+++ b/src/input.c
@@ -41,11 +41,27 @@ static void (*g_quitHandler)(void) = NULL;
  * activity flips it back (see input_preferGamepad / noteGamepadActivity). */
 static bool g_lastWasGamepad = true;
 
+/* Menu controls have fixed meanings, independent of flight assignments. */
+static int g_rawMenuButton = -1;
+static int g_rawMenuZoneX = 0, g_rawMenuZoneY = 0;
+static Uint64 g_rawMenuRepeatX = 0, g_rawMenuRepeatY = 0;
+static bool g_joystickSetup = false;
+
+/* Flush transitions and remember held buttons so leaving setup cannot confirm
+ * the first game menu with the button just used to assign an action. */
+void input_setJoystickSetup(bool active) {
+    g_joystickSetup = active;
+    input_ringReset();
+}
+
 void input_setMode(InputMode mode) {
     /* Leaving text input on during flight lets a desktop IME intercept editing
      * keys it treats specially (Backspace fires the gun here) and intermittently
      * swallow or delay their auto-repeat. Only the menus need composed text. */
-    if (mode != g_mode) gfx_setTextInputEnabled(mode == INPUT_MODE_MENU);
+    if (mode != g_mode) {
+        gfx_setTextInputEnabled(mode == INPUT_MODE_MENU);
+        joy_resetFlightInput();
+    }
     g_mode = mode;
 }
 InputMode input_getMode(void) { return g_mode; }
@@ -73,6 +89,10 @@ void input_ringReset(void) {
     ringHead = ringTail = 0;
     g_joyRawX = 0x80;
     g_joyRawY = 0x80;
+    /* A held setup/confirm button must be released before the next screen can
+     * accept it, rather than immediately skipping that screen. */
+    g_rawMenuButton = joy_rawPressedButton();
+    g_rawMenuZoneX = g_rawMenuZoneY = 0;
 }
 
 bool input_keyWaiting(void) {
@@ -694,6 +714,26 @@ static void pollGamepadMenu(void) {
     stickArrowRepeat(joy_axisRaw(SDL_GAMEPAD_AXIS_LEFTY), KEYCODE_UPARROW, KEYCODE_DNARROW, &zoneY, &repY);
 }
 
+/* Raw flight sticks have no SDL gamepad mapping. Feed their primary axes into
+ * the same menu arrow repeater, with physical buttons 1/2 as confirm/back. */
+static void pollRawJoystickMenu(void) {
+    if (!input_hasFocus() || joy_rawButtonCount() <= 0) {
+        g_rawMenuButton = joy_rawPressedButton();
+        g_rawMenuZoneX = g_rawMenuZoneY = 0;
+        return;
+    }
+    const int button = joy_rawPressedButton();
+    if (button >= 0 && g_rawMenuButton < 0) {
+        if (button == 0) ringPush(0x1c00 | KEYCODE_ENTER);
+        if (button == 1) ringPush(0x0100 | KEYCODE_ESC);
+    }
+    g_rawMenuButton = button;
+    stickArrowRepeat(joy_rawMenuAxis(0), KEYCODE_LEFTARROW, KEYCODE_RIGHTARROW,
+                     &g_rawMenuZoneX, &g_rawMenuRepeatX);
+    stickArrowRepeat(joy_rawMenuAxis(1), KEYCODE_UPARROW, KEYCODE_DNARROW,
+                     &g_rawMenuZoneY, &g_rawMenuRepeatY);
+}
+
 /* --- the single event pump ------------------------------------------------- */
 
 void input_pumpEvents(void) {
@@ -723,6 +763,7 @@ void input_pumpEvents(void) {
             break;
         case SDL_EVENT_WINDOW_FOCUS_LOST:
             g_hasFocus = false;
+            joy_resetFlightInput();
             break;
         case SDL_EVENT_WINDOW_RESIZED:
         case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
@@ -768,8 +809,12 @@ void input_pumpEvents(void) {
 
     if (g_mode == INPUT_MODE_FLIGHT) {
         updateStick();
+        if (joy_rawActive()) g_lastWasGamepad = true;
         pollGamepadFlight();
     } else {
-        pollGamepadMenu();
+        if (!g_joystickSetup) {
+            pollGamepadMenu();
+            pollRawJoystickMenu();
+        }
     }
 }

--- a/src/input.c
+++ b/src/input.c
@@ -18,6 +18,7 @@
 #include "const.h"
 #include "gfx.h"
 #include "joystick.h"
+#include "controls.h"
 #include <SDL3/SDL.h>
 
 /* Game tick clock (timer.c); pumped here so the window stays responsive and the
@@ -500,33 +501,8 @@ static void menuKeyDown(const SDL_Event *ev) {
  * reproduces the same axis assignment and gives smooth diagonals for free.
  * Deflection matches the original first-press value (0x5A off centre). */
 static void updateStick(void) {
-    const bool *ks = SDL_GetKeyboardState(NULL);
-    const Uint8 LO = 0x26, HI = 0xDA; /* centre 0x80 -/+ 0x5A */
-    Uint8 x = 0x80;                   /* g_joyRawX = roll  (left = LO, right = HI) */
-    Uint8 y = 0x80;                   /* g_joyRawY = pitch (up   = LO, down  = HI) */
-
-    if (ks[SDL_SCANCODE_UP] || ks[SDL_SCANCODE_KP_8]) y = LO;
-    if (ks[SDL_SCANCODE_DOWN] || ks[SDL_SCANCODE_KP_2]) y = HI;
-    if (ks[SDL_SCANCODE_LEFT] || ks[SDL_SCANCODE_KP_4]) x = LO;
-    if (ks[SDL_SCANCODE_RIGHT] || ks[SDL_SCANCODE_KP_6]) x = HI;
-    /* Keypad diagonals deflect both axes at once. */
-    if (ks[SDL_SCANCODE_KP_7]) {
-        y = LO;
-        x = LO;
-    }
-    if (ks[SDL_SCANCODE_KP_9]) {
-        y = LO;
-        x = HI;
-    }
-    if (ks[SDL_SCANCODE_KP_1]) {
-        y = HI;
-        x = LO;
-    }
-    if (ks[SDL_SCANCODE_KP_3]) {
-        y = HI;
-        x = HI;
-    }
-
+    Uint8 x = 0x80, y = 0x80;
+    controls_applyAxes(&x, &y, false);
     g_joyRawX = x;
     g_joyRawY = y;
 }
@@ -774,6 +750,7 @@ void input_pumpEvents(void) {
             gfx_repaint();
             break;
         case SDL_EVENT_KEY_DOWN:
+            if (controls_captureKey(ev.key)) break;
             /* A real key hands flight control back to the keyboard (it stays
              * with the keyboard until the stick is moved again). */
             g_lastWasGamepad = false;
@@ -784,7 +761,8 @@ void input_pumpEvents(void) {
                 break;
             }
             if (g_mode == INPUT_MODE_FLIGHT) {
-                uint16 word = biosWord(ev.key.scancode, ev.key.mod);
+                uint16 word = controls_translateKey(ev.key.scancode, ev.key.mod,
+                                                     biosWord(ev.key.scancode, ev.key.mod));
                 if (word) ringPush(word);
             } else {
                 menuKeyDown(&ev);

--- a/src/input.h
+++ b/src/input.h
@@ -37,6 +37,9 @@ void input_pumpEvents(void);
 
 /* --- BIOS-style key ring (AH = scan code, AL = ASCII), shared by all phases - */
 void input_ringReset(void);  /* drop any queued keys, recentre stick */
+/* Setup reads physical joystick controls itself; keep keyboard/window events
+ * active without also translating those controls into menu commands. */
+void input_setJoystickSetup(bool active);
 bool input_keyWaiting(void); /* true when a key word is queued */
 uint16 input_readKey(void);  /* blocking pop: pump + wait, then return */
 

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -349,43 +349,10 @@ void joy_resetFlightInput(void) {
  * flight loop deliberately flushes that ring after reading its first key. */
 Uint16 joy_flightCommand(int selectedWeapon, int viewMode) {
     if (!g_joy || !input_hasFocus()) return 0;
-    if (g_rawPending[RAW_COUNTERMEASURE]) {
-        g_rawPending[RAW_COUNTERMEASURE] = false;
-        const Uint16 command = g_nextFlare ? SCAN_F : SCAN_C;
-        g_nextFlare = !g_nextFlare;
-        return command;
-    }
-    if (g_rawPending[RAW_WEAPON]) {
-        g_rawPending[RAW_WEAPON] = false;
-        return selectedWeapon == 0 ? SCAN_M : selectedWeapon == 1 ? SCAN_G : SCAN_S;
-    }
-    if (g_rawPending[RAW_GEAR]) {
-        g_rawPending[RAW_GEAR] = false;
-        return SCAN_L;
-    }
-    if (g_rawPending[RAW_AUTOPILOT]) {
-        g_rawPending[RAW_AUTOPILOT] = false;
-        return SCAN_P;
-    }
-    if (g_rawPending[RAW_TARGET]) {
-        g_rawPending[RAW_TARGET] = false;
-        return SCAN_T;
-    }
-    if (g_rawPending[RAW_VIEW]) {
-        g_rawPending[RAW_VIEW] = false;
-        /* Follow actual camera state, including changes made with the keyboard.
-         * Target/missile views return to the cockpit rather than losing sync. */
-        switch (viewMode) {
-        case VIEW_COCKPIT: return SCAN_F5;
-        case VIEW_EXT_FOLLOW: return SCAN_F6;
-        case VIEW_EXT_DYNAMIC: return SCAN_F7;
-        default: return SCAN_SPACEBAR;
-        }
-    }
-    for (int action = RAW_CHAFF; action < RAW_PITCH_DOWN; ++action) {
+    for (int action = RAW_COUNTERMEASURE; action < RAW_PITCH_DOWN; ++action) {
         if (g_rawPending[action]) {
             g_rawPending[action] = false;
-            return controls_command((RawAction)action, selectedWeapon, viewMode);
+            return controls_command((RawAction)action, selectedWeapon, viewMode, &g_nextFlare);
         }
     }
     const Uint64 now = SDL_GetTicks();

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -30,6 +30,7 @@
 #include "joystick.h"
 #include "joystick_axes.h"
 #include "joystick_mapping.h"
+#include "controls.h"
 #include "input.h"
 #include "inttype.h"
 #include "comm.h"
@@ -50,7 +51,7 @@ static SDL_Joystick *g_joy = NULL;
 static SDL_JoystickID g_devId = 0;
 
 static int g_rawButtons[RAW_ACTION_COUNT] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-static unsigned g_rawPending = 0;
+static bool g_rawPending[RAW_ACTION_COUNT] = {};
 static bool g_nextFlare = false;
 static int g_throttleAxis = -1;
 static bool g_throttleInvert = true;
@@ -87,13 +88,13 @@ static void configureRawJoystick(void) {
         "F15_JOY_GEAR", "F15_JOY_AUTOPILOT", "F15_JOY_TARGET", "F15_JOY_VIEW"
     };
     for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
-        int fallback = action < buttons ? action : -1;
+        int fallback = action <= RAW_VIEW && action < buttons ? action : -1;
         if ((action == RAW_THRUST_UP || action == RAW_THRUST_DOWN) && g_throttleAxis >= 0) fallback = -1;
         g_rawButtons[action] = fallback;
     }
     /* Precedence: defaults, saved device mapping, explicit launch overrides. */
     joy_loadMapping(joy_mappingPath(g_joy), buttons, g_rawButtons);
-    for (int action = 0; action < RAW_ACTION_COUNT; ++action)
+    for (int action = 0; action <= RAW_VIEW; ++action)
         g_rawButtons[action] = rawAssignment(names[action], g_rawButtons[action], buttons);
     LogInfo(("joystick: %d axes, %d buttons; throttle axis %d (0 = none)",
              axes, buttons, g_throttleAxis + 1));
@@ -105,6 +106,16 @@ bool joy_saveRawMapping(void) {
     return g_joy && joy_saveMapping(joy_mappingPath(g_joy), SDL_GetNumJoystickButtons(g_joy), g_rawButtons);
 }
 
+/* Reset button defaults without reloading profiles or changing the throttle. */
+void joy_resetRawMapping(void) {
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        g_rawButtons[i] = i <= RAW_VIEW && i < joy_rawButtonCount() ? i : -1;
+        if ((i == RAW_THRUST_UP || i == RAW_THRUST_DOWN) && g_throttleAxis >= 0)
+            g_rawButtons[i] = -1;
+    }
+    joy_resetFlightInput();
+}
+
 /* Setup uses the instance ID to stop safely if its device is replaced. */
 SDL_JoystickID joy_rawDeviceId(void) { return g_joy ? g_devId : 0; }
 
@@ -112,6 +123,11 @@ SDL_JoystickID joy_rawDeviceId(void) { return g_joy ? g_devId : 0; }
 static bool rawButton(RawAction action) {
     return g_joy && g_rawButtons[action] >= 0 &&
            SDL_GetJoystickButton(g_joy, g_rawButtons[action]);
+}
+
+/* Directional button polling shares the flight focus guard. */
+bool joy_actionHeld(RawAction action) {
+    return input_hasFocus() && action >= 0 && action < RAW_ACTION_COUNT && rawButton(action);
 }
 
 /* Idle slop on a raw stick can drift the menu cursor (the menus treat
@@ -136,7 +152,7 @@ static void joy_close(void) {
     g_pad = NULL;
     g_joy = NULL;
     g_devId = 0;
-    g_rawPending = 0;
+    SDL_memset(g_rawPending, 0, sizeof(g_rawPending));
     g_nextFlare = false;
     g_throttleAxis = -1;
     g_lastThrottle = -1;
@@ -207,10 +223,10 @@ void joy_handleEvent(const SDL_Event *ev) {
     switch (ev->type) {
     case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
         if (g_joy && ev->jbutton.which == g_devId && input_getMode() == INPUT_MODE_FLIGHT) {
-            for (int action = RAW_COUNTERMEASURE; action < RAW_ACTION_COUNT; ++action)
+            for (int action = RAW_COUNTERMEASURE; action < RAW_PITCH_DOWN; ++action)
                 if (action != RAW_THRUST_UP && action != RAW_THRUST_DOWN &&
                     ev->jbutton.button == g_rawButtons[action])
-                    g_rawPending |= 1u << action;
+                    g_rawPending[action] = true;
         }
         break;
     case SDL_EVENT_GAMEPAD_ADDED:
@@ -242,6 +258,7 @@ static void updateAxes(void) {
     } else {
         joyAxes[0] = joyAxes[1] = 0x80;
     }
+    controls_applyAxes(&joyAxes[0], &joyAxes[1], true);
 }
 
 /* True while fire button n is held. 0 = guns (right trigger, also the menus'
@@ -323,7 +340,7 @@ void joy_bindRawButton(RawAction action, int button) {
 
 /* Discard menu/focus-transition edges so they cannot fire cockpit commands. */
 void joy_resetFlightInput(void) {
-    g_rawPending = 0;
+    SDL_memset(g_rawPending, 0, sizeof(g_rawPending));
     g_lastThrottle = -1;
     g_rawRepeat[0] = g_rawRepeat[1] = 0;
 }
@@ -332,30 +349,30 @@ void joy_resetFlightInput(void) {
  * flight loop deliberately flushes that ring after reading its first key. */
 Uint16 joy_flightCommand(int selectedWeapon, int viewMode) {
     if (!g_joy || !input_hasFocus()) return 0;
-    if (g_rawPending & (1u << RAW_COUNTERMEASURE)) {
-        g_rawPending &= ~(1u << RAW_COUNTERMEASURE);
+    if (g_rawPending[RAW_COUNTERMEASURE]) {
+        g_rawPending[RAW_COUNTERMEASURE] = false;
         const Uint16 command = g_nextFlare ? SCAN_F : SCAN_C;
         g_nextFlare = !g_nextFlare;
         return command;
     }
-    if (g_rawPending & (1u << RAW_WEAPON)) {
-        g_rawPending &= ~(1u << RAW_WEAPON);
+    if (g_rawPending[RAW_WEAPON]) {
+        g_rawPending[RAW_WEAPON] = false;
         return selectedWeapon == 0 ? SCAN_M : selectedWeapon == 1 ? SCAN_G : SCAN_S;
     }
-    if (g_rawPending & (1u << RAW_GEAR)) {
-        g_rawPending &= ~(1u << RAW_GEAR);
+    if (g_rawPending[RAW_GEAR]) {
+        g_rawPending[RAW_GEAR] = false;
         return SCAN_L;
     }
-    if (g_rawPending & (1u << RAW_AUTOPILOT)) {
-        g_rawPending &= ~(1u << RAW_AUTOPILOT);
+    if (g_rawPending[RAW_AUTOPILOT]) {
+        g_rawPending[RAW_AUTOPILOT] = false;
         return SCAN_P;
     }
-    if (g_rawPending & (1u << RAW_TARGET)) {
-        g_rawPending &= ~(1u << RAW_TARGET);
+    if (g_rawPending[RAW_TARGET]) {
+        g_rawPending[RAW_TARGET] = false;
         return SCAN_T;
     }
-    if (g_rawPending & (1u << RAW_VIEW)) {
-        g_rawPending &= ~(1u << RAW_VIEW);
+    if (g_rawPending[RAW_VIEW]) {
+        g_rawPending[RAW_VIEW] = false;
         /* Follow actual camera state, including changes made with the keyboard.
          * Target/missile views return to the cockpit rather than losing sync. */
         switch (viewMode) {
@@ -363,6 +380,12 @@ Uint16 joy_flightCommand(int selectedWeapon, int viewMode) {
         case VIEW_EXT_FOLLOW: return SCAN_F6;
         case VIEW_EXT_DYNAMIC: return SCAN_F7;
         default: return SCAN_SPACEBAR;
+        }
+    }
+    for (int action = RAW_CHAFF; action < RAW_PITCH_DOWN; ++action) {
+        if (g_rawPending[action]) {
+            g_rawPending[action] = false;
+            return controls_command((RawAction)action, selectedWeapon, viewMode);
         }
     }
     const Uint64 now = SDL_GetTicks();

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -32,7 +32,9 @@
 #include "inttype.h"
 #include "comm.h"
 #include "log.h"
+#include "egkeys.h"
 #include <dos.h>
+#include <stdlib.h>
 
 /* joyAxes[0] = X (roll), joyAxes[1] = Y (pitch); 0x80 = centred. Defined in
  * stdata.c, shared by all three former programs. */
@@ -43,6 +45,59 @@ extern uint8 joyAxes[];
 static SDL_Gamepad *g_pad = NULL;
 static SDL_Joystick *g_joy = NULL;
 static SDL_JoystickID g_devId = 0;
+
+static int g_rawButtons[RAW_ACTION_COUNT] = {0, 1, 2, 3, 4, 5};
+static unsigned g_rawPending = 0;
+static bool g_nextFlare = false;
+static int g_throttleAxis = -1;
+static bool g_throttleInvert = true;
+static int g_lastThrottle = -1;
+static Uint64 g_rawRepeat[2] = {0, 0};
+
+/* Environment overrides use human-facing, one-based indices; zero disables
+ * an assignment. Reject malformed values rather than selecting another axis. */
+static int rawAssignment(const char *name, int fallback, int count) {
+    const char *value = SDL_getenv(name);
+    if (!value) return fallback;
+    char *end = NULL;
+    long index = strtol(value, &end, 10);
+    if (end == value || *end || index < 0 || index > count) {
+        LogInfo(("joystick: invalid %s='%s'; keeping default", name, value));
+        return fallback;
+    }
+    return (int)index - 1;
+}
+
+/* Only the ST200's known X/Y/throttle layout is inferred. Axis count alone
+ * cannot distinguish a throttle from a twist rudder on other devices. */
+static void configureRawJoystick(void) {
+    const int axes = SDL_GetNumJoystickAxes(g_joy);
+    const int buttons = SDL_GetNumJoystickButtons(g_joy);
+    const bool st200 = SDL_GetJoystickVendor(g_joy) == 0x06a3 &&
+                       SDL_GetJoystickProduct(g_joy) == 0x0502;
+    g_throttleAxis = rawAssignment("F15_JOY_THROTTLE_AXIS", st200 && axes == 3 ? 2 : -1, axes);
+    /* Never accidentally replace the primary flight stick with thrust. */
+    if (g_throttleAxis >= 0 && g_throttleAxis < 2) g_throttleAxis = -1;
+    const char *invert = SDL_getenv("F15_JOY_THROTTLE_INVERT");
+    g_throttleInvert = !invert || SDL_strcmp(invert, "0") != 0;
+    static const char *names[RAW_ACTION_COUNT] = {
+        "F15_JOY_CANNON", "F15_JOY_MISSILE", "F15_JOY_COUNTERMEASURE",
+        "F15_JOY_WEAPON", "F15_JOY_THRUST_UP", "F15_JOY_THRUST_DOWN"
+    };
+    for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
+        int fallback = action < buttons ? action : -1;
+        if (action >= RAW_THRUST_UP && g_throttleAxis >= 0) fallback = -1;
+        g_rawButtons[action] = rawAssignment(names[action], fallback, buttons);
+    }
+    LogInfo(("joystick: %d axes, %d buttons; throttle axis %d (0 = none)",
+             axes, buttons, g_throttleAxis + 1));
+}
+
+/* Fire is level-triggered; discrete actions below are latched from SDL edges. */
+static bool rawButton(RawAction action) {
+    return g_joy && g_rawButtons[action] >= 0 &&
+           SDL_GetJoystickButton(g_joy, g_rawButtons[action]);
+}
 
 /* Idle slop on a raw stick can drift the menu cursor (the menus treat
  * joyAxes outside 78..178 as a held direction), so snap a small band around
@@ -66,6 +121,11 @@ static void joy_close(void) {
     g_pad = NULL;
     g_joy = NULL;
     g_devId = 0;
+    g_rawPending = 0;
+    g_nextFlare = false;
+    g_throttleAxis = -1;
+    g_lastThrottle = -1;
+    g_rawRepeat[0] = g_rawRepeat[1] = 0;
     if (commData) commData->setupUseJoy = 0;
 }
 
@@ -84,6 +144,7 @@ static void joy_open(SDL_JoystickID id) {
         if (g_joy) {
             g_devId = id;
             LogInfo(("joystick: using joystick '%s'", SDL_GetJoystickName(g_joy)));
+            configureRawJoystick();
         }
     }
     if (g_devId && commData) commData->setupUseJoy = 1;
@@ -129,6 +190,13 @@ void joy_shutdown(void) {
  * (SDL_IsGamepad), leaving the raw path for sticks with no mapping. */
 void joy_handleEvent(const SDL_Event *ev) {
     switch (ev->type) {
+    case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
+        if (g_joy && ev->jbutton.which == g_devId && input_getMode() == INPUT_MODE_FLIGHT) {
+            for (int action = RAW_COUNTERMEASURE; action < RAW_THRUST_UP; ++action)
+                if (ev->jbutton.button == g_rawButtons[action])
+                    g_rawPending |= 1u << action;
+        }
+        break;
     case SDL_EVENT_GAMEPAD_ADDED:
         joy_open(ev->gdevice.which);
         break;
@@ -163,8 +231,8 @@ static void updateAxes(void) {
 /* True while fire button n is held. 0 = guns (right trigger, also the menus'
  * confirm button); 1 = missiles (left trigger). The face buttons A/B drive
  * other cockpit actions (brake / designate target) via eginput.c, so they are
- * deliberately not fire buttons. The raw fallback maps straight to physical
- * buttons 0 and 1. */
+ * deliberately not fire buttons. Raw sticks retain upstream's cannon-first,
+ * missile-second layout, with additional actions on the remaining buttons. */
 static int buttonDown(int n) {
     if (g_pad) {
         if (n == 0)
@@ -173,8 +241,9 @@ static int buttonDown(int n) {
             return SDL_GetGamepadAxis(g_pad, SDL_GAMEPAD_AXIS_LEFT_TRIGGER) > JOY_TRIGGER_THRESHOLD;
         return 0;
     }
-    if (g_joy && n < SDL_GetNumJoystickButtons(g_joy))
-        return SDL_GetJoystickButton(g_joy, n);
+    if (!input_hasFocus()) return 0;
+    if (n == 0) return rawButton(RAW_CANNON);
+    if (n == 1) return rawButton(RAW_MISSILE);
     return 0;
 }
 
@@ -186,6 +255,100 @@ bool joy_isGamepad(void) { return g_pad != NULL; }
 bool joy_connected(void) { return g_devId != 0; }
 bool joy_button(SDL_GamepadButton b) { return g_pad && SDL_GetGamepadButton(g_pad, b); }
 Sint16 joy_axisRaw(SDL_GamepadAxis a) { return g_pad ? SDL_GetGamepadAxis(g_pad, a) : 0; }
+
+/* A keyboard command must not permanently disconnect a raw flight stick.
+ * Ignore the throttle here: its off-centre resting value is not stick use. */
+bool joy_rawActive(void) {
+    if (!g_joy || !input_hasFocus()) return false;
+    for (int axis = 0; axis < 2 && axis < SDL_GetNumJoystickAxes(g_joy); ++axis)
+        if (SDL_abs((int)SDL_GetJoystickAxis(g_joy, axis)) > JOY_AXIS_DEADZONE) return true;
+    for (int action = 0; action < RAW_ACTION_COUNT; ++action)
+        if (rawButton((RawAction)action)) return true;
+    return false;
+}
+
+/* No raw device means no configurable buttons (mapped pads keep their layout). */
+int joy_rawButtonCount(void) {
+    return g_joy ? SDL_GetNumJoystickButtons(g_joy) : 0;
+}
+
+/* Setup waits for release before calling this to learn a fresh button press. */
+int joy_rawPressedButton(void) {
+    for (int button = 0; button < joy_rawButtonCount(); ++button)
+        if (SDL_GetJoystickButton(g_joy, button)) return button;
+    return -1;
+}
+
+/* Do not interpret optional throttle/rudder axes as menu directions. */
+Sint16 joy_rawMenuAxis(int axis) {
+    if (!g_joy || axis < 0 || axis > 1 || axis >= SDL_GetNumJoystickAxes(g_joy)) return 0;
+    return SDL_GetJoystickAxis(g_joy, axis);
+}
+
+/* Missing buttons are displayed as unassigned, including after unplugging. */
+int joy_rawBinding(RawAction action) {
+    if (action < 0 || action >= RAW_ACTION_COUNT) return -1;
+    const int button = g_rawButtons[action];
+    return button < joy_rawButtonCount() ? button : -1;
+}
+
+/* Swap conflicting assignments rather than firing two actions with one press. */
+void joy_bindRawButton(RawAction action, int button) {
+    if (action < 0 || action >= RAW_ACTION_COUNT || button < -1 || button >= joy_rawButtonCount()) return;
+    const int previous = g_rawButtons[action];
+    if (button >= 0) {
+        for (int other = 0; other < RAW_ACTION_COUNT; ++other)
+            if (other != action && g_rawButtons[other] == button)
+                g_rawButtons[other] = previous;
+    }
+    g_rawButtons[action] = button;
+    joy_resetFlightInput();
+}
+
+/* Discard menu/focus-transition edges so they cannot fire cockpit commands. */
+void joy_resetFlightInput(void) {
+    g_rawPending = 0;
+    g_lastThrottle = -1;
+    g_rawRepeat[0] = g_rawRepeat[1] = 0;
+}
+
+/* Consume one command per simulation step, outside the BIOS ring: the legacy
+ * flight loop deliberately flushes that ring after reading its first key. */
+Uint16 joy_flightCommand(int selectedWeapon) {
+    if (!g_joy || !input_hasFocus()) return 0;
+    if (g_rawPending & (1u << RAW_COUNTERMEASURE)) {
+        g_rawPending &= ~(1u << RAW_COUNTERMEASURE);
+        const Uint16 command = g_nextFlare ? SCAN_F : SCAN_C;
+        g_nextFlare = !g_nextFlare;
+        return command;
+    }
+    if (g_rawPending & (1u << RAW_WEAPON)) {
+        g_rawPending &= ~(1u << RAW_WEAPON);
+        return selectedWeapon == 0 ? SCAN_M : selectedWeapon == 1 ? SCAN_G : SCAN_S;
+    }
+    const Uint64 now = SDL_GetTicks();
+    for (int direction = 0; direction < 2; ++direction) {
+        if (!rawButton((RawAction)(RAW_THRUST_UP + direction))) {
+            g_rawRepeat[direction] = 0;
+        } else if (!g_rawRepeat[direction] || now >= g_rawRepeat[direction]) {
+            g_rawRepeat[direction] = now + (g_rawRepeat[direction] ? 100 : 250);
+            return direction == 0 ? SCAN_EQUAL : SCAN_MINUS;
+        }
+    }
+    return 0;
+}
+
+/* Only lever movement changes thrust, leaving keyboard afterburner/throttle
+ * usable. One-percent hysteresis suppresses resting axis noise. */
+int joy_throttleChange(void) {
+    if (!g_joy || g_throttleAxis < 0 || !input_hasFocus()) return -1;
+    const int raw = (int)SDL_GetJoystickAxis(g_joy, g_throttleAxis) + 32768;
+    const int percent = ((g_throttleInvert ? 65535 - raw : raw) * 100 + 32767) / 65535;
+    if (g_lastThrottle >= 0 && SDL_abs(percent - g_lastThrottle) < 2 &&
+        !(percent != g_lastThrottle && (percent == 0 || percent == 100))) return -1;
+    g_lastThrottle = percent;
+    return percent;
+}
 
 /* === game-facing joystick API (declared in egcode.h / stcode.h / slot.h) === */
 

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -29,6 +29,7 @@
  */
 #include "joystick.h"
 #include "joystick_axes.h"
+#include "joystick_mapping.h"
 #include "input.h"
 #include "inttype.h"
 #include "comm.h"
@@ -86,11 +87,24 @@ static void configureRawJoystick(void) {
     for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
         int fallback = action < buttons ? action : -1;
         if (action >= RAW_THRUST_UP && g_throttleAxis >= 0) fallback = -1;
-        g_rawButtons[action] = rawAssignment(names[action], fallback, buttons);
+        g_rawButtons[action] = fallback;
     }
+    /* Precedence: defaults, saved device mapping, explicit launch overrides. */
+    joy_loadMapping(joy_mappingPath(g_joy), buttons, g_rawButtons);
+    for (int action = 0; action < RAW_ACTION_COUNT; ++action)
+        g_rawButtons[action] = rawAssignment(names[action], g_rawButtons[action], buttons);
     LogInfo(("joystick: %d axes, %d buttons; throttle axis %d (0 = none)",
              axes, buttons, g_throttleAxis + 1));
 }
+
+/* Fire is level-triggered; discrete actions below are latched from SDL edges. */
+/* Only the setup's current raw device may be saved, never a mapped gamepad. */
+bool joy_saveRawMapping(void) {
+    return g_joy && joy_saveMapping(joy_mappingPath(g_joy), SDL_GetNumJoystickButtons(g_joy), g_rawButtons);
+}
+
+/* Setup uses the instance ID to stop safely if its device is replaced. */
+SDL_JoystickID joy_rawDeviceId(void) { return g_joy ? g_devId : 0; }
 
 /* Fire is level-triggered; discrete actions below are latched from SDL edges. */
 static bool rawButton(RawAction action) {

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -35,6 +35,7 @@
 #include "comm.h"
 #include "log.h"
 #include "egkeys.h"
+#include "egtypes.h"
 #include <dos.h>
 #include <stdlib.h>
 
@@ -48,7 +49,7 @@ static SDL_Gamepad *g_pad = NULL;
 static SDL_Joystick *g_joy = NULL;
 static SDL_JoystickID g_devId = 0;
 
-static int g_rawButtons[RAW_ACTION_COUNT] = {0, 1, 2, 3, 4, 5};
+static int g_rawButtons[RAW_ACTION_COUNT] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 static unsigned g_rawPending = 0;
 static bool g_nextFlare = false;
 static int g_throttleAxis = -1;
@@ -82,11 +83,12 @@ static void configureRawJoystick(void) {
     g_throttleInvert = !invert || SDL_strcmp(invert, "0") != 0;
     static const char *names[RAW_ACTION_COUNT] = {
         "F15_JOY_CANNON", "F15_JOY_MISSILE", "F15_JOY_COUNTERMEASURE",
-        "F15_JOY_WEAPON", "F15_JOY_THRUST_UP", "F15_JOY_THRUST_DOWN"
+        "F15_JOY_WEAPON", "F15_JOY_THRUST_UP", "F15_JOY_THRUST_DOWN",
+        "F15_JOY_GEAR", "F15_JOY_AUTOPILOT", "F15_JOY_TARGET", "F15_JOY_VIEW"
     };
     for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
         int fallback = action < buttons ? action : -1;
-        if (action >= RAW_THRUST_UP && g_throttleAxis >= 0) fallback = -1;
+        if ((action == RAW_THRUST_UP || action == RAW_THRUST_DOWN) && g_throttleAxis >= 0) fallback = -1;
         g_rawButtons[action] = fallback;
     }
     /* Precedence: defaults, saved device mapping, explicit launch overrides. */
@@ -205,8 +207,9 @@ void joy_handleEvent(const SDL_Event *ev) {
     switch (ev->type) {
     case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
         if (g_joy && ev->jbutton.which == g_devId && input_getMode() == INPUT_MODE_FLIGHT) {
-            for (int action = RAW_COUNTERMEASURE; action < RAW_THRUST_UP; ++action)
-                if (ev->jbutton.button == g_rawButtons[action])
+            for (int action = RAW_COUNTERMEASURE; action < RAW_ACTION_COUNT; ++action)
+                if (action != RAW_THRUST_UP && action != RAW_THRUST_DOWN &&
+                    ev->jbutton.button == g_rawButtons[action])
                     g_rawPending |= 1u << action;
         }
         break;
@@ -327,7 +330,7 @@ void joy_resetFlightInput(void) {
 
 /* Consume one command per simulation step, outside the BIOS ring: the legacy
  * flight loop deliberately flushes that ring after reading its first key. */
-Uint16 joy_flightCommand(int selectedWeapon) {
+Uint16 joy_flightCommand(int selectedWeapon, int viewMode) {
     if (!g_joy || !input_hasFocus()) return 0;
     if (g_rawPending & (1u << RAW_COUNTERMEASURE)) {
         g_rawPending &= ~(1u << RAW_COUNTERMEASURE);
@@ -338,6 +341,29 @@ Uint16 joy_flightCommand(int selectedWeapon) {
     if (g_rawPending & (1u << RAW_WEAPON)) {
         g_rawPending &= ~(1u << RAW_WEAPON);
         return selectedWeapon == 0 ? SCAN_M : selectedWeapon == 1 ? SCAN_G : SCAN_S;
+    }
+    if (g_rawPending & (1u << RAW_GEAR)) {
+        g_rawPending &= ~(1u << RAW_GEAR);
+        return SCAN_L;
+    }
+    if (g_rawPending & (1u << RAW_AUTOPILOT)) {
+        g_rawPending &= ~(1u << RAW_AUTOPILOT);
+        return SCAN_P;
+    }
+    if (g_rawPending & (1u << RAW_TARGET)) {
+        g_rawPending &= ~(1u << RAW_TARGET);
+        return SCAN_T;
+    }
+    if (g_rawPending & (1u << RAW_VIEW)) {
+        g_rawPending &= ~(1u << RAW_VIEW);
+        /* Follow actual camera state, including changes made with the keyboard.
+         * Target/missile views return to the cockpit rather than losing sync. */
+        switch (viewMode) {
+        case VIEW_COCKPIT: return SCAN_F5;
+        case VIEW_EXT_FOLLOW: return SCAN_F6;
+        case VIEW_EXT_DYNAMIC: return SCAN_F7;
+        default: return SCAN_SPACEBAR;
+        }
     }
     const Uint64 now = SDL_GetTicks();
     for (int direction = 0; direction < 2; ++direction) {

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -28,6 +28,7 @@
  * routes the game through the joystick paths above.
  */
 #include "joystick.h"
+#include "joystick_axes.h"
 #include "input.h"
 #include "inttype.h"
 #include "comm.h"
@@ -68,14 +69,12 @@ static int rawAssignment(const char *name, int fallback, int count) {
     return (int)index - 1;
 }
 
-/* Only the ST200's known X/Y/throttle layout is inferred. Axis count alone
- * cannot distinguish a throttle from a twist rudder on other devices. */
+/* Prefer a throttle identified by OS metadata. Axis count alone cannot
+ * distinguish a throttle from a twist rudder on other devices. */
 static void configureRawJoystick(void) {
     const int axes = SDL_GetNumJoystickAxes(g_joy);
     const int buttons = SDL_GetNumJoystickButtons(g_joy);
-    const bool st200 = SDL_GetJoystickVendor(g_joy) == 0x06a3 &&
-                       SDL_GetJoystickProduct(g_joy) == 0x0502;
-    g_throttleAxis = rawAssignment("F15_JOY_THROTTLE_AXIS", st200 && axes == 3 ? 2 : -1, axes);
+    g_throttleAxis = rawAssignment("F15_JOY_THROTTLE_AXIS", joy_detectThrottleAxis(g_joy), axes);
     /* Never accidentally replace the primary flight stick with thrust. */
     if (g_throttleAxis >= 0 && g_throttleAxis < 2) g_throttleAxis = -1;
     const char *invert = SDL_getenv("F15_JOY_THROTTLE_INVERT");

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -32,7 +32,8 @@ Sint16 joy_axisRaw(SDL_GamepadAxis a);
 
 /* Raw-stick priority bindings; command polling is once per flight step. */
 enum RawAction { RAW_CANNON, RAW_MISSILE, RAW_COUNTERMEASURE, RAW_WEAPON,
-                 RAW_THRUST_UP, RAW_THRUST_DOWN, RAW_ACTION_COUNT };
+                 RAW_THRUST_UP, RAW_THRUST_DOWN, RAW_GEAR, RAW_AUTOPILOT,
+                 RAW_TARGET, RAW_VIEW, RAW_ACTION_COUNT };
 /* Setup accesses only the active raw device, never a mapped gamepad. */
 int joy_rawButtonCount(void);
 int joy_rawPressedButton(void);
@@ -46,7 +47,7 @@ bool joy_saveRawMapping(void);
 SDL_JoystickID joy_rawDeviceId(void);
 bool joy_rawActive(void);
 void joy_resetFlightInput(void);
-Uint16 joy_flightCommand(int selectedWeapon);
+Uint16 joy_flightCommand(int selectedWeapon, int viewMode);
 /* Changed thrust percentage (0..100), or -1 when no lever update is pending. */
 int joy_throttleChange(void);
 

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -41,6 +41,9 @@ Sint16 joy_rawMenuAxis(int axis);
 int joy_rawBinding(RawAction action);
 void joy_bindRawButton(RawAction action, int button);
 void joy_showSetup(void);
+/* Persist the current raw device; false leaves the previous saved file intact. */
+bool joy_saveRawMapping(void);
+SDL_JoystickID joy_rawDeviceId(void);
 bool joy_rawActive(void);
 void joy_resetFlightInput(void);
 Uint16 joy_flightCommand(int selectedWeapon);

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -30,4 +30,21 @@ bool joy_button(SDL_GamepadButton b);
 /* Current gamepad axis value, -32768..32767 (0 unless a gamepad is active). */
 Sint16 joy_axisRaw(SDL_GamepadAxis a);
 
+/* Raw-stick priority bindings; command polling is once per flight step. */
+enum RawAction { RAW_CANNON, RAW_MISSILE, RAW_COUNTERMEASURE, RAW_WEAPON,
+                 RAW_THRUST_UP, RAW_THRUST_DOWN, RAW_ACTION_COUNT };
+/* Setup accesses only the active raw device, never a mapped gamepad. */
+int joy_rawButtonCount(void);
+int joy_rawPressedButton(void);
+/* Calibrated primary axes for setup navigation; zero if unavailable. */
+Sint16 joy_rawMenuAxis(int axis);
+int joy_rawBinding(RawAction action);
+void joy_bindRawButton(RawAction action, int button);
+void joy_showSetup(void);
+bool joy_rawActive(void);
+void joy_resetFlightInput(void);
+Uint16 joy_flightCommand(int selectedWeapon);
+/* Changed thrust percentage (0..100), or -1 when no lever update is pending. */
+int joy_throttleChange(void);
+
 #endif /* JOYSTICK_H */

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -33,7 +33,25 @@ Sint16 joy_axisRaw(SDL_GamepadAxis a);
 /* Raw-stick priority bindings; command polling is once per flight step. */
 enum RawAction { RAW_CANNON, RAW_MISSILE, RAW_COUNTERMEASURE, RAW_WEAPON,
                  RAW_THRUST_UP, RAW_THRUST_DOWN, RAW_GEAR, RAW_AUTOPILOT,
-                 RAW_TARGET, RAW_VIEW, RAW_ACTION_COUNT };
+                 RAW_TARGET, RAW_VIEW,
+                 RAW_CHAFF, RAW_FLARE, RAW_SIDEWINDER, RAW_AMRAAM, RAW_MAVERICK,
+                 RAW_AFTERBURNER, RAW_FULL_THRUST, RAW_IDLE, RAW_BRAKE,
+                 RAW_RADAR, RAW_ZOOM_IN, RAW_ZOOM_OUT, RAW_DIRECTOR, RAW_WAYPOINT,
+                 RAW_COCKPIT, RAW_FORWARD, RAW_LEFT_VIEW, RAW_RIGHT_VIEW, RAW_REAR,
+                 RAW_FOLLOW, RAW_DYNAMIC, RAW_SIDE_VIEW, RAW_MISSILE_VIEW,
+                 RAW_EXTERNAL_TARGET, RAW_TARGET_VIEW, RAW_EJECT, RAW_PAUSE,
+                 RAW_ACCEL, RAW_SOUND, RAW_DETAIL, RAW_SENSITIVITY, RAW_NIGHT,
+                 RAW_TRAINING, RAW_END_MISSION, RAW_BOSS, RAW_CALIBRATE,
+                 RAW_MEMORY, RAW_FRAME_TIME, RAW_REARM, RAW_MAP_NORTH,
+                 RAW_MAP_SOUTH, RAW_MAP_WEST, RAW_MAP_EAST,
+                 RAW_PITCH_DOWN, RAW_PITCH_UP, RAW_ROLL_LEFT, RAW_ROLL_RIGHT,
+                 RAW_KP_UP, RAW_KP_DOWN, RAW_KP_LEFT, RAW_KP_RIGHT,
+                 RAW_KP_UP_LEFT, RAW_KP_UP_RIGHT, RAW_KP_DOWN_LEFT, RAW_KP_DOWN_RIGHT,
+                 RAW_ACTION_COUNT };
+/* Reset the active raw device, without loading its saved profile or overrides. */
+void joy_resetRawMapping(void);
+/* Held directional buttons supplement the physical stick axes. */
+bool joy_actionHeld(RawAction action);
 /* Setup accesses only the active raw device, never a mapped gamepad. */
 int joy_rawButtonCount(void);
 int joy_rawPressedButton(void);

--- a/src/joystick_axes.h
+++ b/src/joystick_axes.h
@@ -1,0 +1,65 @@
+/* SDL exposes raw axis indices, but not their hardware meanings. Linux names
+ * those axes in evdev/joydev metadata. Query metadata only: SDL still owns
+ * calibration and all input events. Other platforms keep the explicit override. */
+#ifndef F15_JOYSTICK_AXES_H
+#define F15_JOYSTICK_AXES_H
+
+#include <SDL3/SDL.h>
+
+#ifdef __linux__
+#include <fcntl.h>
+#include <linux/input.h>
+#include <linux/joystick.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+/* joydev includes hats in its axis map; SDL removes them from analog indices.
+ * evdev entries supplied below precede all hat codes, so the same rule applies. */
+static inline int joy_linuxThrottleIndex(const unsigned char *codes, int count) {
+    int axis = 0;
+    for (int i = 0; i < count; ++i) {
+        if (codes[i] >= ABS_HAT0X && codes[i] <= ABS_HAT3Y) continue;
+        if (codes[i] == ABS_THROTTLE) return axis;
+        ++axis;
+    }
+    return -1;
+}
+#endif
+
+/* Read the same device SDL opened. Failure, virtual devices, and unnamed axes
+ * deliberately return "unknown", never guessing that a third axis is thrust. */
+static inline int joy_detectThrottleAxis(SDL_Joystick *joystick) {
+#ifdef __linux__
+    const char *path = SDL_GetJoystickPath(joystick);
+    if (!path) return -1;
+    const int fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    if (fd < 0) return -1;
+    unsigned char codes[ABS_CNT] = {};
+    unsigned char bits[(ABS_CNT + 7) / 8] = {};
+    int count = 0;
+    if (ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(bits)), bits) >= 0) {
+        /* SDL's evdev backend enumerates supported codes in ascending order,
+         * skipping codes whose EVIOCGABS query fails. ABS_THROTTLE is below
+         * ABS_HAT0X, so hat classification cannot affect its axis index. */
+        for (int code = 0; code <= ABS_THROTTLE; ++code) {
+            struct input_absinfo info = {};
+            if ((bits[code / 8] & (1u << (code % 8))) &&
+                ioctl(fd, EVIOCGABS(code), &info) >= 0)
+                codes[count++] = (unsigned char)code;
+        }
+    } else {
+        unsigned char axes = 0;
+        if (ioctl(fd, JSIOCGAXES, &axes) >= 0 && axes <= ABS_CNT &&
+            ioctl(fd, JSIOCGAXMAP, codes) >= 0)
+            count = axes;
+    }
+    close(fd);
+    const int axis = joy_linuxThrottleIndex(codes, count);
+    return axis < SDL_GetNumJoystickAxes(joystick) ? axis : -1;
+#else
+    (void)joystick;
+    return -1;
+#endif
+}
+
+#endif

--- a/src/joystick_mapping.cpp
+++ b/src/joystick_mapping.cpp
@@ -4,6 +4,13 @@
 #include "controls.h"
 #include <fstream>
 
+/* Versions added action groups; old profiles leave later actions unassigned. */
+enum JoystickProfileVersion {
+    PROFILE_BASIC_ACTIONS = 1,
+    PROFILE_GEAR_AND_VIEWS = 2,
+    PROFILE_ALL_ACTIONS = 3
+};
+
 /* Reject out-of-range and duplicate assignments as a unit, not partially. */
 static bool validMapping(int count, const int *buttons) {
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
@@ -36,10 +43,12 @@ bool joy_loadMapping(const std::string &path, int count, int *buttons) {
     std::string name;
     int version = 0;
     int candidate[RAW_ACTION_COUNT] = {};
-    if (!(file >> name >> version) || name != "F15_JOYSTICK" || version < 1 || version > 3) return false;
+    if (!(file >> name >> version) || name != "F15_JOYSTICK" ||
+        version < PROFILE_BASIC_ACTIONS || version > PROFILE_ALL_ACTIONS) return false;
     /* Version 1 had six actions. Preserve them and leave new actions unassigned
      * so they cannot collide with buttons already chosen by the user. */
-    const int savedActions = version == 1 ? RAW_THRUST_DOWN + 1 : version == 2 ? RAW_VIEW + 1 : RAW_ACTION_COUNT;
+    const int savedActions = version == PROFILE_BASIC_ACTIONS ? RAW_THRUST_DOWN + 1 :
+                             version == PROFILE_GEAR_AND_VIEWS ? RAW_VIEW + 1 : RAW_ACTION_COUNT;
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) candidate[i] = -1;
     for (int i = 0; i < savedActions; ++i) {
         int button = 0;
@@ -55,7 +64,7 @@ bool joy_loadMapping(const std::string &path, int count, int *buttons) {
  * write fails. Unique temporary names avoid clobbering another running game. */
 bool joy_saveMapping(const std::string &path, int count, const int *buttons) {
     if (path.empty() || !validMapping(count, buttons)) return false;
-    std::string data = "F15_JOYSTICK 3\n";
+    std::string data = "F15_JOYSTICK " + std::to_string(PROFILE_ALL_ACTIONS) + "\n";
     for (int i = 0; i < RAW_ACTION_COUNT; ++i)
         data += std::string(controls_action((RawAction)i).name) + " " + std::to_string(buttons[i] + 1) + "\n";
     const std::string temporary = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";

--- a/src/joystick_mapping.cpp
+++ b/src/joystick_mapping.cpp
@@ -1,12 +1,8 @@
 /* Persistence is separate from input and UI. Profiles are deliberately small,
  * versioned text files; explicit environment bindings are applied after loading. */
 #include "joystick_mapping.h"
+#include "controls.h"
 #include <fstream>
-
-static const char *actionNames[RAW_ACTION_COUNT] = {
-    "cannon", "missile", "countermeasure", "weapon", "thrust_up", "thrust_down",
-    "gear", "autopilot", "target", "view"
-};
 
 /* Reject out-of-range and duplicate assignments as a unit, not partially. */
 static bool validMapping(int count, const int *buttons) {
@@ -40,14 +36,14 @@ bool joy_loadMapping(const std::string &path, int count, int *buttons) {
     std::string name;
     int version = 0;
     int candidate[RAW_ACTION_COUNT] = {};
-    if (!(file >> name >> version) || name != "F15_JOYSTICK" || (version != 1 && version != 2)) return false;
+    if (!(file >> name >> version) || name != "F15_JOYSTICK" || version < 1 || version > 3) return false;
     /* Version 1 had six actions. Preserve them and leave new actions unassigned
      * so they cannot collide with buttons already chosen by the user. */
-    const int savedActions = version == 1 ? RAW_THRUST_DOWN + 1 : RAW_ACTION_COUNT;
+    const int savedActions = version == 1 ? RAW_THRUST_DOWN + 1 : version == 2 ? RAW_VIEW + 1 : RAW_ACTION_COUNT;
     for (int i = 0; i < RAW_ACTION_COUNT; ++i) candidate[i] = -1;
     for (int i = 0; i < savedActions; ++i) {
         int button = 0;
-        if (!(file >> name >> button) || name != actionNames[i] || button < 0 || button > count) return false;
+        if (!(file >> name >> button) || name != controls_action((RawAction)i).name || button < 0 || button > count) return false;
         candidate[i] = button - 1;
     }
     if (file >> name || !file.eof() || !validMapping(count, candidate)) return false;
@@ -59,9 +55,9 @@ bool joy_loadMapping(const std::string &path, int count, int *buttons) {
  * write fails. Unique temporary names avoid clobbering another running game. */
 bool joy_saveMapping(const std::string &path, int count, const int *buttons) {
     if (path.empty() || !validMapping(count, buttons)) return false;
-    std::string data = "F15_JOYSTICK 2\n";
+    std::string data = "F15_JOYSTICK 3\n";
     for (int i = 0; i < RAW_ACTION_COUNT; ++i)
-        data += std::string(actionNames[i]) + " " + std::to_string(buttons[i] + 1) + "\n";
+        data += std::string(controls_action((RawAction)i).name) + " " + std::to_string(buttons[i] + 1) + "\n";
     const std::string temporary = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";
     const bool saved = SDL_SaveFile(temporary.c_str(), data.data(), data.size()) &&
                        SDL_RenamePath(temporary.c_str(), path.c_str());

--- a/src/joystick_mapping.cpp
+++ b/src/joystick_mapping.cpp
@@ -1,0 +1,65 @@
+/* Persistence is separate from input and UI. Profiles are deliberately small,
+ * versioned text files; explicit environment bindings are applied after loading. */
+#include "joystick_mapping.h"
+#include <fstream>
+
+static const char *actionNames[RAW_ACTION_COUNT] = {
+    "cannon", "missile", "countermeasure", "weapon", "thrust_up", "thrust_down"
+};
+
+/* Reject out-of-range and duplicate assignments as a unit, not partially. */
+static bool validMapping(int count, const int *buttons) {
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        if (buttons[i] < -1 || buttons[i] >= count) return false;
+        for (int j = 0; j < i; ++j)
+            if (buttons[i] >= 0 && buttons[i] == buttons[j]) return false;
+    }
+    return true;
+}
+
+/* SDL supplies a writable platform-specific directory. The optional directory
+ * override is also used by tests so they never alter a user's real mappings. */
+std::string joy_mappingPath(SDL_Joystick *joystick) {
+    if (!joystick) return {};
+    const char *overrideDir = SDL_getenv("F15_JOY_CONFIG_DIR");
+    char *pref = overrideDir ? nullptr : SDL_GetPrefPath("f15se2-ex", "joystick");
+    const std::string directory = overrideDir ? overrideDir : pref ? pref : "";
+    SDL_free(pref);
+    if (directory.empty() || !SDL_CreateDirectory(directory.c_str())) return {};
+    char guid[33] = {};
+    SDL_GUIDToString(SDL_GetJoystickGUID(joystick), guid, sizeof(guid));
+    return directory + "/" + guid + "-" + std::to_string(SDL_GetNumJoystickAxes(joystick)) +
+           "-" + std::to_string(SDL_GetNumJoystickButtons(joystick)) + ".txt";
+}
+
+/* Parse into a candidate first; missing, malformed, or future versions cannot
+ * overwrite valid defaults. Stored button numbers are one-based, zero is off. */
+bool joy_loadMapping(const std::string &path, int count, int *buttons) {
+    std::ifstream file(path);
+    std::string name;
+    int version = 0;
+    int candidate[RAW_ACTION_COUNT] = {};
+    if (!(file >> name >> version) || name != "F15_JOYSTICK" || version != 1) return false;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        int button = 0;
+        if (!(file >> name >> button) || name != actionNames[i] || button < 0 || button > count) return false;
+        candidate[i] = button - 1;
+    }
+    if (file >> name || !file.eof() || !validMapping(count, candidate)) return false;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) buttons[i] = candidate[i];
+    return true;
+}
+
+/* Rename within the same directory preserves the last saved mapping when a
+ * write fails. Unique temporary names avoid clobbering another running game. */
+bool joy_saveMapping(const std::string &path, int count, const int *buttons) {
+    if (path.empty() || !validMapping(count, buttons)) return false;
+    std::string data = "F15_JOYSTICK 1\n";
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
+        data += std::string(actionNames[i]) + " " + std::to_string(buttons[i] + 1) + "\n";
+    const std::string temporary = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";
+    const bool saved = SDL_SaveFile(temporary.c_str(), data.data(), data.size()) &&
+                       SDL_RenamePath(temporary.c_str(), path.c_str());
+    if (!saved) SDL_RemovePath(temporary.c_str());
+    return saved;
+}

--- a/src/joystick_mapping.cpp
+++ b/src/joystick_mapping.cpp
@@ -4,7 +4,8 @@
 #include <fstream>
 
 static const char *actionNames[RAW_ACTION_COUNT] = {
-    "cannon", "missile", "countermeasure", "weapon", "thrust_up", "thrust_down"
+    "cannon", "missile", "countermeasure", "weapon", "thrust_up", "thrust_down",
+    "gear", "autopilot", "target", "view"
 };
 
 /* Reject out-of-range and duplicate assignments as a unit, not partially. */
@@ -39,8 +40,12 @@ bool joy_loadMapping(const std::string &path, int count, int *buttons) {
     std::string name;
     int version = 0;
     int candidate[RAW_ACTION_COUNT] = {};
-    if (!(file >> name >> version) || name != "F15_JOYSTICK" || version != 1) return false;
-    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+    if (!(file >> name >> version) || name != "F15_JOYSTICK" || (version != 1 && version != 2)) return false;
+    /* Version 1 had six actions. Preserve them and leave new actions unassigned
+     * so they cannot collide with buttons already chosen by the user. */
+    const int savedActions = version == 1 ? RAW_THRUST_DOWN + 1 : RAW_ACTION_COUNT;
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) candidate[i] = -1;
+    for (int i = 0; i < savedActions; ++i) {
         int button = 0;
         if (!(file >> name >> button) || name != actionNames[i] || button < 0 || button > count) return false;
         candidate[i] = button - 1;
@@ -54,7 +59,7 @@ bool joy_loadMapping(const std::string &path, int count, int *buttons) {
  * write fails. Unique temporary names avoid clobbering another running game. */
 bool joy_saveMapping(const std::string &path, int count, const int *buttons) {
     if (path.empty() || !validMapping(count, buttons)) return false;
-    std::string data = "F15_JOYSTICK 1\n";
+    std::string data = "F15_JOYSTICK 2\n";
     for (int i = 0; i < RAW_ACTION_COUNT; ++i)
         data += std::string(actionNames[i]) + " " + std::to_string(buttons[i] + 1) + "\n";
     const std::string temporary = path + "." + std::to_string(SDL_GetPerformanceCounter()) + ".tmp";

--- a/src/joystick_mapping.h
+++ b/src/joystick_mapping.h
@@ -1,0 +1,14 @@
+#ifndef F15_JOYSTICK_MAPPING_H
+#define F15_JOYSTICK_MAPPING_H
+
+#include "joystick.h"
+#include <string>
+
+/* Profile identity includes SDL GUID and control counts, not the device path. */
+std::string joy_mappingPath(SDL_Joystick *joystick);
+/* Invalid/incomplete profiles leave the caller's defaults unchanged. */
+bool joy_loadMapping(const std::string &path, int count, int *buttons);
+/* Replace a complete profile only after successfully writing its temporary file. */
+bool joy_saveMapping(const std::string &path, int count, const int *buttons);
+
+#endif

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -63,6 +63,85 @@ static void drawJoystickSetup(int selected, int first, bool keyboard, bool saveF
     gfx_commitPage();
 }
 
+/* Only transient screen state lives here; saved bindings belong to controls. */
+struct SetupState {
+    int selected = continueRow;
+    int first = 0;
+    bool keyboard = true;
+    bool released = false;
+    bool deleteHeld = false;
+    bool saveFailed = false;
+    int stickZone = 0;
+    Uint64 repeatAt = 0;
+};
+
+/* Either stick axis navigates with the same dead zone and repeat timing. */
+static void navigateWithStick(SetupState &state) {
+    const int x = joy_rawMenuAxis(0), y = joy_rawMenuAxis(1);
+    const int axis = SDL_abs(y) >= SDL_abs(x) ? y : x;
+    const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
+    const Uint64 now = SDL_GetTicks();
+    if (zone && (zone != state.stickZone || now >= state.repeatAt)) {
+        state.selected = (state.selected + zone + RAW_ACTION_COUNT + 2) % (RAW_ACTION_COUNT + 2);
+        state.repeatAt = now + (zone != state.stickZone ? 400 : 200);
+    }
+    state.stickZone = zone;
+}
+
+/* Consume menu keys, never flight bindings. Escape requests save-and-play. */
+static bool navigateWithKeyboard(SetupState &state, bool &activate) {
+    bool finish = false;
+    while (input_keyWaiting()) {
+        const uint16 key = input_readKey();
+        if ((key & 255) == KEYCODE_ESC) finish = true;
+        else if ((key & 255) == KEYCODE_ENTER) activate = true;
+        else if (key == KEYCODE_UPARROW) state.selected = (state.selected + RAW_ACTION_COUNT + 1) % (RAW_ACTION_COUNT + 2);
+        else if (key == KEYCODE_DNARROW) state.selected = (state.selected + 1) % (RAW_ACTION_COUNT + 2);
+        else if (key == KEYCODE_LEFTARROW) state.keyboard = true;
+        else if (key == KEYCODE_RIGHTARROW) state.keyboard = false;
+    }
+    return finish;
+}
+
+/* A fresh button assigns the row, or activates Continue/Reset. */
+static void assignJoystickButton(SetupState &state, bool &activate) {
+    const int pressed = joy_rawPressedButton();
+    if (pressed < 0) state.released = true;
+    else if (state.released) {
+        if (state.selected >= RAW_ACTION_COUNT) activate = true;
+        else {
+            state.keyboard = false;
+            const RawAction action = (RawAction)state.selected;
+            joy_bindRawButton(action, joy_rawBinding(action) == pressed ? -1 : pressed);
+        }
+        state.released = false;
+    }
+}
+
+/* Start capture or restore defaults; only Continue asks the caller to finish. */
+static bool activateSelection(SetupState &state) {
+    if (state.selected == continueRow) return true;
+    if (state.selected == resetRow) {
+        controls_resetKeyboard();
+        joy_resetRawMapping();
+        state.saveFailed = false;
+    } else if (state.keyboard) {
+        controls_beginCapture((RawAction)state.selected);
+        input_ringReset();
+    }
+    return false;
+}
+
+/* A failed save leaves the screen open; a second Continue permits playing
+ * unsaved. Both independent profiles are attempted even if one fails. */
+static bool saveAndContinue(SetupState &state, const std::string &keyboardPath) {
+    const bool keysSaved = state.saveFailed || controls_saveKeyboard(keyboardPath);
+    const bool stickSaved = state.saveFailed || !joy_rawDeviceId() || joy_saveRawMapping();
+    state.saveFailed = !(keysSaved && stickSaved);
+    state.selected = continueRow;
+    return !state.saveFailed;
+}
+
 /* Keyboard setup is available without a joystick. A hotplugged device keeps
  * its own profile; losing a stick does not prevent continuing with keys. */
 void joy_showSetup(void) {
@@ -78,28 +157,22 @@ void joy_showSetup(void) {
      * same color indices different RGB values, unlike the surrounding menus. */
     gfx_setDac(1);
     SDL_JoystickID device = joy_rawDeviceId();
-    int selected = continueRow;
-    int first = 0;
-    bool keyboard = true;
-    bool released = joy_rawPressedButton() < 0;
-    bool deleteHeld = false;
+    SetupState state;
+    state.released = joy_rawPressedButton() < 0;
     bool finished = false;
-    bool saveFailed = false;
-    int stickZone = 0;
-    Uint64 repeatAt = 0;
-    drawJoystickSetup(selected, first, keyboard, saveFailed);
+    drawJoystickSetup(state.selected, state.first, state.keyboard, state.saveFailed);
     while (!finished && !input_quitRequested()) {
         const bool wasCapturing = controls_capturing();
         input_pumpEvents();
         if (joy_rawDeviceId() != device) {
             device = joy_rawDeviceId();
-            released = false;
+            state.released = false;
         }
         if (!input_hasFocus()) {
             controls_beginCapture((RawAction)-1);
             input_ringReset();
-            released = false;
-            stickZone = 0;
+            state.released = false;
+            state.stickZone = 0;
             SDL_Delay(20);
             continue;
         }
@@ -107,67 +180,26 @@ void joy_showSetup(void) {
         bool continueRequested = false;
         const bool deleteNow = SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_DELETE];
         if (!wasCapturing && !controls_capturing()) {
-            if (deleteNow && !deleteHeld && selected < RAW_ACTION_COUNT) {
-                if (keyboard) controls_bindKey((RawAction)selected, SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE);
-                else joy_bindRawButton((RawAction)selected, -1);
+            if (deleteNow && !state.deleteHeld && state.selected < RAW_ACTION_COUNT) {
+                if (state.keyboard) controls_bindKey((RawAction)state.selected, SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE);
+                else joy_bindRawButton((RawAction)state.selected, -1);
             }
-            const int x = joy_rawMenuAxis(0), y = joy_rawMenuAxis(1);
-            const int axis = SDL_abs(y) >= SDL_abs(x) ? y : x;
-            const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
-            const Uint64 now = SDL_GetTicks();
-            if (zone && (zone != stickZone || now >= repeatAt)) {
-                selected = (selected + zone + RAW_ACTION_COUNT + 2) % (RAW_ACTION_COUNT + 2);
-                repeatAt = now + (zone != stickZone ? 400 : 200);
-            }
-            stickZone = zone;
-            while (input_keyWaiting()) {
-                const uint16 key = input_readKey();
-                if ((key & 255) == KEYCODE_ESC) continueRequested = true;
-                else if ((key & 255) == KEYCODE_ENTER) activate = true;
-                else if (key == KEYCODE_UPARROW) selected = (selected + RAW_ACTION_COUNT + 1) % (RAW_ACTION_COUNT + 2);
-                else if (key == KEYCODE_DNARROW) selected = (selected + 1) % (RAW_ACTION_COUNT + 2);
-                else if (key == KEYCODE_LEFTARROW) keyboard = true;
-                else if (key == KEYCODE_RIGHTARROW) keyboard = false;
-            }
-            const int pressed = joy_rawPressedButton();
-            if (pressed < 0) released = true;
-            else if (released) {
-                if (selected >= RAW_ACTION_COUNT) activate = true;
-                else {
-                    keyboard = false;
-                    joy_bindRawButton((RawAction)selected, joy_rawBinding((RawAction)selected) == pressed ? -1 : pressed);
-                }
-                released = false;
-            }
-            if (activate) {
-                if (selected == continueRow) continueRequested = true;
-                else if (selected == resetRow) {
-                    controls_resetKeyboard();
-                    joy_resetRawMapping();
-                    saveFailed = false;
-                } else if (keyboard) {
-                    controls_beginCapture((RawAction)selected);
-                    input_ringReset();
-                }
-            }
+            navigateWithStick(state);
+            continueRequested = navigateWithKeyboard(state, activate);
+            assignJoystickButton(state, activate);
+            if (activate && activateSelection(state)) continueRequested = true;
         } else {
             /* A captured Enter or arrow must not also activate or move a row. */
             input_ringReset();
-            released = joy_rawPressedButton() < 0;
+            state.released = joy_rawPressedButton() < 0;
         }
-        deleteHeld = deleteNow;
-        if (continueRequested) {
-            const bool keysSaved = saveFailed || controls_saveKeyboard(keyboardPath);
-            const bool stickSaved = saveFailed || !joy_rawDeviceId() || joy_saveRawMapping();
-            finished = keysSaved && stickSaved;
-            saveFailed = !finished;
-            selected = continueRow;
+        state.deleteHeld = deleteNow;
+        if (continueRequested) finished = saveAndContinue(state, keyboardPath);
+        if (state.selected < RAW_ACTION_COUNT) {
+            if (state.selected < state.first) state.first = state.selected;
+            if (state.selected >= state.first + visibleRows) state.first = state.selected - visibleRows + 1;
         }
-        if (selected < RAW_ACTION_COUNT) {
-            if (selected < first) first = selected;
-            if (selected >= first + visibleRows) first = selected - visibleRows + 1;
-        }
-        drawJoystickSetup(selected, first, keyboard, saveFailed);
+        drawJoystickSetup(state.selected, state.first, state.keyboard, state.saveFailed);
         SDL_Delay(20);
     }
     controls_beginCapture((RawAction)-1);

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -7,7 +7,7 @@
 #include "shared/common.h"
 
 /* Render one complete legacy page so normal expose/repaint also works. */
-static void drawJoystickSetup(int selected) {
+static void drawJoystickSetup(int selected, bool saveFailed) {
     int pitch = 0;
     uint8 *pixels = gfx_pagePixels(0, &pitch);
     if (!pixels) return;
@@ -43,16 +43,18 @@ static void drawJoystickSetup(int selected) {
             SDL_snprintf(binding, sizeof(binding), "Button %d", button + 1);
         drawStringAt(page, binding, 210, y);
     }
-    page[2] = COLOR_WHITE;
-    drawStringCentered(page, "ENTER: CONTINUE", 0, 141, LOGICAL_WIDTH);
+    page[2] = selected == RAW_ACTION_COUNT ? COLOR_WHITE : COLOR_LIGHTGRAY;
+    drawStringCentered(page, selected == RAW_ACTION_COUNT ? "> CONTINUE <" : "CONTINUE",
+                       0, 141, LOGICAL_WIDTH);
     page[2] = COLOR_LIGHTRED;
     page[6] = 0;
     drawStringCentered(page, "Move stick: select   Press button: assign", 0, 163, LOGICAL_WIDTH);
-    drawStringCentered(page, "DEL: unassign   ESC: continue", 0, 175, LOGICAL_WIDTH);
+    drawStringCentered(page, saveFailed ? "Save failed. Continue again to play unsaved." :
+                       "CONTINUE: any button   ENTER: save and play", 0, 175, LOGICAL_WIDTH);
     gfx_commitPage();
 }
 
-/* Show once at application startup. Bindings remain in memory for all missions.
+/* Show once at application startup. Continue saves bindings for this device.
  * A disconnected stick exits safely; menu button presses cannot fire weapons. */
 void joy_showSetup(void) {
     if (joy_rawButtonCount() <= 0) return;
@@ -62,15 +64,20 @@ void joy_showSetup(void) {
     gfx_setTextInputEnabled(false);
     input_ringReset();
     gfx_setDac(0);
-    int selected = 0;
+    const SDL_JoystickID device = joy_rawDeviceId();
+    const int rowCount = RAW_ACTION_COUNT + 1;
+    int selected = RAW_ACTION_COUNT;
     bool released = joy_rawPressedButton() < 0;
     bool deleteHeld = false;
     bool finished = false;
+    bool saveFailed = false;
     int stickZone = 0;
     Uint64 repeatAt = 0;
-    drawJoystickSetup(selected);
+    drawJoystickSetup(selected, saveFailed);
     while (!finished && joy_rawButtonCount() > 0 && !input_quitRequested()) {
         input_pumpEvents();
+        if (joy_rawDeviceId() != device) break;
+        bool continueRequested = false;
         if (!input_hasFocus()) {
             input_ringReset();
             released = false;
@@ -80,7 +87,7 @@ void joy_showSetup(void) {
         }
         const bool *keys = SDL_GetKeyboardState(NULL);
         const bool deleteNow = keys[SDL_SCANCODE_DELETE];
-        if (deleteNow && !deleteHeld) {
+        if (deleteNow && !deleteHeld && selected < RAW_ACTION_COUNT) {
             joy_bindRawButton((RawAction)selected, -1);
         }
         deleteHeld = deleteNow;
@@ -92,27 +99,38 @@ void joy_showSetup(void) {
         const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
         const Uint64 now = SDL_GetTicks();
         if (zone && (zone != stickZone || now >= repeatAt)) {
-            selected = (selected + zone + RAW_ACTION_COUNT) % RAW_ACTION_COUNT;
+            selected = (selected + zone + rowCount) % rowCount;
             repeatAt = now + (zone != stickZone ? 400 : 200);
         }
         stickZone = zone;
         while (input_keyWaiting()) {
             const uint16 key = input_readKey();
             if ((key & 255) == KEYCODE_ESC || (key & 255) == KEYCODE_ENTER) {
-                finished = true;
+                continueRequested = true;
             } else if (key == KEYCODE_UPARROW || key == KEYCODE_LEFTARROW) {
-                selected = (selected + RAW_ACTION_COUNT - 1) % RAW_ACTION_COUNT;
+                selected = (selected + rowCount - 1) % rowCount;
             } else if (key == KEYCODE_DNARROW || key == KEYCODE_RIGHTARROW) {
-                selected = (selected + 1) % RAW_ACTION_COUNT;
+                selected = (selected + 1) % rowCount;
             }
         }
         const int pressed = joy_rawPressedButton();
         if (pressed < 0) released = true;
-        else if (released && !finished) {
-            joy_bindRawButton((RawAction)selected, pressed);
+        else if (released && !continueRequested) {
+            if (selected == RAW_ACTION_COUNT) continueRequested = true;
+            else {
+                /* Pressing the same assignment again clears it without a
+                 * keyboard. Assigning another action's button still swaps. */
+                joy_bindRawButton((RawAction)selected,
+                                  joy_rawBinding((RawAction)selected) == pressed ? -1 : pressed);
+            }
             released = false;
         }
-        drawJoystickSetup(selected);
+        if (continueRequested) {
+            finished = saveFailed || joy_saveRawMapping();
+            saveFailed = !finished;
+            selected = RAW_ACTION_COUNT;
+        }
+        drawJoystickSetup(selected, saveFailed);
         SDL_Delay(20);
     }
     input_setJoystickSetup(false);

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -28,10 +28,11 @@ static void drawJoystickSetup(int selected, bool saveFailed) {
 
     static const char *labels[RAW_ACTION_COUNT] = {
         "Fire cannon", "Fire missile", "Chaff / flare", "Cycle weapon",
-        "Increase thrust", "Decrease thrust"
+        "Increase thrust", "Decrease thrust", "Landing gear", "Autopilot",
+        "Next target", "Switch 3D view"
     };
     for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
-        const int y = 56 + action * 13;
+        const int y = 48 + action * 9;
         page[2] = action == selected ? COLOR_WHITE : COLOR_LIGHTGRAY;
         drawStringAt(page, action == selected ? ">" : " ", 19, y);
         drawStringAt(page, labels[action], 32, y);

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -1,0 +1,122 @@
+/* Startup-only raw-stick setup, drawn with the original game's bitmap font.
+ * It owns no SDL window or event pump; normal quit/focus handling stays active. */
+#include "joystick.h"
+#include "input.h"
+#include "gfx.h"
+#include "const.h"
+#include "shared/common.h"
+
+/* Render one complete legacy page so normal expose/repaint also works. */
+static void drawJoystickSetup(int selected) {
+    int pitch = 0;
+    uint8 *pixels = gfx_pagePixels(0, &pitch);
+    if (!pixels) return;
+    for (int y = 0; y < LOGICAL_HEIGHT; ++y)
+        SDL_memset(pixels + y * pitch, COLOR_BLACK, LOGICAL_WIDTH);
+
+    int16 page[12] = {};
+    page[2] = COLOR_LIGHTRED;
+    page[6] = 1;
+    gfx_setDrawColor(COLOR_LIGHTRED);
+    gfx_drawLine(8, 8, 311, 8);
+    gfx_drawLine(311, 8, 311, 191);
+    gfx_drawLine(311, 191, 8, 191);
+    gfx_drawLine(8, 191, 8, 8);
+    drawStringCentered(page, "JOYSTICK SETUP", 0, 19, LOGICAL_WIDTH);
+    page[2] = COLOR_LIGHTGRAY;
+    drawStringCentered(page, "Assign your flight buttons", 0, 35, LOGICAL_WIDTH);
+
+    static const char *labels[RAW_ACTION_COUNT] = {
+        "Fire cannon", "Fire missile", "Chaff / flare", "Cycle weapon",
+        "Increase thrust", "Decrease thrust"
+    };
+    for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
+        const int y = 56 + action * 13;
+        page[2] = action == selected ? COLOR_WHITE : COLOR_LIGHTGRAY;
+        drawStringAt(page, action == selected ? ">" : " ", 19, y);
+        drawStringAt(page, labels[action], 32, y);
+        char binding[24] = {};
+        const int button = joy_rawBinding((RawAction)action);
+        if (button < 0)
+            SDL_snprintf(binding, sizeof(binding), "Not assigned");
+        else
+            SDL_snprintf(binding, sizeof(binding), "Button %d", button + 1);
+        drawStringAt(page, binding, 210, y);
+    }
+    page[2] = COLOR_WHITE;
+    drawStringCentered(page, "ENTER: CONTINUE", 0, 141, LOGICAL_WIDTH);
+    page[2] = COLOR_LIGHTRED;
+    page[6] = 0;
+    drawStringCentered(page, "Move stick: select   Press button: assign", 0, 163, LOGICAL_WIDTH);
+    drawStringCentered(page, "DEL: unassign   ESC: continue", 0, 175, LOGICAL_WIDTH);
+    gfx_commitPage();
+}
+
+/* Show once at application startup. Bindings remain in memory for all missions.
+ * A disconnected stick exits safely; menu button presses cannot fire weapons. */
+void joy_showSetup(void) {
+    if (joy_rawButtonCount() <= 0) return;
+    const InputMode previousMode = input_getMode();
+    input_setMode(INPUT_MODE_MENU);
+    input_setJoystickSetup(true);
+    gfx_setTextInputEnabled(false);
+    input_ringReset();
+    gfx_setDac(0);
+    int selected = 0;
+    bool released = joy_rawPressedButton() < 0;
+    bool deleteHeld = false;
+    bool finished = false;
+    int stickZone = 0;
+    Uint64 repeatAt = 0;
+    drawJoystickSetup(selected);
+    while (!finished && joy_rawButtonCount() > 0 && !input_quitRequested()) {
+        input_pumpEvents();
+        if (!input_hasFocus()) {
+            input_ringReset();
+            released = false;
+            stickZone = 0;
+            SDL_Delay(20);
+            continue;
+        }
+        const bool *keys = SDL_GetKeyboardState(NULL);
+        const bool deleteNow = keys[SDL_SCANCODE_DELETE];
+        if (deleteNow && !deleteHeld) {
+            joy_bindRawButton((RawAction)selected, -1);
+        }
+        deleteHeld = deleteNow;
+        /* Either primary axis can select rows. Follow the larger deflection,
+         * with a broad centre dead zone and delayed repeat to avoid jitter. */
+        const int x = joy_rawMenuAxis(0);
+        const int y = joy_rawMenuAxis(1);
+        const int axis = SDL_abs(y) >= SDL_abs(x) ? y : x;
+        const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
+        const Uint64 now = SDL_GetTicks();
+        if (zone && (zone != stickZone || now >= repeatAt)) {
+            selected = (selected + zone + RAW_ACTION_COUNT) % RAW_ACTION_COUNT;
+            repeatAt = now + (zone != stickZone ? 400 : 200);
+        }
+        stickZone = zone;
+        while (input_keyWaiting()) {
+            const uint16 key = input_readKey();
+            if ((key & 255) == KEYCODE_ESC || (key & 255) == KEYCODE_ENTER) {
+                finished = true;
+            } else if (key == KEYCODE_UPARROW || key == KEYCODE_LEFTARROW) {
+                selected = (selected + RAW_ACTION_COUNT - 1) % RAW_ACTION_COUNT;
+            } else if (key == KEYCODE_DNARROW || key == KEYCODE_RIGHTARROW) {
+                selected = (selected + 1) % RAW_ACTION_COUNT;
+            }
+        }
+        const int pressed = joy_rawPressedButton();
+        if (pressed < 0) released = true;
+        else if (released && !finished) {
+            joy_bindRawButton((RawAction)selected, pressed);
+            released = false;
+        }
+        drawJoystickSetup(selected);
+        SDL_Delay(20);
+    }
+    input_setJoystickSetup(false);
+    input_setMode(previousMode);
+    gfx_setTextInputEnabled(previousMode == INPUT_MODE_MENU);
+    joy_resetFlightInput();
+}

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -63,7 +63,7 @@ static void drawJoystickSetup(int selected, int first, bool keyboard, bool saveF
     drawStringCentered(page, selected == resetRow ? "> RESET DEFAULTS <" : "RESET DEFAULTS", 0, 162, LOGICAL_WIDTH);
     page[2] = COLOR_LIGHTRED;
     drawStringCentered(page, saveFailed ? "Save failed. Continue to play unsaved." :
-                       controls_capturing() ? "Press key / chord. ESC cancels." :
+                       controls_capturing() ? "Press key / chord to assign." :
                        "ENTER: edit  DEL: clear  ESC: finish", 0, 177, LOGICAL_WIDTH);
     gfx_commitPage();
 }

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -1,19 +1,23 @@
-/* Startup-only raw-stick setup, drawn with the original game's bitmap font.
- * It owns no SDL window or event pump; normal quit/focus handling stays active. */
+/* Startup controls editor in the original bitmap style. Input.c remains the
+ * sole SDL event pump; flight assignments never change menu navigation. */
 #include "joystick.h"
+#include "controls.h"
 #include "input.h"
 #include "gfx.h"
 #include "const.h"
 #include "shared/common.h"
 
-/* Render one complete legacy page so normal expose/repaint also works. */
-static void drawJoystickSetup(int selected, bool saveFailed) {
+static const int visibleRows = 8;
+static const int continueRow = RAW_ACTION_COUNT;
+static const int resetRow = RAW_ACTION_COUNT + 1;
+
+/* Scroll the action table, keeping Continue and Reset visible on every page. */
+static void drawJoystickSetup(int selected, int first, bool keyboard, bool saveFailed) {
     int pitch = 0;
     uint8 *pixels = gfx_pagePixels(0, &pitch);
     if (!pixels) return;
     for (int y = 0; y < LOGICAL_HEIGHT; ++y)
         SDL_memset(pixels + y * pitch, COLOR_BLACK, LOGICAL_WIDTH);
-
     int16 page[12] = {};
     page[2] = COLOR_LIGHTRED;
     page[6] = 1;
@@ -22,118 +26,151 @@ static void drawJoystickSetup(int selected, bool saveFailed) {
     gfx_drawLine(311, 8, 311, 191);
     gfx_drawLine(311, 191, 8, 191);
     gfx_drawLine(8, 191, 8, 8);
-    drawStringCentered(page, "JOYSTICK SETUP", 0, 19, LOGICAL_WIDTH);
+    drawStringCentered(page, "CONTROLS SETUP", 0, 18, LOGICAL_WIDTH);
     page[2] = COLOR_LIGHTGRAY;
-    drawStringCentered(page, "Assign your flight buttons", 0, 35, LOGICAL_WIDTH);
-
-    static const char *labels[RAW_ACTION_COUNT] = {
-        "Fire cannon", "Fire missile", "Chaff / flare", "Cycle weapon",
-        "Increase thrust", "Decrease thrust", "Landing gear", "Autopilot",
-        "Next target", "Switch 3D view"
-    };
-    for (int action = 0; action < RAW_ACTION_COUNT; ++action) {
-        const int y = 48 + action * 9;
+    drawStringAt(page, keyboard ? "> Keyboard" : "Keyboard", 170, 35);
+    drawStringAt(page, keyboard ? "Joystick" : "> Joystick", 258, 35);
+    for (int row = 0; row < visibleRows && first + row < RAW_ACTION_COUNT; ++row) {
+        const RawAction action = (RawAction)(first + row);
+        const int y = 49 + row * 11;
         page[2] = action == selected ? COLOR_WHITE : COLOR_LIGHTGRAY;
-        drawStringAt(page, action == selected ? ">" : " ", 19, y);
-        drawStringAt(page, labels[action], 32, y);
-        char binding[24] = {};
-        const int button = joy_rawBinding((RawAction)action);
-        if (button < 0)
-            SDL_snprintf(binding, sizeof(binding), "Not assigned");
-        else
-            SDL_snprintf(binding, sizeof(binding), "Button %d", button + 1);
-        drawStringAt(page, binding, 210, y);
+        drawStringAt(page, action == selected ? ">" : " ", 14, y);
+        drawStringAt(page, controls_action(action).label, 23, y);
+        /* Keep the columns bounded with the readable font. The selected
+         * binding is also shown in full below the list, including modifiers. */
+        const std::string key = controls_keyName(action);
+        const std::string shortKey = key.size() > 11 ? key.substr(0, 10) + ">" : key;
+        drawStringAt(page, shortKey.c_str(), 170, y);
+        char button[16] = {};
+        const int binding = joy_rawBinding(action);
+        if (binding < 0) SDL_strlcpy(button, "-", sizeof(button));
+        else SDL_snprintf(button, sizeof(button), "%d", binding + 1);
+        drawStringAt(page, button, 270, y);
     }
-    page[2] = selected == RAW_ACTION_COUNT ? COLOR_WHITE : COLOR_LIGHTGRAY;
-    drawStringCentered(page, selected == RAW_ACTION_COUNT ? "> CONTINUE <" : "CONTINUE",
-                       0, 141, LOGICAL_WIDTH);
+    if (selected < RAW_ACTION_COUNT) {
+        page[2] = COLOR_WHITE;
+        const std::string binding = "Key: " + controls_keyName((RawAction)selected);
+        drawStringCentered(page, binding.c_str(), 0, 138, LOGICAL_WIDTH);
+    }
+    page[2] = selected == continueRow ? COLOR_WHITE : COLOR_LIGHTGRAY;
+    drawStringCentered(page, selected == continueRow ? "> CONTINUE <" : "CONTINUE", 0, 151, LOGICAL_WIDTH);
+    page[2] = selected == resetRow ? COLOR_WHITE : COLOR_LIGHTGRAY;
+    drawStringCentered(page, selected == resetRow ? "> RESET DEFAULTS <" : "RESET DEFAULTS", 0, 162, LOGICAL_WIDTH);
     page[2] = COLOR_LIGHTRED;
-    page[6] = 0;
-    drawStringCentered(page, "Move stick: select   Press button: assign", 0, 163, LOGICAL_WIDTH);
-    drawStringCentered(page, saveFailed ? "Save failed. Continue again to play unsaved." :
-                       "CONTINUE: any button   ENTER: save and play", 0, 175, LOGICAL_WIDTH);
+    drawStringCentered(page, saveFailed ? "Save failed. Continue to play unsaved." :
+                       controls_capturing() ? "Press key / chord. ESC cancels." :
+                       "ENTER: edit  DEL: clear  ESC: finish", 0, 177, LOGICAL_WIDTH);
     gfx_commitPage();
 }
 
-/* Show once at application startup. Continue saves bindings for this device.
- * A disconnected stick exits safely; menu button presses cannot fire weapons. */
+/* Keyboard setup is available without a joystick. A hotplugged device keeps
+ * its own profile; losing a stick does not prevent continuing with keys. */
 void joy_showSetup(void) {
-    if (joy_rawButtonCount() <= 0) return;
+    controls_resetKeyboard();
+    const std::string keyboardPath = controls_keyboardPath();
+    controls_loadKeyboard(keyboardPath);
     const InputMode previousMode = input_getMode();
     input_setMode(INPUT_MODE_MENU);
     input_setJoystickSetup(true);
     gfx_setTextInputEnabled(false);
     input_ringReset();
-    gfx_setDac(0);
-    const SDL_JoystickID device = joy_rawDeviceId();
-    const int rowCount = RAW_ACTION_COUNT + 1;
-    int selected = RAW_ACTION_COUNT;
+    /* Pilot selection and mission menus use palette 1. Palette 0 gives these
+     * same color indices different RGB values, unlike the surrounding menus. */
+    gfx_setDac(1);
+    SDL_JoystickID device = joy_rawDeviceId();
+    int selected = continueRow;
+    int first = 0;
+    bool keyboard = true;
     bool released = joy_rawPressedButton() < 0;
     bool deleteHeld = false;
     bool finished = false;
     bool saveFailed = false;
     int stickZone = 0;
     Uint64 repeatAt = 0;
-    drawJoystickSetup(selected, saveFailed);
-    while (!finished && joy_rawButtonCount() > 0 && !input_quitRequested()) {
+    drawJoystickSetup(selected, first, keyboard, saveFailed);
+    while (!finished && !input_quitRequested()) {
+        const bool wasCapturing = controls_capturing();
         input_pumpEvents();
-        if (joy_rawDeviceId() != device) break;
-        bool continueRequested = false;
+        if (joy_rawDeviceId() != device) {
+            device = joy_rawDeviceId();
+            released = false;
+        }
         if (!input_hasFocus()) {
+            controls_beginCapture((RawAction)-1);
             input_ringReset();
             released = false;
             stickZone = 0;
             SDL_Delay(20);
             continue;
         }
-        const bool *keys = SDL_GetKeyboardState(NULL);
-        const bool deleteNow = keys[SDL_SCANCODE_DELETE];
-        if (deleteNow && !deleteHeld && selected < RAW_ACTION_COUNT) {
-            joy_bindRawButton((RawAction)selected, -1);
+        bool activate = false;
+        bool continueRequested = false;
+        const bool deleteNow = SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_DELETE];
+        if (!wasCapturing && !controls_capturing()) {
+            if (deleteNow && !deleteHeld && selected < RAW_ACTION_COUNT) {
+                if (keyboard) controls_bindKey((RawAction)selected, SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE);
+                else joy_bindRawButton((RawAction)selected, -1);
+            }
+            const int x = joy_rawMenuAxis(0), y = joy_rawMenuAxis(1);
+            const int axis = SDL_abs(y) >= SDL_abs(x) ? y : x;
+            const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
+            const Uint64 now = SDL_GetTicks();
+            if (zone && (zone != stickZone || now >= repeatAt)) {
+                selected = (selected + zone + RAW_ACTION_COUNT + 2) % (RAW_ACTION_COUNT + 2);
+                repeatAt = now + (zone != stickZone ? 400 : 200);
+            }
+            stickZone = zone;
+            while (input_keyWaiting()) {
+                const uint16 key = input_readKey();
+                if ((key & 255) == KEYCODE_ESC) continueRequested = true;
+                else if ((key & 255) == KEYCODE_ENTER) activate = true;
+                else if (key == KEYCODE_UPARROW) selected = (selected + RAW_ACTION_COUNT + 1) % (RAW_ACTION_COUNT + 2);
+                else if (key == KEYCODE_DNARROW) selected = (selected + 1) % (RAW_ACTION_COUNT + 2);
+                else if (key == KEYCODE_LEFTARROW) keyboard = true;
+                else if (key == KEYCODE_RIGHTARROW) keyboard = false;
+            }
+            const int pressed = joy_rawPressedButton();
+            if (pressed < 0) released = true;
+            else if (released) {
+                if (selected >= RAW_ACTION_COUNT) activate = true;
+                else {
+                    keyboard = false;
+                    joy_bindRawButton((RawAction)selected, joy_rawBinding((RawAction)selected) == pressed ? -1 : pressed);
+                }
+                released = false;
+            }
+            if (activate) {
+                if (selected == continueRow) continueRequested = true;
+                else if (selected == resetRow) {
+                    controls_resetKeyboard();
+                    joy_resetRawMapping();
+                    saveFailed = false;
+                } else if (keyboard) {
+                    controls_beginCapture((RawAction)selected);
+                    input_ringReset();
+                }
+            }
+        } else {
+            /* A captured Enter or arrow must not also activate or move a row. */
+            input_ringReset();
+            released = joy_rawPressedButton() < 0;
         }
         deleteHeld = deleteNow;
-        /* Either primary axis can select rows. Follow the larger deflection,
-         * with a broad centre dead zone and delayed repeat to avoid jitter. */
-        const int x = joy_rawMenuAxis(0);
-        const int y = joy_rawMenuAxis(1);
-        const int axis = SDL_abs(y) >= SDL_abs(x) ? y : x;
-        const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
-        const Uint64 now = SDL_GetTicks();
-        if (zone && (zone != stickZone || now >= repeatAt)) {
-            selected = (selected + zone + rowCount) % rowCount;
-            repeatAt = now + (zone != stickZone ? 400 : 200);
-        }
-        stickZone = zone;
-        while (input_keyWaiting()) {
-            const uint16 key = input_readKey();
-            if ((key & 255) == KEYCODE_ESC || (key & 255) == KEYCODE_ENTER) {
-                continueRequested = true;
-            } else if (key == KEYCODE_UPARROW || key == KEYCODE_LEFTARROW) {
-                selected = (selected + rowCount - 1) % rowCount;
-            } else if (key == KEYCODE_DNARROW || key == KEYCODE_RIGHTARROW) {
-                selected = (selected + 1) % rowCount;
-            }
-        }
-        const int pressed = joy_rawPressedButton();
-        if (pressed < 0) released = true;
-        else if (released && !continueRequested) {
-            if (selected == RAW_ACTION_COUNT) continueRequested = true;
-            else {
-                /* Pressing the same assignment again clears it without a
-                 * keyboard. Assigning another action's button still swaps. */
-                joy_bindRawButton((RawAction)selected,
-                                  joy_rawBinding((RawAction)selected) == pressed ? -1 : pressed);
-            }
-            released = false;
-        }
         if (continueRequested) {
-            finished = saveFailed || joy_saveRawMapping();
+            const bool keysSaved = saveFailed || controls_saveKeyboard(keyboardPath);
+            const bool stickSaved = saveFailed || !joy_rawDeviceId() || joy_saveRawMapping();
+            finished = keysSaved && stickSaved;
             saveFailed = !finished;
-            selected = RAW_ACTION_COUNT;
+            selected = continueRow;
         }
-        drawJoystickSetup(selected, saveFailed);
+        if (selected < RAW_ACTION_COUNT) {
+            if (selected < first) first = selected;
+            if (selected >= first + visibleRows) first = selected - visibleRows + 1;
+        }
+        drawJoystickSetup(selected, first, keyboard, saveFailed);
         SDL_Delay(20);
     }
+    controls_beginCapture((RawAction)-1);
     input_setJoystickSetup(false);
     input_setMode(previousMode);
     gfx_setTextInputEnabled(previousMode == INPUT_MODE_MENU);

--- a/src/joystick_setup.c
+++ b/src/joystick_setup.c
@@ -10,6 +10,11 @@
 static const int visibleRows = 8;
 static const int continueRow = RAW_ACTION_COUNT;
 static const int resetRow = RAW_ACTION_COUNT + 1;
+static const int rowCount = resetRow + 1;
+static const int stickNavigationThreshold = 16000;
+static const Uint64 firstNavigationRepeatMs = 400;
+static const Uint64 navigationRepeatMs = 200;
+static const Uint32 setupPollMs = 20;
 
 /* Scroll the action table, keeping Continue and Reset visible on every page. */
 static void drawJoystickSetup(int selected, int first, bool keyboard, bool saveFailed) {
@@ -79,11 +84,12 @@ struct SetupState {
 static void navigateWithStick(SetupState &state) {
     const int x = joy_rawMenuAxis(0), y = joy_rawMenuAxis(1);
     const int axis = SDL_abs(y) >= SDL_abs(x) ? y : x;
-    const int zone = axis < -16000 ? -1 : axis > 16000 ? 1 : 0;
+    const int zone = axis < -stickNavigationThreshold ? -1 :
+                     axis > stickNavigationThreshold ? 1 : 0;
     const Uint64 now = SDL_GetTicks();
     if (zone && (zone != state.stickZone || now >= state.repeatAt)) {
-        state.selected = (state.selected + zone + RAW_ACTION_COUNT + 2) % (RAW_ACTION_COUNT + 2);
-        state.repeatAt = now + (zone != state.stickZone ? 400 : 200);
+        state.selected = (state.selected + zone + rowCount) % rowCount;
+        state.repeatAt = now + (zone != state.stickZone ? firstNavigationRepeatMs : navigationRepeatMs);
     }
     state.stickZone = zone;
 }
@@ -95,8 +101,8 @@ static bool navigateWithKeyboard(SetupState &state, bool &activate) {
         const uint16 key = input_readKey();
         if ((key & 255) == KEYCODE_ESC) finish = true;
         else if ((key & 255) == KEYCODE_ENTER) activate = true;
-        else if (key == KEYCODE_UPARROW) state.selected = (state.selected + RAW_ACTION_COUNT + 1) % (RAW_ACTION_COUNT + 2);
-        else if (key == KEYCODE_DNARROW) state.selected = (state.selected + 1) % (RAW_ACTION_COUNT + 2);
+        else if (key == KEYCODE_UPARROW) state.selected = (state.selected + rowCount - 1) % rowCount;
+        else if (key == KEYCODE_DNARROW) state.selected = (state.selected + 1) % rowCount;
         else if (key == KEYCODE_LEFTARROW) state.keyboard = true;
         else if (key == KEYCODE_RIGHTARROW) state.keyboard = false;
     }
@@ -173,7 +179,7 @@ void joy_showSetup(void) {
             input_ringReset();
             state.released = false;
             state.stickZone = 0;
-            SDL_Delay(20);
+            SDL_Delay(setupPollMs);
             continue;
         }
         bool activate = false;
@@ -200,7 +206,7 @@ void joy_showSetup(void) {
             if (state.selected >= state.first + visibleRows) state.first = state.selected - visibleRows + 1;
         }
         drawJoystickSetup(state.selected, state.first, state.keyboard, state.saveFailed);
-        SDL_Delay(20);
+        SDL_Delay(setupPollMs);
     }
     controls_beginCapture((RawAction)-1);
     input_setJoystickSetup(false);

--- a/tests/controls_behavior_tests.cpp
+++ b/tests/controls_behavior_tests.cpp
@@ -97,6 +97,57 @@ static void profileValidation() {
         require(controls_command(RAW_VIEW, 0, views[i]) == commands[i], "view cycle follows game state");
 }
 
+static void remoteKeys(const std::string &path) {
+    controls_resetKeyboard();
+    input_setMode(INPUT_MODE_MENU);
+    input_ringReset();
+    setupKey(SDL_SCANCODE_SELECT, SDLK_SELECT);
+    require(input_keyWaiting() && input_readKey() == SCAN_ENTER, "remote Select confirms menus");
+    setupKey(SDL_SCANCODE_AC_BACK, SDLK_AC_BACK);
+    require(input_keyWaiting() && input_readKey() == SCAN_ESCAPE, "remote Back exits menus");
+
+    const struct {
+        RawAction action;
+        SDL_Scancode scancode;
+        SDL_Keycode key;
+        Uint16 command;
+    } buttons[] = {
+        {RAW_MISSILE, SDL_SCANCODE_SELECT, SDLK_SELECT, SCAN_ENTER},
+        {RAW_GEAR, SDL_SCANCODE_AC_BACK, SDLK_AC_BACK, SCAN_L},
+        {RAW_AUTOPILOT, SDL_SCANCODE_VOLUMEUP, SDLK_VOLUMEUP, SCAN_P},
+        {RAW_FLARE, SDL_SCANCODE_ESCAPE, SDLK_ESCAPE, SCAN_F}
+    };
+    for (const auto &button : buttons) {
+        controls_beginCapture(button.action);
+        setupKey(button.scancode, button.key);
+        input_pumpEvents();
+        require(!controls_capturing(), "remote key completes capture");
+        require(!input_keyWaiting(), "captured remote key does not navigate menu");
+        require(controls_keyboardBinding(button.action).key == button.scancode, "remote scancode captured");
+        require(!controls_keyName(button.action).empty(), "remote binding has a visible name");
+    }
+    controls_beginCapture(RAW_GEAR);
+    SDL_KeyboardEvent unknown = {};
+    require(controls_captureKey(unknown) && controls_capturing(), "unknown key does not end capture");
+    require(controls_keyboardBinding(RAW_GEAR).key == SDL_SCANCODE_AC_BACK, "unknown key does not erase binding");
+    unknown.scancode = SDL_SCANCODE_SELECT;
+    unknown.repeat = true;
+    require(controls_captureKey(unknown) && controls_capturing(), "repeat does not assign a remote key");
+    controls_beginCapture((RawAction)-1);
+
+    require(controls_saveKeyboard(path), "save remote bindings");
+    controls_resetKeyboard();
+    require(controls_loadKeyboard(path), "reload remote bindings");
+    input_setMode(INPUT_MODE_FLIGHT);
+    for (const auto &button : buttons) {
+        setupKey(button.scancode, button.key);
+        require(input_keyWaiting() && input_readKey() == button.command, "saved remote key reaches flight command");
+    }
+    controls_resetKeyboard();
+    require(controls_saveKeyboard(path), "restore defaults for subsequent setup tests");
+    input_setMode(INPUT_MODE_MENU);
+}
+
 static void directionalButtons() {
     SDL_VirtualJoystickDesc desc = {};
     SDL_INIT_INTERFACE(&desc);
@@ -169,10 +220,12 @@ int main() {
     event.key.scancode = SDL_SCANCODE_F11;
     require(controls_captureKey(event.key) && !controls_capturing(), "capture assigns chord");
     require(controls_translateKey(SDL_SCANCODE_F11, SDL_KMOD_SHIFT, 0) == SCAN_L, "captured chord acts");
-    controls_beginCapture(RAW_GEAR);
+    controls_beginCapture(RAW_MISSILE);
     event.key.scancode = SDL_SCANCODE_ESCAPE;
+    event.key.mod = SDL_KMOD_NONE;
     controls_captureKey(event.key);
-    require(!controls_capturing(), "escape cancels capture");
+    require(!controls_capturing() && controls_keyboardBinding(RAW_MISSILE).key == SDL_SCANCODE_ESCAPE,
+            "Escape can be assigned like other remote keys");
     const std::string path = controls_keyboardPath();
     require(controls_saveKeyboard(path), "save keyboard");
     controls_resetKeyboard();
@@ -192,6 +245,7 @@ int main() {
     require(g_textRecorder == nullptr, "keyboard-only setup defaults to Continue");
     require(controls_loadKeyboard(path), "setup saves valid defaults after invalid profile");
     profileValidation();
+    remoteKeys(path);
     directionalButtons();
     g_textRecorder = editThenReset;
     joy_showSetup();

--- a/tests/controls_behavior_tests.cpp
+++ b/tests/controls_behavior_tests.cpp
@@ -1,4 +1,5 @@
 #include "controls.h"
+#include "controls_mapping.h"
 #include "input.h"
 #include "egkeys.h"
 #include "egtypes.h"
@@ -23,6 +24,110 @@ static void pressEnter(const char *text, int, int, int, int) {
     event.key.key = SDLK_RETURN;
     SDL_PushEvent(&event);
     g_textRecorder = nullptr;
+}
+
+static int setupStep = 0;
+
+static void setupKey(SDL_Scancode sc, SDL_Keycode key) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = sc;
+    event.key.key = key;
+    require(SDL_PushEvent(&event), "queue setup navigation");
+}
+
+static void editThenReset(const char *text, int, int, int, int) {
+    if (!SDL_strstr(text, "ENTER: edit") && !SDL_strstr(text, "Press key / chord")) return;
+    switch (setupStep++) {
+    case 0: setupKey(SDL_SCANCODE_UP, SDLK_UP); break;
+    case 1:
+        setupKey(SDL_SCANCODE_LEFT, SDLK_LEFT);
+        setupKey(SDL_SCANCODE_RETURN, SDLK_RETURN);
+        break;
+    case 2:
+        require(controls_capturing(), "Enter enters actual setup capture");
+        setupKey(SDL_SCANCODE_F12, SDLK_F12);
+        break;
+    case 3:
+        require(controls_keyboardBinding(RAW_KP_DOWN_RIGHT).key == SDL_SCANCODE_F12,
+                "setup assigns selected action");
+        setupKey(SDL_SCANCODE_DOWN, SDLK_DOWN);
+        setupKey(SDL_SCANCODE_DOWN, SDLK_DOWN);
+        setupKey(SDL_SCANCODE_RETURN, SDLK_RETURN);
+        break;
+    case 4:
+        require(controls_keyboardBinding(RAW_KP_DOWN_RIGHT).key == SDL_SCANCODE_KP_3,
+                "Reset defaults restores edited action");
+        setupKey(SDL_SCANCODE_ESCAPE, SDLK_ESCAPE);
+        g_textRecorder = nullptr;
+        break;
+    default: require(false, "unexpected setup loop");
+    }
+}
+
+static void profileValidation() {
+    ControlBinding profile[RAW_ACTION_COUNT] = {};
+    controls_resetKeyboard();
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) profile[i] = controls_keyboardBinding((RawAction)i);
+    const ControlBinding original = profile[RAW_GEAR];
+    for (const ControlBinding invalid : {
+            ControlBinding{SDL_SCANCODE_LSHIFT, SDL_KMOD_NONE},
+            ControlBinding{SDL_SCANCODE_RETURN, SDL_KMOD_ALT},
+            ControlBinding{SDL_SCANCODE_KP_ENTER, SDL_KMOD_NONE},
+            ControlBinding{SDL_SCANCODE_L, SDL_KMOD_LCTRL},
+            ControlBinding{SDL_SCANCODE_UNKNOWN, SDL_KMOD_CTRL},
+            profile[RAW_MISSILE]}) {
+        profile[RAW_GEAR] = invalid;
+        require(!controls_replaceKeyboard(profile), "reject invalid complete profile");
+        require(controls_keyboardBinding(RAW_GEAR).key == original.key, "atomic rejection");
+    }
+    profile[RAW_GEAR] = original;
+    require(controls_replaceKeyboard(profile), "valid profile accepted");
+    require(!controls_bindKey((RawAction)-1, SDL_SCANCODE_F12, SDL_KMOD_NONE), "invalid action rejected");
+    bool sequence = false;
+    require(controls_command(RAW_COUNTERMEASURE, 0, 0, &sequence) == SCAN_C &&
+            controls_command(RAW_COUNTERMEASURE, 0, 0, &sequence) == SCAN_F, "device-local sequence");
+    for (int weapon = 0; weapon < 3; ++weapon) {
+        const Uint16 commands[] = {SCAN_M, SCAN_G, SCAN_S};
+        require(controls_command(RAW_WEAPON, weapon, 0) == commands[weapon], "weapon cycle");
+    }
+    const int views[] = {VIEW_COCKPIT, VIEW_EXT_FOLLOW, VIEW_EXT_DYNAMIC, VIEW_TARGET};
+    const Uint16 commands[] = {SCAN_F5, SCAN_F6, SCAN_F7, SCAN_SPACEBAR};
+    for (int i = 0; i < 4; ++i)
+        require(controls_command(RAW_VIEW, 0, views[i]) == commands[i], "view cycle follows game state");
+}
+
+static void directionalButtons() {
+    SDL_VirtualJoystickDesc desc = {};
+    SDL_INIT_INTERFACE(&desc);
+    desc.type = SDL_JOYSTICK_TYPE_FLIGHT_STICK;
+    desc.naxes = 2;
+    desc.nbuttons = 2;
+    const SDL_JoystickID id = SDL_AttachVirtualJoystick(&desc);
+    require(id != 0, "attach directional fixture");
+    SDL_Joystick *stick = SDL_OpenJoystick(id);
+    require(stick != nullptr, "open directional fixture");
+    SDL_Event event = {};
+    event.type = SDL_EVENT_JOYSTICK_ADDED;
+    event.jdevice.which = id;
+    joy_handleEvent(&event);
+    joy_bindRawButton(RAW_ROLL_LEFT, 0);
+    joy_bindRawButton(RAW_KP_DOWN_RIGHT, 1);
+    require(SDL_SetJoystickVirtualButton(stick, 0, true), "hold left");
+    SDL_UpdateJoysticks();
+    Uint8 x = 128, y = 128;
+    controls_applyAxes(&x, &y, true);
+    require(x == 0x26 && y == 128, "directional button sets roll");
+    require(SDL_SetJoystickVirtualButton(stick, 1, true), "hold diagonal");
+    SDL_UpdateJoysticks();
+    controls_applyAxes(&x, &y, true);
+    require(x == 0xda && y == 0xda, "diagonal overrides single direction");
+    joy_resetRawMapping();
+    require(joy_rawBinding(RAW_CANNON) == 0 && joy_rawBinding(RAW_MISSILE) == 1,
+            "reset restores physical fire buttons");
+    SDL_CloseJoystick(stick);
+    require(SDL_DetachVirtualJoystick(id), "detach fixture");
+    joy_shutdown();
 }
 
 int main() {
@@ -86,6 +191,11 @@ int main() {
     joy_showSetup();
     require(g_textRecorder == nullptr, "keyboard-only setup defaults to Continue");
     require(controls_loadKeyboard(path), "setup saves valid defaults after invalid profile");
+    profileValidation();
+    directionalButtons();
+    g_textRecorder = editThenReset;
+    joy_showSetup();
+    require(setupStep == 5 && !controls_capturing(), "navigate, capture, reset and exit real setup");
     gfx_videoShutdown();
     SDL_Quit();
     SDL_unsetenv_unsafe("F15_JOY_CONFIG_DIR");

--- a/tests/controls_behavior_tests.cpp
+++ b/tests/controls_behavior_tests.cpp
@@ -1,0 +1,94 @@
+#include "controls.h"
+#include "input.h"
+#include "egkeys.h"
+#include "egtypes.h"
+#include "gfx.h"
+#include "gfx_impl.h"
+#include "headless.h"
+#include "shared/common.h"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <cstdlib>
+
+static void require(bool ok, const char *message) {
+    if (!ok) { std::cerr << message << "\n"; std::exit(1); }
+}
+
+static void pressEnter(const char *text, int, int, int, int) {
+    if (SDL_strcmp(text, "> CONTINUE <")) return;
+    SDL_Event event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_RETURN;
+    event.key.key = SDLK_RETURN;
+    SDL_PushEvent(&event);
+    g_textRecorder = nullptr;
+}
+
+int main() {
+    test_headless_init();
+    require(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD), "SDL init");
+    const auto dir = std::filesystem::temp_directory_path() /
+        ("f15-controls-" + std::to_string(SDL_GetPerformanceCounter()));
+    std::filesystem::create_directories(dir);
+    SDL_setenv_unsafe("F15_JOY_CONFIG_DIR", dir.string().c_str(), 1);
+    controls_resetKeyboard();
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i) {
+        const RawAction action = (RawAction)i;
+        const ControlAction &info = controls_action(action);
+        require(info.name && *info.name && info.label && *info.label, "every action has metadata");
+        if (info.key)
+            require(controls_translateKey(info.key, info.modifiers, 0) == info.command, "original keyboard defaults");
+    }
+    require(controls_translateKey(SDL_SCANCODE_KP_ENTER, SDL_KMOD_NONE, 0) == SCAN_ENTER, "keypad Enter alias");
+    require(controls_bindKey(RAW_GEAR, SDL_SCANCODE_P, SDL_KMOD_NONE), "swap keys");
+    require(controls_translateKey(SDL_SCANCODE_P, SDL_KMOD_NONE, 0) == SCAN_L, "P is gear");
+    require(controls_translateKey(SDL_SCANCODE_L, SDL_KMOD_NONE, 0) == SCAN_P, "L is autopilot");
+    require(controls_bindKey(RAW_GEAR, SDL_SCANCODE_UNKNOWN, SDL_KMOD_NONE), "clear key");
+    require(controls_translateKey(SDL_SCANCODE_P, SDL_KMOD_NONE, SCAN_P) == 0, "displaced default suppressed");
+    require(!controls_bindKey(RAW_GEAR, SDL_SCANCODE_RETURN, SDL_KMOD_ALT), "fullscreen reserved");
+    require(!controls_bindKey(RAW_GEAR, SDL_SCANCODE_LSHIFT, SDL_KMOD_NONE), "modifier alone rejected");
+    require(controls_bindKey(RAW_GEAR, SDL_SCANCODE_F12, SDL_KMOD_CTRL), "arbitrary physical key");
+    require(controls_translateKey(SDL_SCANCODE_F12, SDL_KMOD_RCTRL, 0) == SCAN_L, "normalize right modifier");
+    input_setMode(INPUT_MODE_FLIGHT);
+    SDL_Event event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_F12;
+    event.key.mod = SDL_KMOD_LCTRL;
+    SDL_PushEvent(&event);
+    require(input_keyWaiting() && input_readKey() == SCAN_L, "real input pump applies mapping");
+    controls_beginCapture(RAW_GEAR);
+    event.key.scancode = SDL_SCANCODE_LSHIFT;
+    event.key.mod = SDL_KMOD_LSHIFT;
+    require(controls_captureKey(event.key) && controls_capturing(), "capture waits for key");
+    event.key.scancode = SDL_SCANCODE_F11;
+    require(controls_captureKey(event.key) && !controls_capturing(), "capture assigns chord");
+    require(controls_translateKey(SDL_SCANCODE_F11, SDL_KMOD_SHIFT, 0) == SCAN_L, "captured chord acts");
+    controls_beginCapture(RAW_GEAR);
+    event.key.scancode = SDL_SCANCODE_ESCAPE;
+    controls_captureKey(event.key);
+    require(!controls_capturing(), "escape cancels capture");
+    const std::string path = controls_keyboardPath();
+    require(controls_saveKeyboard(path), "save keyboard");
+    controls_resetKeyboard();
+    require(controls_translateKey(SDL_SCANCODE_L, SDL_KMOD_NONE, 0) == SCAN_L, "reset restores defaults");
+    require(controls_loadKeyboard(path), "load keyboard");
+    require(controls_translateKey(SDL_SCANCODE_F11, SDL_KMOD_SHIFT, 0) == SCAN_L, "roundtrip");
+    std::ofstream(path) << "F15_KEYBOARD 1\ncannon 999999 0\n";
+    require(!controls_loadKeyboard(path), "malformed file rejected");
+    require(controls_translateKey(SDL_SCANCODE_F11, SDL_KMOD_SHIFT, 0) == SCAN_L, "failed load preserves mapping");
+    require(!controls_saveKeyboard((dir / "missing" / "keyboard.txt").string()), "failed save reported");
+    gfx_videoInit();
+    gfx_initState();
+    gfx_setMode13();
+    input_setMode(INPUT_MODE_MENU);
+    g_textRecorder = pressEnter;
+    joy_showSetup();
+    require(g_textRecorder == nullptr, "keyboard-only setup defaults to Continue");
+    require(controls_loadKeyboard(path), "setup saves valid defaults after invalid profile");
+    gfx_videoShutdown();
+    SDL_Quit();
+    SDL_unsetenv_unsafe("F15_JOY_CONFIG_DIR");
+    std::filesystem::remove_all(dir);
+    std::cout << "controls_behavior_tests passed\n";
+}

--- a/tests/joystick_behavior_tests.cpp
+++ b/tests/joystick_behavior_tests.cpp
@@ -1,5 +1,7 @@
 #include "joystick.h"
 #include "joystick_axes.h"
+#include "joystick_mapping.h"
+#include "shared/common.h"
 #include "input.h"
 #include "egkeys.h"
 #include "gfx.h"
@@ -10,8 +12,19 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <filesystem>
+#include <fstream>
 
 namespace {
+
+static SDL_Joystick *setupStick = nullptr;
+
+void pressContinueOnDraw(const char *text, int, int, int, int) {
+    if (setupStick && SDL_strcmp(text, "> CONTINUE <") == 0) {
+        SDL_SetJoystickVirtualButton(setupStick, 0, true);
+        setupStick = nullptr;
+    }
+}
 
 void require(bool condition, const char *message) {
     if (!condition) {
@@ -239,13 +252,68 @@ void menuAndSetup() {
             "menu input resumes after setup and release");
     stick.button(0, false);
 
-    pushKey(SDL_SCANCODE_RETURN, SDLK_RETURN);
+    // Real setup loop must default to Continue and exit with a joystick only.
+    setupStick = stick.handle;
+    g_textRecorder = pressContinueOnDraw;
     joy_showSetup();
+    g_textRecorder = nullptr;
+    require(setupStick == nullptr, "Continue is selected by default");
     int pitch = 0;
     const uint8 *pixels = gfx_pagePixels(0, &pitch);
     require(pixels && pixels[8 * pitch + 8] == COLOR_LIGHTRED,
             "actual setup screen renders legacy border headlessly");
     require(!input_keyWaiting(), "setup consumes its continue key");
+    stick.button(0, false);
+}
+
+void persistence(const std::filesystem::path &directory) {
+    const std::string path = (directory / "roundtrip.txt").string();
+    int original[RAW_ACTION_COUNT] = {2, 0, 1, 3, -1, -1};
+    int loaded[RAW_ACTION_COUNT] = {-1, -1, -1, -1, -1, -1};
+    require(joy_saveMapping(path, 4, original), "save complete mapping");
+    require(joy_loadMapping(path, 4, loaded), "load complete mapping");
+    for (int i = 0; i < RAW_ACTION_COUNT; ++i)
+        require(loaded[i] == original[i], "roundtrip preserves bindings and disabled actions");
+    original[0] = -1;
+    require(joy_saveMapping(path, 4, original) && joy_loadMapping(path, 4, loaded) && loaded[0] == -1,
+            "replacement save updates existing file");
+    original[0] = 0;
+    require(!joy_saveMapping(path, 4, original), "duplicate assignments are not saved");
+    require(joy_loadMapping(path, 4, loaded) && loaded[0] == -1,
+            "rejected save preserves previous profile");
+
+    const char *invalid[] = {
+        "F15_JOYSTICK 2\n", "F15_JOYSTICK 1\ncannon 1\n",
+        "F15_JOYSTICK 1\ncannon 999999999999999999999\n",
+        "F15_JOYSTICK 1\ncannon 1\nmissile 1\ncountermeasure 3\nweapon 4\nthrust_up 0\nthrust_down 0\n",
+        "F15_JOYSTICK 1\ncannon 5\nmissile 2\ncountermeasure 3\nweapon 4\nthrust_up 0\nthrust_down 0\n"
+    };
+    for (const char *contents : invalid) {
+        std::ofstream(path) << contents;
+        require(!joy_loadMapping(path, 4, loaded), "invalid profile rejected");
+        require(loaded[0] == -1 && loaded[1] == 0, "invalid load leaves caller mapping unchanged");
+    }
+    require(!joy_saveMapping((directory / "missing" / "mapping.txt").string(), 4, loaded),
+            "unwritable path reports save failure");
+    {
+        Stick stick(2, 7);
+        joy_bindRawButton(RAW_CANNON, 6);
+        require(joy_saveRawMapping(), "save active device mapping");
+    }
+    {
+        Stick stick(2, 7);
+        require(joy_rawBinding(RAW_CANNON) == 6, "reopening device restores mapping");
+    }
+    SDL_setenv_unsafe("F15_JOY_CANNON", "1", 1);
+    {
+        Stick stick(2, 7);
+        require(joy_rawBinding(RAW_CANNON) == 0, "explicit environment overrides saved mapping");
+    }
+    SDL_unsetenv_unsafe("F15_JOY_CANNON");
+    {
+        Stick stick(2, 8);
+        require(joy_rawBinding(RAW_CANNON) == 0, "different control count gets separate profile");
+    }
 }
 
 void overridesAndGamepad() {
@@ -280,6 +348,10 @@ void overridesAndGamepad() {
 
 int main() {
     test_headless_init();
+    const auto directory = std::filesystem::temp_directory_path() /
+        ("f15-joystick-tests-" + std::to_string(SDL_GetPerformanceCounter()));
+    std::filesystem::create_directories(directory);
+    SDL_setenv_unsafe("F15_JOY_CONFIG_DIR", directory.string().c_str(), 1);
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
     require(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD), "initialize SDL");
     gfx_videoInit();
@@ -290,7 +362,10 @@ int main() {
     throttle();
     menuAndSetup();
     overridesAndGamepad();
+    persistence(directory);
     gfx_videoShutdown();
     SDL_Quit();
+    SDL_unsetenv_unsafe("F15_JOY_CONFIG_DIR");
+    std::filesystem::remove_all(directory);
     std::cout << "joystick_behavior_tests passed\n";
 }

--- a/tests/joystick_behavior_tests.cpp
+++ b/tests/joystick_behavior_tests.cpp
@@ -1,4 +1,5 @@
 #include "joystick.h"
+#include "joystick_axes.h"
 #include "input.h"
 #include "egkeys.h"
 #include "gfx.h"
@@ -38,14 +39,14 @@ struct Stick {
     SDL_JoystickID id = 0;
     SDL_Joystick *handle = nullptr;
 
-    Stick(int axes, int buttons, bool st200 = false, bool gamepad = false) {
+    Stick(int axes, int buttons, bool gamepad = false) {
         SDL_VirtualJoystickDesc desc = {};
         SDL_INIT_INTERFACE(&desc);
         desc.type = gamepad ? SDL_JOYSTICK_TYPE_GAMEPAD : SDL_JOYSTICK_TYPE_FLIGHT_STICK;
         desc.naxes = axes;
         desc.nbuttons = buttons;
-        desc.vendor_id = st200 ? 0x06a3 : 0x1234;
-        desc.product_id = st200 ? 0x0502 : 0xabcd;
+        desc.vendor_id = 0x1234;
+        desc.product_id = 0xabcd;
         desc.name = "F15 joystick test";
         id = SDL_AttachVirtualJoystick(&desc);
         require(id != 0, "attach virtual joystick");
@@ -149,16 +150,30 @@ void flightCommands() {
 }
 
 void throttle() {
+#ifdef __linux__
+    const unsigned char simple[] = {ABS_X, ABS_Y, ABS_THROTTLE};
+    const unsigned char extended[] = {ABS_X, ABS_Y, ABS_RX, ABS_RY, ABS_THROTTLE};
+    const unsigned char twist[] = {ABS_X, ABS_Y, ABS_RZ};
+    const unsigned char hats[] = {ABS_X, ABS_Y, ABS_HAT0X, ABS_HAT0Y, ABS_THROTTLE};
+    require(joy_linuxThrottleIndex(simple, 3) == 2, "generic three-axis throttle metadata");
+    require(joy_linuxThrottleIndex(extended, 5) == 4, "throttle need not be third axis");
+    require(joy_linuxThrottleIndex(twist, 3) == -1, "rudder metadata does not mean throttle");
+    require(joy_linuxThrottleIndex(hats, 5) == 2, "joydev hats do not shift SDL analog indices");
+    require(joy_linuxThrottleIndex(simple, 0) == -1, "missing metadata has no throttle");
+#endif
     {
         Stick stick(3, 6);
         stick.axis(2, -32768);
         require(joy_throttleChange() == -1, "unknown third axis is not guessed as throttle");
         require(joy_rawBinding(RAW_THRUST_UP) == 4, "unknown extra axis retains thrust buttons");
     }
+    // SDL virtual devices have no kernel metadata; use the explicit assignment
+    // to exercise the identical runtime throttle path on every CI platform.
+    SDL_setenv_unsafe("F15_JOY_THROTTLE_AXIS", "3", 1);
     {
-        Stick stick(3, 6, true);
+        Stick stick(3, 6);
         require(joy_rawBinding(RAW_THRUST_UP) == -1 && joy_rawBinding(RAW_THRUST_DOWN) == -1,
-                "recognized lever leaves thrust buttons unassigned");
+                "configured lever leaves thrust buttons unassigned");
         stick.axis(2, 32767);
         require(joy_throttleChange() == 0, "lever idle endpoint");
         require(joy_throttleChange() == -1, "stationary lever does not overwrite keyboard thrust");
@@ -180,9 +195,9 @@ void throttle() {
     }
     SDL_setenv_unsafe("F15_JOY_THROTTLE_AXIS", "0", 1);
     {
-        Stick stick(3, 6, true);
+        Stick stick(3, 6);
         require(joy_throttleChange() == -1 && joy_rawBinding(RAW_THRUST_UP) == 4,
-                "explicitly disabling recognized throttle restores button fallback");
+                "explicitly disabling throttle restores button fallback");
     }
     SDL_unsetenv_unsafe("F15_JOY_THROTTLE_AXIS");
     SDL_unsetenv_unsafe("F15_JOY_THROTTLE_INVERT");
@@ -250,7 +265,7 @@ void overridesAndGamepad() {
     SDL_unsetenv_unsafe("F15_JOY_COUNTERMEASURE");
     SDL_unsetenv_unsafe("F15_JOY_WEAPON");
     {
-        Stick pad(SDL_GAMEPAD_AXIS_COUNT, SDL_GAMEPAD_BUTTON_COUNT, false, true);
+        Stick pad(SDL_GAMEPAD_AXIS_COUNT, SDL_GAMEPAD_BUTTON_COUNT, true);
         pad.axis(SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, 32767);
         require(misc_readJoystick(0) != 0, "gamepad right trigger still fires cannon");
         pad.axis(SDL_GAMEPAD_AXIS_LEFT_TRIGGER, 32767);

--- a/tests/joystick_behavior_tests.cpp
+++ b/tests/joystick_behavior_tests.cpp
@@ -4,6 +4,7 @@
 #include "shared/common.h"
 #include "input.h"
 #include "egkeys.h"
+#include "egtypes.h"
 #include "gfx.h"
 #include "gfx_impl.h"
 #include "headless.h"
@@ -128,38 +129,62 @@ void defaultsAndRemapping() {
 void flightCommands() {
     Stick stick(2, 6);
     stick.button(2, true);
-    require(joy_flightCommand(0) == SCAN_C, "countermeasure starts with chaff");
-    require(joy_flightCommand(0) == 0, "held countermeasure is not repeated");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_C, "countermeasure starts with chaff");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0, "held countermeasure is not repeated");
     stick.button(2, false);
     stick.button(2, true);
-    require(joy_flightCommand(0) == SCAN_F, "next countermeasure is flare");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_F, "next countermeasure is flare");
     stick.button(2, false);
     for (int weapon = 0; weapon < 3; ++weapon) {
         stick.button(3, true);
         const int expected[] = {SCAN_M, SCAN_G, SCAN_S};
-        require(joy_flightCommand(weapon) == expected[weapon], "cycle follows actual selected weapon");
+        require(joy_flightCommand(weapon, VIEW_COCKPIT) == expected[weapon], "cycle follows actual selected weapon");
         stick.button(3, false);
     }
     stick.button(4, true);
-    require(joy_flightCommand(0) == SCAN_EQUAL, "button five raises thrust without lever");
-    require(joy_flightCommand(0) == 0, "thrust repeat waits initially");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_EQUAL, "button five raises thrust without lever");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0, "thrust repeat waits initially");
     SDL_Delay(260);
-    require(joy_flightCommand(0) == SCAN_EQUAL, "held thrust button repeats");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_EQUAL, "held thrust button repeats");
     stick.button(4, false);
-    require(joy_flightCommand(0) == 0, "release stops thrust repeat");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0, "release stops thrust repeat");
     stick.button(5, true);
-    require(joy_flightCommand(0) == SCAN_MINUS, "button six lowers thrust");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_MINUS, "button six lowers thrust");
     stick.button(5, false);
 
     // The game flushes keyboard events; raw commands must survive that flush.
     stick.button(2, true);
     stick.button(3, true);
     input_ringReset();
-    require(joy_flightCommand(0) == SCAN_C, "first pending command survives BIOS-ring reset");
-    require(joy_flightCommand(0) == SCAN_M, "second simultaneous action survives next step");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_C, "first pending command survives BIOS-ring reset");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_M, "second simultaneous action survives next step");
     focus(false);
-    require(joy_flightCommand(0) == 0 && !joy_rawActive(), "unfocused stick does not control flight");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0 && !joy_rawActive(), "unfocused stick does not control flight");
     focus(true);
+}
+
+void autopilotAndViews() {
+    Stick stick(2, 10);
+    stick.button(6, true);
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_L, "gear uses existing keyboard command");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0, "held gear button does not toggle repeatedly");
+    stick.button(6, false);
+    stick.button(7, true);
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_P, "autopilot uses existing keyboard command");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0, "held autopilot button does not toggle repeatedly");
+    stick.button(7, false);
+    stick.button(8, true);
+    require(joy_flightCommand(0, VIEW_COCKPIT) == SCAN_T, "next target uses existing keyboard command");
+    require(joy_flightCommand(0, VIEW_COCKPIT) == 0, "held target button does not cycle repeatedly");
+    stick.button(8, false);
+    const int views[] = {VIEW_COCKPIT, VIEW_EXT_FOLLOW, VIEW_EXT_DYNAMIC, VIEW_EXT_SIDE, VIEW_TARGET};
+    const int commands[] = {SCAN_F5, SCAN_F6, SCAN_F7, SCAN_SPACEBAR, SCAN_SPACEBAR};
+    for (int i = 0; i < 5; ++i) {
+        stick.button(9, true);
+        require(joy_flightCommand(0, views[i]) == commands[i], "view cycle follows current camera");
+        require(joy_flightCommand(0, views[i]) == 0, "view switch is edge-triggered");
+        stick.button(9, false);
+    }
 }
 
 void throttle() {
@@ -268,8 +293,8 @@ void menuAndSetup() {
 
 void persistence(const std::filesystem::path &directory) {
     const std::string path = (directory / "roundtrip.txt").string();
-    int original[RAW_ACTION_COUNT] = {2, 0, 1, 3, -1, -1};
-    int loaded[RAW_ACTION_COUNT] = {-1, -1, -1, -1, -1, -1};
+    int original[RAW_ACTION_COUNT] = {2, 0, 1, 3, -1, -1, -1, -1, -1, -1};
+    int loaded[RAW_ACTION_COUNT] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
     require(joy_saveMapping(path, 4, original), "save complete mapping");
     require(joy_loadMapping(path, 4, loaded), "load complete mapping");
     for (int i = 0; i < RAW_ACTION_COUNT; ++i)
@@ -359,6 +384,7 @@ int main() {
     gfx_setMode13();
     defaultsAndRemapping();
     flightCommands();
+    autopilotAndViews();
     throttle();
     menuAndSetup();
     overridesAndGamepad();

--- a/tests/joystick_behavior_tests.cpp
+++ b/tests/joystick_behavior_tests.cpp
@@ -295,6 +295,7 @@ void persistence(const std::filesystem::path &directory) {
     const std::string path = (directory / "roundtrip.txt").string();
     int original[RAW_ACTION_COUNT] = {2, 0, 1, 3, -1, -1, -1, -1, -1, -1};
     int loaded[RAW_ACTION_COUNT] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+    for (int i = RAW_VIEW + 1; i < RAW_ACTION_COUNT; ++i) original[i] = loaded[i] = -1;
     require(joy_saveMapping(path, 4, original), "save complete mapping");
     require(joy_loadMapping(path, 4, loaded), "load complete mapping");
     for (int i = 0; i < RAW_ACTION_COUNT; ++i)
@@ -365,7 +366,7 @@ void overridesAndGamepad() {
         require(misc_readJoystick(1) != 0, "gamepad left trigger still fires missile");
         require(joy_rawButtonCount() == 0 && joy_throttleChange() == -1,
                 "raw defaults do not affect mapped gamepad");
-        joy_showSetup();
+        // Controls setup also serves keyboards now; tested separately below.
     }
 }
 

--- a/tests/joystick_behavior_tests.cpp
+++ b/tests/joystick_behavior_tests.cpp
@@ -1,0 +1,281 @@
+#include "joystick.h"
+#include "input.h"
+#include "egkeys.h"
+#include "gfx.h"
+#include "gfx_impl.h"
+#include "headless.h"
+#include "slot.h"
+#include "const.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char *message) {
+    if (!condition) {
+        std::cerr << "failed: " << message << ": " << SDL_GetError() << '\n';
+        std::exit(1);
+    }
+}
+
+void pushKey(SDL_Scancode scancode, SDL_Keycode keycode) {
+    SDL_Event event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = scancode;
+    event.key.key = keycode;
+    require(SDL_PushEvent(&event), "queue keyboard event");
+}
+
+void focus(bool active) {
+    SDL_Event event = {};
+    event.type = active ? SDL_EVENT_WINDOW_FOCUS_GAINED : SDL_EVENT_WINDOW_FOCUS_LOST;
+    require(SDL_PushEvent(&event), "queue focus event");
+    input_pumpEvents();
+}
+
+struct Stick {
+    SDL_JoystickID id = 0;
+    SDL_Joystick *handle = nullptr;
+
+    Stick(int axes, int buttons, bool st200 = false, bool gamepad = false) {
+        SDL_VirtualJoystickDesc desc = {};
+        SDL_INIT_INTERFACE(&desc);
+        desc.type = gamepad ? SDL_JOYSTICK_TYPE_GAMEPAD : SDL_JOYSTICK_TYPE_FLIGHT_STICK;
+        desc.naxes = axes;
+        desc.nbuttons = buttons;
+        desc.vendor_id = st200 ? 0x06a3 : 0x1234;
+        desc.product_id = st200 ? 0x0502 : 0xabcd;
+        desc.name = "F15 joystick test";
+        id = SDL_AttachVirtualJoystick(&desc);
+        require(id != 0, "attach virtual joystick");
+        handle = SDL_OpenJoystick(id);
+        require(handle != nullptr, "open virtual joystick");
+        // Bind the fixture before pumping device arrivals, even when the test
+        // machine also has a physical joystick connected.
+        SDL_Event added = {};
+        added.type = gamepad ? SDL_EVENT_GAMEPAD_ADDED : SDL_EVENT_JOYSTICK_ADDED;
+        added.jdevice.which = id;
+        joy_handleEvent(&added);
+        joy_init();
+        input_setMode(INPUT_MODE_FLIGHT);
+        input_setJoystickSetup(false);
+        focus(true);
+        require(joy_isGamepad() == gamepad, "fixture uses requested input backend");
+    }
+
+    ~Stick() {
+        joy_shutdown();
+        SDL_CloseJoystick(handle);
+        require(SDL_DetachVirtualJoystick(id), "detach virtual joystick");
+        SDL_FlushEvents(SDL_EVENT_FIRST, SDL_EVENT_LAST);
+    }
+
+    void button(int index, bool down) {
+        require(SDL_SetJoystickVirtualButton(handle, index, down), "set virtual button");
+        SDL_UpdateJoysticks();
+        input_pumpEvents();
+    }
+
+    void axis(int index, Sint16 value) {
+        require(SDL_SetJoystickVirtualAxis(handle, index, value), "set virtual axis");
+        SDL_UpdateJoysticks();
+        input_pumpEvents();
+    }
+};
+
+void defaultsAndRemapping() {
+    for (int count : {1, 2, 4, 6}) {
+        Stick stick(2, count);
+        for (int action = 0; action < RAW_ACTION_COUNT; ++action)
+            require(joy_rawBinding((RawAction)action) == (action < count ? action : -1),
+                    "default order preserves upstream fire buttons and respects button count");
+        stick.button(0, true);
+        require(misc_readJoystick(0) != 0 && misc_readJoystick(1) == 0,
+                "first button fires cannon, not missiles");
+        stick.button(0, false);
+        if (count > 1) {
+            stick.button(1, true);
+            require(misc_readJoystick(1) != 0 && misc_readJoystick(0) == 0,
+                    "second button fires missiles, not cannon");
+            stick.button(1, false);
+            joy_bindRawButton(RAW_CANNON, 1);
+            require(joy_rawBinding(RAW_CANNON) == 1 && joy_rawBinding(RAW_MISSILE) == 0,
+                    "assigning occupied button swaps actions");
+        }
+        joy_bindRawButton(RAW_CANNON, -1);
+        require(joy_rawBinding(RAW_CANNON) == -1, "unassign action");
+        joy_bindRawButton(RAW_CANNON, count);
+        require(joy_rawBinding(RAW_CANNON) == -1, "reject nonexistent button");
+        require(joy_throttleChange() == -1, "two-axis stick has no throttle");
+    }
+}
+
+void flightCommands() {
+    Stick stick(2, 6);
+    stick.button(2, true);
+    require(joy_flightCommand(0) == SCAN_C, "countermeasure starts with chaff");
+    require(joy_flightCommand(0) == 0, "held countermeasure is not repeated");
+    stick.button(2, false);
+    stick.button(2, true);
+    require(joy_flightCommand(0) == SCAN_F, "next countermeasure is flare");
+    stick.button(2, false);
+    for (int weapon = 0; weapon < 3; ++weapon) {
+        stick.button(3, true);
+        const int expected[] = {SCAN_M, SCAN_G, SCAN_S};
+        require(joy_flightCommand(weapon) == expected[weapon], "cycle follows actual selected weapon");
+        stick.button(3, false);
+    }
+    stick.button(4, true);
+    require(joy_flightCommand(0) == SCAN_EQUAL, "button five raises thrust without lever");
+    require(joy_flightCommand(0) == 0, "thrust repeat waits initially");
+    SDL_Delay(260);
+    require(joy_flightCommand(0) == SCAN_EQUAL, "held thrust button repeats");
+    stick.button(4, false);
+    require(joy_flightCommand(0) == 0, "release stops thrust repeat");
+    stick.button(5, true);
+    require(joy_flightCommand(0) == SCAN_MINUS, "button six lowers thrust");
+    stick.button(5, false);
+
+    // The game flushes keyboard events; raw commands must survive that flush.
+    stick.button(2, true);
+    stick.button(3, true);
+    input_ringReset();
+    require(joy_flightCommand(0) == SCAN_C, "first pending command survives BIOS-ring reset");
+    require(joy_flightCommand(0) == SCAN_M, "second simultaneous action survives next step");
+    focus(false);
+    require(joy_flightCommand(0) == 0 && !joy_rawActive(), "unfocused stick does not control flight");
+    focus(true);
+}
+
+void throttle() {
+    {
+        Stick stick(3, 6);
+        stick.axis(2, -32768);
+        require(joy_throttleChange() == -1, "unknown third axis is not guessed as throttle");
+        require(joy_rawBinding(RAW_THRUST_UP) == 4, "unknown extra axis retains thrust buttons");
+    }
+    {
+        Stick stick(3, 6, true);
+        require(joy_rawBinding(RAW_THRUST_UP) == -1 && joy_rawBinding(RAW_THRUST_DOWN) == -1,
+                "recognized lever leaves thrust buttons unassigned");
+        stick.axis(2, 32767);
+        require(joy_throttleChange() == 0, "lever idle endpoint");
+        require(joy_throttleChange() == -1, "stationary lever does not overwrite keyboard thrust");
+        stick.axis(2, -32768);
+        require(joy_throttleChange() == 100, "lever full-thrust endpoint");
+        stick.axis(2, 0);
+        require(joy_throttleChange() == 50, "lever midpoint");
+        stick.axis(2, 100);
+        require(joy_throttleChange() == -1, "resting lever noise is ignored");
+    }
+    SDL_setenv_unsafe("F15_JOY_THROTTLE_AXIS", "3", 1);
+    SDL_setenv_unsafe("F15_JOY_THROTTLE_INVERT", "0", 1);
+    {
+        Stick stick(3, 4);
+        stick.axis(2, -32768);
+        require(joy_throttleChange() == 0, "explicit axis supports opposite polarity");
+        stick.axis(2, 32767);
+        require(joy_throttleChange() == 100, "opposite polarity full thrust");
+    }
+    SDL_setenv_unsafe("F15_JOY_THROTTLE_AXIS", "0", 1);
+    {
+        Stick stick(3, 6, true);
+        require(joy_throttleChange() == -1 && joy_rawBinding(RAW_THRUST_UP) == 4,
+                "explicitly disabling recognized throttle restores button fallback");
+    }
+    SDL_unsetenv_unsafe("F15_JOY_THROTTLE_AXIS");
+    SDL_unsetenv_unsafe("F15_JOY_THROTTLE_INVERT");
+}
+
+void menuAndSetup() {
+    Stick stick(2, 4);
+    input_setMode(INPUT_MODE_MENU);
+    input_ringReset();
+    stick.axis(1, 24000);
+    require(input_keyWaiting() && input_readKey() == KEYCODE_DNARROW, "stick selects menu row");
+    stick.axis(1, 0);
+    stick.axis(0, -24000);
+    require(input_keyWaiting() && input_readKey() == KEYCODE_LEFTARROW, "stick selects menu column");
+    stick.axis(0, 0);
+    stick.button(0, true);
+    require(input_keyWaiting() && input_readKey() == SCAN_ENTER, "first menu button confirms");
+    require(!input_keyWaiting(), "held menu button does not confirm repeatedly");
+    stick.button(0, false);
+    stick.button(1, true);
+    require(input_keyWaiting() && input_readKey() == SCAN_ESCAPE, "second menu button goes back");
+    stick.button(1, false);
+
+    input_setJoystickSetup(true);
+    stick.axis(1, 24000);
+    stick.button(0, true);
+    require(!input_keyWaiting(), "setup suppresses menu translation of stick and buttons");
+    require(joy_rawPressedButton() == 0 && joy_rawMenuAxis(1) == 24000,
+            "physical controls remain readable during setup");
+    pushKey(SDL_SCANCODE_DOWN, SDLK_DOWN);
+    require(input_keyWaiting() && input_readKey() == KEYCODE_DNARROW,
+            "keyboard still selects during setup");
+    stick.axis(1, 0);
+    input_setJoystickSetup(false);
+    require(!input_keyWaiting(), "held assignment button does not confirm next menu");
+    stick.button(0, false);
+    stick.button(0, true);
+    require(input_keyWaiting() && input_readKey() == SCAN_ENTER,
+            "menu input resumes after setup and release");
+    stick.button(0, false);
+
+    pushKey(SDL_SCANCODE_RETURN, SDLK_RETURN);
+    joy_showSetup();
+    int pitch = 0;
+    const uint8 *pixels = gfx_pagePixels(0, &pitch);
+    require(pixels && pixels[8 * pitch + 8] == COLOR_LIGHTRED,
+            "actual setup screen renders legacy border headlessly");
+    require(!input_keyWaiting(), "setup consumes its continue key");
+}
+
+void overridesAndGamepad() {
+    SDL_setenv_unsafe("F15_JOY_CANNON", "2", 1);
+    SDL_setenv_unsafe("F15_JOY_MISSILE", "1", 1);
+    SDL_setenv_unsafe("F15_JOY_COUNTERMEASURE", "0", 1);
+    SDL_setenv_unsafe("F15_JOY_WEAPON", "invalid", 1);
+    {
+        Stick stick(2, 4);
+        require(joy_rawBinding(RAW_CANNON) == 1 && joy_rawBinding(RAW_MISSILE) == 0,
+                "environment indices are one-based");
+        require(joy_rawBinding(RAW_COUNTERMEASURE) == -1, "zero disables a binding");
+        require(joy_rawBinding(RAW_WEAPON) == 3, "malformed assignment preserves default");
+    }
+    SDL_unsetenv_unsafe("F15_JOY_CANNON");
+    SDL_unsetenv_unsafe("F15_JOY_MISSILE");
+    SDL_unsetenv_unsafe("F15_JOY_COUNTERMEASURE");
+    SDL_unsetenv_unsafe("F15_JOY_WEAPON");
+    {
+        Stick pad(SDL_GAMEPAD_AXIS_COUNT, SDL_GAMEPAD_BUTTON_COUNT, false, true);
+        pad.axis(SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, 32767);
+        require(misc_readJoystick(0) != 0, "gamepad right trigger still fires cannon");
+        pad.axis(SDL_GAMEPAD_AXIS_LEFT_TRIGGER, 32767);
+        require(misc_readJoystick(1) != 0, "gamepad left trigger still fires missile");
+        require(joy_rawButtonCount() == 0 && joy_throttleChange() == -1,
+                "raw defaults do not affect mapped gamepad");
+        joy_showSetup();
+    }
+}
+
+} // namespace
+
+int main() {
+    test_headless_init();
+    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+    require(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD), "initialize SDL");
+    gfx_videoInit();
+    gfx_initState();
+    gfx_setMode13();
+    defaultsAndRemapping();
+    flightCommands();
+    throttle();
+    menuAndSetup();
+    overridesAndGamepad();
+    gfx_videoShutdown();
+    SDL_Quit();
+    std::cout << "joystick_behavior_tests passed\n";
+}


### PR DESCRIPTION
Adds a startup controls screen in the original bitmap style: flight actions, keyboard and raw joystick assignments, reset defaults, and saved profiles. Existing keyboard shortcuts and the first two joystick fire buttons remain defaults. Menu navigation, text entry, and mapped gamepad bindings are unchanged.

Review order:
1. controls.cpp: action catalog, keyboard translation and storage.
2. joystick.c / joystick_mapping.cpp: button commands and per-device profiles.
3. joystick_setup.c: scrollable setup screen and key capture.
4. input.c: flight-only translation hooks.
5. Tests: defaults, remapping, capture, persistence and joystick-only/keyboard-only setup.

Linux build and all 32 tests passed before the final font/palette adjustments; the final UI version was rebuilt and launched. Current CI results are pending. Separate from mouse PR #48.