### PR TITLE
DOS: fix audio, joystick firing and high-resolution title

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ else()
                 SDL3
                 URL "https://github.com/libsdl-org/SDL/archive/e442a9a5e1d6eb2621e9206f5176c53b0d034e09.tar.gz"
                 URL_HASH SHA256=8ebc84ff04c076c0e6249c885fc1efc6dc5f13a411b31de8621478646ff76bcf
+                PATCH_COMMAND ${CMAKE_COMMAND} -DSDL_SOURCE_DIR=<SOURCE_DIR>
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_sdl_dos_audio.cmake
                 UPDATE_DISCONNECTED TRUE
             )
         else()

--- a/cmake/patch_sdl_dos_audio.cmake
+++ b/cmake/patch_sdl_dos_audio.cmake
@@ -1,0 +1,18 @@
+# The pinned SDL DOS audio backend yields only when its ring buffer is full.
+# Slow mixing can leave it permanently empty, starving the cooperative main
+# thread. Keep this workaround until the SDL revision includes a fairness fix.
+# Upstream: https://github.com/libsdl-org/SDL/pull/16288
+# Remove this script and its PATCH_COMMAND after updating and testing SDL.
+set(audio_source "${SDL_SOURCE_DIR}/src/audio/dos/SDL_dosaudio_sb.c")
+file(READ "${audio_source}" source)
+set(original "    const int size = hidden->ring_size;\n\n    for (;;) {")
+set(replacement "    const int size = hidden->ring_size;\n\n    // Yield even if slow mixing keeps the ring from filling: the main thread\n    // must process input and advance the game between audio iterations.\n    DOS_Yield();\n\n    for (;;) {")
+string(FIND "${source}" "${replacement}" patched_position)
+if(patched_position EQUAL -1)
+    string(FIND "${source}" "${original}" original_position)
+    if(original_position EQUAL -1)
+        message(FATAL_ERROR "SDL DOS audio wait changed; review the cooperative yield patch")
+    endif()
+    string(REPLACE "${original}" "${replacement}" source "${source}")
+    file(WRITE "${audio_source}" "${source}")
+endif()

--- a/docs/dos.md
+++ b/docs/dos.md
@@ -1,0 +1,94 @@
+# DOS preview
+
+This is a preview of the F-15 SE2 DOS port from upstream PR #27, with
+follow-up runtime fixes. It is not an official upstream release.
+
+## Run
+
+You need your own original F-15 Strike Eagle II game files. They are not
+included in the download. Extract the DOS ZIP into a writable directory
+alongside those files, keeping `CWSDPMI.EXE` beside `F15SE2EX.EXE`, then run:
+
+```text
+F15SE2EX.EXE
+```
+
+Alternatively, keep the game data in another directory:
+
+```text
+F15SE2EX.EXE --game C:\F15
+```
+
+Use `--nointro` to skip the logo/intro sequence. Back up your pilot records
+before testing: the game writes to its normal game-data directory.
+
+For DOSBox on Linux, with the executable and game files in separate folders:
+
+```text
+mount c /path/to/dos-release
+mount d /path/to/original-game
+c:
+F15SE2EX.EXE --game D:/
+```
+
+Tested interactively in DOSBox 0.74-3 with Sound Blaster 16 and AdLib
+emulation. Physical DOS hardware has not been tested. This is a 32-bit DJGPP
+build; it needs a DPMI host and VGA/VESA graphics. Configure `BLASTER` for
+your Sound Blaster-compatible card on real hardware.
+
+## Controls and audio
+
+Connect the joystick before starting DOSBox. The DOS driver exposes two axes
+and four buttons; the X/Y axes steer, button 1 fires the cannon, and button 2
+fires missiles. Those two buttons also confirm/cancel menu choices.
+Buttons 3 and 4 retain afterburner and weapon-cycle actions respectively.
+Keyboard controls are unchanged.
+
+Explicit joystick calibration is not included yet. The SDL DOS driver
+currently learns its axis range while the stick moves.
+
+FM music and effects use AdLib-compatible hardware registers on DOS rather
+than software OPL synthesis. Digitized speech still uses SDL's Sound Blaster
+audio output. This is a game-side DOS backend, not an SDL workaround.
+
+## Temporary SDL workarounds
+
+- Audio starvation: `cmake/patch_sdl_dos_audio.cmake` adds a cooperative yield
+  even when the audio ring has free space. Tracked by
+  https://github.com/libsdl-org/SDL/pull/16288.
+- Joystick mapping: `src/joystick.c` supplies bindings for the controls the
+  DOS driver actually exposes. The generic mapping otherwise reads missing
+  trigger axes as half-pressed. Tracked by
+  https://github.com/libsdl-org/SDL/issues/16289.
+
+Neither upstream fix is assumed to be available merely because it was
+reported. When updating SDL, check the linked changes, test idle joystick
+input and slow audio mixing, then remove the superseded workarounds.
+
+## Build
+
+With DJGPP's cross-compilers on `PATH` and a DJGPP CMake toolchain file:
+
+```sh
+cmake -S . -B build-dos \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/i586-pc-msdosdjgpp.cmake \
+  -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_DEPENDENCIES=ON
+cmake --build build-dos -j4
+```
+
+The output is `build-dos/f15se2ex.exe`. Build output and original game assets
+must not be committed. The release's source archive includes dependency
+sources and additional instructions for rebuilding without fetching them.
+
+## Redistribution
+
+The binary ZIP includes the game's MIT license and the SDL, Nuked OPL3 and
+QuickDigest5 licenses. The accompanying source archive contains the matching
+game and dependency source used to build the binary, including the SDL patch.
+QuickDigest5 is GPLv3 and Nuked OPL3 is LGPLv2.1; preserve those terms when
+redistributing the linked build. This does not grant rights to original
+commercial game assets.
+
+CWSDPMI release 7 is included unmodified with its documentation. You have the
+right to receive its source and binary updates:
+https://sandmann.dotster.com/cwsdpmi/

--- a/docs/dos.md
+++ b/docs/dos.md
@@ -1,7 +1,6 @@
 # DOS preview
 
-This is a preview of the F-15 SE2 DOS port from upstream PR #27, with
-follow-up runtime fixes. It is not an official upstream release.
+32bit DOS port of F-15 SE2 Ex
 
 ## Run
 
@@ -31,10 +30,7 @@ c:
 F15SE2EX.EXE --game D:/
 ```
 
-Tested interactively in DOSBox 0.74-3 with Sound Blaster 16 and AdLib
-emulation. Physical DOS hardware has not been tested. This is a 32-bit DJGPP
-build; it needs a DPMI host and VGA/VESA graphics. Configure `BLASTER` for
-your Sound Blaster-compatible card on real hardware.
+This is a 32-bit DJGPP build; it needs a DPMI host and VGA/VESA graphics. Configure `BLASTER` for your Sound Blaster-compatible card on real hardware.
 
 ## Controls and audio
 

--- a/src/asound/asound_dos_opl.h
+++ b/src/asound/asound_dos_opl.h
@@ -1,0 +1,26 @@
+#ifndef ASOUND_DOS_OPL_H
+#define ASOUND_DOS_OPL_H
+
+/* pc.h also declares kbhit(), which the game supplies through compat64. */
+#include <inlines/pc.h>
+
+/* AdLib-compatible OPL2 registers, also decoded by Sound Blaster cards. */
+enum {
+    ASND_OPL_ADDRESS_PORT = 0x388,
+    ASND_OPL_DATA_PORT = 0x389,
+    ASND_OPL_ADDRESS_DELAY_READS = 6,
+    ASND_OPL_DATA_DELAY_READS = 35
+};
+
+static void asnd_writeDosOpl(unsigned char reg, unsigned char value) {
+    outportb(ASND_OPL_ADDRESS_PORT, reg);
+    /* Status reads supply the OPL2 bus delays without yielding halfway through
+     * a register write: about 3.3 us after address, 23 us after data. */
+    for (int i = 0; i < ASND_OPL_ADDRESS_DELAY_READS; ++i)
+        inportb(ASND_OPL_ADDRESS_PORT);
+    outportb(ASND_OPL_DATA_PORT, value);
+    for (int i = 0; i < ASND_OPL_DATA_DELAY_READS; ++i)
+        inportb(ASND_OPL_ADDRESS_PORT);
+}
+
+#endif

--- a/src/asound/asound_sdl.c
+++ b/src/asound/asound_sdl.c
@@ -31,6 +31,10 @@ extern "C" {
 #include "input.h"  /* input_keyWaiting / input_setMode */
 #include "log.h"
 
+#ifdef __DJGPP__
+#include "asound_dos_opl.h"
+#endif
+
 #define ASND_OUT_RATE 44100 /* SDL output sample rate (Hz) */
 #define ASND_TICK_HZ 60     /* sequencer tick = game tick rate */
 #define ASND_SAMPLE_HZ 7231 /* F15DGTL.BIN playback rate (PIT ch2 1193182/165) */
@@ -66,7 +70,11 @@ static void asnd_syncChip(void) {
     for (int r = 0; r < ASOPL_REGISTER_COUNT; r++) {
         AsoundU8 v = asopl_get_register(&g_opl, (AsoundU8)r);
         if (g_hwShadow[r] == v) continue;
+#ifdef __DJGPP__
+        asnd_writeDosOpl((unsigned char)r, v);
+#else
         OPL3_WriteReg(&g_chip, (uint16_t)r, v);
+#endif
         g_hwShadow[r] = v;
     }
 }
@@ -151,7 +159,13 @@ static void SDLCALL asnd_callback(void *user, SDL_AudioStream *stream,
         if (chunk > (int)g_tickAccum) chunk = (int)g_tickAccum;
         if (chunk > ASND_CHUNK) chunk = ASND_CHUNK;
 
+#ifdef __DJGPP__
+        /* The AdLib chip produces FM audio directly. Only digitized speech
+         * needs PCM; synthesizing OPL again costs most of a DOS CPU's time. */
+        SDL_memset(buf, 0, chunk * 2 * sizeof(Sint16));
+#else
         OPL3_GenerateStream(&g_chip, buf, (uint32_t)chunk);
+#endif
         asnd_mixSample(buf, chunk);
         g_tickAccum -= chunk;
         SDL_UnlockMutex(g_lock);

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -424,6 +424,33 @@ void gfx_freeSpriteBuf(int handle) {
  * clears it when the title is dismissed. */
 static bool gfxHiResActive = false;
 
+static bool gfx_setDirectFBMode(int width, int height) {
+    int count = 0;
+    SDL_DisplayMode **modes = SDL_GetFullscreenDisplayModes(
+        SDL_GetDisplayForWindow(sdlWindow), &count);
+    const SDL_DisplayMode *best = NULL;
+    for (int i = 0; modes && i < count; ++i) {
+        const SDL_DisplayMode *mode = modes[i];
+        /* 640x350 may be planar-only. A 640x480 INDEX8 VESA mode can
+         * contain the title without losing pixels or changing its palette. */
+        if (mode->format == SDL_PIXELFORMAT_INDEX8 && mode->w == width &&
+            mode->h >= height && (!best || mode->h < best->h))
+            best = mode;
+    }
+    bool selected = best && SDL_SetWindowFullscreenMode(sdlWindow, best);
+    SDL_free(modes);
+    if (!selected || !SDL_SyncWindow(sdlWindow)) return false;
+
+    /* The old framebuffer and its palette belong to the previous mode. */
+    SDL_DestroyWindowSurface(sdlWindow);
+    SDL_Surface *surface = SDL_GetWindowSurface(sdlWindow);
+    if (!surface || surface->format != SDL_PIXELFORMAT_INDEX8 ||
+        surface->w != width || surface->h < height) return false;
+    if (gfxPalette) SDL_SetSurfacePalette(surface, gfxPalette);
+    SDL_ClearSurface(surface, 0, 0, 0, 1);
+    return true;
+}
+
 /* Bring up the window-surface present: request the native-resolution INDEX8
  * fullscreen mode (mode 13h on DOS) and adopt its window surface, presenting with
  * SDL_UpdateWindowSurface (a straight VRAM copy + VGA DAC program) instead of the
@@ -509,6 +536,7 @@ static void gfx_presentDirectFB(SDL_Surface *page, int shake) {
     if (!page) return;
     ws = SDL_GetWindowSurface(sdlWindow);
     if (!ws || ws->format != SDL_PIXELFORMAT_INDEX8) return;
+    if (gfxPalette) SDL_SetSurfacePalette(ws, gfxPalette);
 
     w = page->w < ws->w ? page->w : ws->w;
     h = page->h < ws->h ? page->h : ws->h;
@@ -518,6 +546,8 @@ static void gfx_presentDirectFB(SDL_Surface *page, int shake) {
 
     sp = (const Uint8 *)page->pixels;
     dp = (Uint8 *)ws->pixels;
+    /* Centre a 350-line title in a taller VESA mode. */
+    dp += (size_t)((ws->h - h) / 2) * ws->pitch;
     for (y = 0; y < h; y++)
         SDL_memcpy(dp + (size_t)y * ws->pitch,
                    sp + (size_t)y * page->pitch + shake, (size_t)copyw);
@@ -713,15 +743,21 @@ static void initRowOffsets(void) {
  * SDL. This is also the lo-res restore after the (possibly hi-res) title. */
 void FAR CDECL gfx_setMode13(void) {
     initRowOffsets();
+    if (s_directFB && gfxHiResActive &&
+        !gfx_setDirectFBMode(LOGICAL_WIDTH, LOGICAL_HEIGHT))
+        LogCritical(("Cannot restore 320x200 framebuffer: %s", SDL_GetError()));
     gfxHiResActive = false;
     gfx_getState()->modeFlag = 1;
 }
 
-/* Title-screen hi-res: switch to the 640x350 title surface. Both backends scale
- * whatever surface they're handed to the window via the shared r2d mapping (which
- * derives the virtual size from the surface), so this just flags hi-res; the
- * present picks up the 640x350 hi-res surface from gfx_presentHiRes. */
+/* Desktop renderers scale the title surface. The DOS framebuffer instead needs
+ * an actual display-mode change before it can accept a 640-wide image. */
 bool video_setHiRes(void) {
+    if (s_directFB && !gfx_setDirectFBMode(HIRES_WIDTH, HIRES_HEIGHT)) {
+        if (!gfx_setDirectFBMode(LOGICAL_WIDTH, LOGICAL_HEIGHT))
+            LogCritical(("Cannot restore title fallback mode: %s", SDL_GetError()));
+        return false;
+    }
     gfxHiResActive = true;
     return true;
 }

--- a/src/joystick.c
+++ b/src/joystick.c
@@ -73,6 +73,24 @@ static void joy_close(void) {
  * joystick. No-op when a device is already active. */
 static void joy_open(SDL_JoystickID id) {
     if (g_devId) return;
+#ifdef __DJGPP__
+    /* Temporary workaround: https://github.com/libsdl-org/SDL/issues/16289
+     * Revisit after updating SDL; retain the DOS fire/menu button bindings.
+     * SDL's DOS driver exposes two axes and four buttons. Its generic gamepad
+     * mapping invents trigger axes 4/5: their missing-axis value becomes 16383,
+     * above our fire threshold. Map physical buttons to triggers instead;
+     * this also preserves the menu pump's confirm/cancel handling. */
+    char guid[33] = {0};
+    char mapping[256] = {0};
+    SDL_GUIDToString(SDL_GetJoystickGUIDForID(id), guid, sizeof(guid));
+    SDL_snprintf(mapping, sizeof(mapping),
+                 "%s,DOS Gameport Joystick,leftx:a0,lefty:a1,"
+                 "righttrigger:b0,lefttrigger:b1,x:b2,y:b3,", guid);
+    if (SDL_AddGamepadMapping(mapping) < 0) {
+        LogInfo(("joystick: DOS mapping failed: %s", SDL_GetError()));
+        return;
+    }
+#endif
     if (SDL_IsGamepad(id)) {
         g_pad = SDL_OpenGamepad(id);
         if (g_pad) {


### PR DESCRIPTION
Follow-up to #27, based directly on its dos branch.

Separate commits for:
- Temporary SDL audio-yield patch: libsdl-org/SDL#16288.
- Direct AdLib output on DOS; PCM speech stays on SDL.
- Actual framebuffer mode switching for the 640-wide title.
- Temporary DOS joystick mapping: libsdl-org/SDL#16289.
- DOS setup and workaround-removal notes.

The runtime changes were built with DJGPP and tried in DOSBox 0.74-3 on a rebased copy of #27. Physical DOS hardware is untested. No game assets or build output are committed.

@AJenbo