### PR TITLE
[review: high] Add optional WebAssembly browser build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,37 @@
+name: Browser build
+on:
+  workflow_dispatch:
+  push:
+    branches: [wasm-upstream]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'web/**'
+      - 'cmake/wasm.cmake'
+      - 'CMakeLists.txt'
+      - '.github/workflows/wasm.yml'
+
+jobs:
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Emscripten
+        run: |
+          git clone --depth 1 https://github.com/emscripten-core/emsdk.git "$RUNNER_TEMP/emsdk"
+          "$RUNNER_TEMP/emsdk/emsdk" install 4.0.14
+          "$RUNNER_TEMP/emsdk/emsdk" activate 4.0.14
+      - name: Build
+        shell: bash
+        run: |
+          source "$RUNNER_TEMP/emsdk/emsdk_env.sh"
+          emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-wasm -j2
+      - uses: actions/upload-artifact@v4
+        with:
+          name: f15se2-browser
+          path: |
+            build-wasm/index.html
+            build-wasm/launcher.js
+            build-wasm/f15se2-ex.js
+            build-wasm/f15se2-ex.wasm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(F15SE2-EX
     LANGUAGES C CXX
 )
 
+if(EMSCRIPTEN)
+    include(cmake/wasm.cmake)
+endif()
+
 #==============================================================================
 # Options
 #==============================================================================
@@ -57,6 +61,9 @@ else()
             UPDATE_DISCONNECTED TRUE
         )
         FetchContent_MakeAvailable(SDL3)
+        if(EMSCRIPTEN)
+            f15_patch_sdl_missing_axes("${sdl3_SOURCE_DIR}")
+        endif()
     else()
         # DOWNLOAD_DEPENDENCIES is off: a system SDL3 is mandatory.
         find_package(SDL3 3.4.0 REQUIRED CONFIG COMPONENTS SDL3)
@@ -187,6 +194,10 @@ set(END_SOURCES
     ${SRC_DIR}/endata.c
 )
 
+if(EMSCRIPTEN)
+    list(APPEND EGAME_SOURCES ${SRC_DIR}/r3d_gles_compat.c ${SRC_DIR}/web_runtime.c)
+endif()
+
 list(APPEND F15SE2_SOURCES ${EGAME_SOURCES})
 list(APPEND F15SE2_SOURCES ${END_SOURCES})
 
@@ -203,11 +214,15 @@ set_source_files_properties(
 
 # OpenGL for the GL 3D backend (r3d_gl.c). The immediate-mode 1.x path needs only
 # the base GL library; SDL3 supplies the GL headers and context management.
-find_package(OpenGL REQUIRED)
+if(NOT EMSCRIPTEN)
+    find_package(OpenGL REQUIRED)
+endif()
 
 # Some tests use std::thread; link a threads library explicitly so it resolves
 # across toolchains (not all fold pthread into libc).
-find_package(Threads REQUIRED)
+if(NOT EMSCRIPTEN)
+    find_package(Threads REQUIRED)
+endif()
 
 #------------------------------------------------------------------------------
 # Sanitizers (GCC/Clang, opt-in). Applied at directory scope so the executable
@@ -270,7 +285,10 @@ target_compile_definitions(f15se2_core PUBLIC DEBUG)
 if(AUTOSTART)
     target_compile_definitions(f15se2_core PUBLIC DEBUG_AUTOSTART)
 endif()
-target_link_libraries(f15se2_core PUBLIC SDL3::SDL3 OpenGL::GL)
+target_link_libraries(f15se2_core PUBLIC SDL3::SDL3)
+if(NOT EMSCRIPTEN)
+    target_link_libraries(f15se2_core PUBLIC OpenGL::GL)
+endif()
 
 add_executable(f15se2 ${SRC_DIR}/f15.c)
 set_target_properties(f15se2 PROPERTIES OUTPUT_NAME "f15se2-ex")
@@ -369,6 +387,11 @@ if(WIN32)
             $<TARGET_FILE_DIR:f15se2>
         )
     endif()
+endif()
+
+if(EMSCRIPTEN)
+    f15_configure_browser(f15se2)
+    return() # Browser assets are imported locally; native tests stay below.
 endif()
 
 # HD assets (optional high-res sprite art, GPU backends only) live in assets/ and are

--- a/cmake/wasm.cmake
+++ b/cmake/wasm.cmake
@@ -1,0 +1,50 @@
+# SDL and the game share the browser thread; Asyncify preserves legacy waits.
+set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+set(SDL_STATIC ON CACHE BOOL "" FORCE)
+set(SDL_TEST_LIBRARY OFF CACHE BOOL "" FORCE)
+set(SDL_TESTS OFF CACHE BOOL "" FORCE)
+
+# Temporary backport: https://github.com/libsdl-org/SDL/issues/16289
+function(f15_patch_sdl_missing_axes source_dir)
+    set(source_file "${source_dir}/src/joystick/SDL_gamepad.c")
+    file(READ "${source_file}" source)
+    set(original "                    value = SDL_GetJoystickAxis(gamepad->joystick, binding->input.axis.axis);")
+    set(replacement [=[                    const int input_axis = binding->input.axis.axis;
+                    /* Missing axes would normalize to a half-pressed trigger. */
+                    if (input_axis < 0 || input_axis >= gamepad->joystick->naxes) {
+                        continue;
+                    }
+                    value = SDL_GetJoystickAxis(gamepad->joystick, input_axis);]=])
+    string(FIND "${source}" "${replacement}" patched_position)
+    if(NOT patched_position EQUAL -1)
+        return()
+    endif()
+    string(FIND "${source}" "${original}" original_position)
+    if(original_position EQUAL -1)
+        message(FATAL_ERROR "SDL axis backport no longer matches; review or remove it for this SDL version")
+    endif()
+    string(REPLACE "${original}" "${replacement}" source "${source}")
+    file(WRITE "${source_file}" "${source}")
+endfunction()
+
+function(f15_configure_browser target)
+    set_target_properties(${target} PROPERTIES OUTPUT_NAME "f15se2-ex" SUFFIX ".js")
+    target_link_options(${target} PRIVATE
+        "-sASYNCIFY=1"
+        "-sASYNCIFY_STACK_SIZE=131072"
+        "-sSTACK_SIZE=1048576"
+        "-sALLOW_MEMORY_GROWTH=1"
+        # The GLES compatibility renderer uses client-side vertex arrays.
+        "-sFULL_ES2=1"
+        "-sFORCE_FILESYSTEM=1"
+        "-sMODULARIZE=1"
+        "-sEXPORT_NAME=createF15Game"
+        "-sEXPORTED_RUNTIME_METHODS=['FS','callMain']"
+        "-sEXIT_RUNTIME=1"
+        "-lidbfs.js"
+        "--pre-js=${PROJECT_SOURCE_DIR}/web/storage.js")
+    foreach(file index.html launcher.js)
+        configure_file("${PROJECT_SOURCE_DIR}/web/${file}"
+            "${CMAKE_CURRENT_BINARY_DIR}/${file}" COPYONLY)
+    endforeach()
+endfunction()

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -1,0 +1,56 @@
+# Browser port
+
+This branch builds upstream main for browsers using Emscripten and SDL3.
+A GLES2 compatibility layer reuses the existing OpenGL scene renderer.
+Keyboard and browser-supported gamepads use upstream controls. Android camera,
+sensors, JNI, controls mapping and touch-menu changes are not included.
+
+## Build
+
+Install and activate the [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html), then:
+
+```sh
+emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release
+cmake --build build-wasm -j2
+python3 -m http.server --directory build-wasm 8000
+```
+
+Open `http://localhost:8000`. Do not open `index.html` through `file://`.
+The Browser build workflow also produces a downloadable artifact. Serve its
+contents from a static HTTP server; HTTPS is recommended outside localhost.
+No commercial game assets are included.
+
+## Play and save
+
+1. Extract your original DOS game files locally.
+2. Select their folder in the launcher. It must contain `15FLT.3D3`.
+3. Click Start flight. Click the canvas if keyboard input goes to the page.
+4. Use Save to browser before closing the tab. Export pilot file downloads
+   `HallFame`; put it in your game folder before importing to restore a backup.
+
+Import replaces the browser's existing game folder, including its pilot file.
+ZIP import is not implemented; extract archives before selecting a folder.
+Folder selection needs a browser supporting directory file inputs.
+
+Game files and pilot progress live in `/game`; SDL control preferences live in
+`/libsdl`. Both are backed by IndexedDB. Autosave runs every five seconds;
+closing the tab immediately after a change can lose it. Storage is specific to
+the browser profile and origin (including port). Private browsing, storage
+eviction and clearing site data can remove it. Pilot export does not include
+control mappings. Reload the page before starting another session.
+
+## Implementation boundaries
+
+`web/` owns importing, persistence and launch UI. `cmake/wasm.cmake` contains
+browser build settings. `web_runtime.c` yields from the shared timer pump so
+legacy polling loops do not block browser events. Asyncify retains their
+synchronous control flow; it is not a simulation rewrite.
+
+WebGL uses GLES2 with Emscripten's client-side array emulation (`FULL_ES2`).
+The launcher uses WebGL; it does not offer software-renderer selection.
+Browser gamepad support and audio activation depend
+on browser/device permissions. This initial port still needs a browser playthrough;
+native tests alone do not validate WebGL, Asyncify or IndexedDB behavior.
+
+Chrome may append `.txt` to exported pilot files. Remove that suffix before
+restoring the file to the original game folder as `HallFame`.

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -24,7 +24,11 @@
  * have no 3D pass and composite the page at present instead.
  */
 #include <SDL3/SDL.h>
+#ifdef __EMSCRIPTEN__
+#include "r3d_gles_compat.h"
+#else
 #include <SDL3/SDL_opengl.h>
+#endif
 
 #include "r3d.h"
 #include "r3d_gl.h"
@@ -77,6 +81,11 @@ static const int GL_MSAA_SAMPLES = 4;
 int r3dgl_msaaSamples(void) { return GL_MSAA_SAMPLES; }
 
 void r3dgl_setGLAttributes(int msaaSamples) {
+#ifdef __EMSCRIPTEN__
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#endif
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     /* 8-bit stencil (D24S8, universal on GL 1.1) — the shadow pass masks each covered
      * pixel so a self-overlapping silhouette blends exactly once. */
@@ -97,7 +106,16 @@ int r3dgl_initContext(SDL_Window *win) {
     }
     SDL_GL_MakeCurrent(win, s_ctx);
     SDL_GL_SetSwapInterval(1);
+#ifdef __EMSCRIPTEN__
+    if (!r3dgles_compatInit()) {
+        SDL_GL_DestroyContext(s_ctx);
+        s_ctx = NULL;
+        return 0;
+    }
+    s_glFogCoordf = r3dgles_fogCoordf;
+#else
     s_glFogCoordf = (void (*)(GLfloat))SDL_GL_GetProcAddress("glFogCoordf");
+#endif
     if (GL_MSAA_SAMPLES > 0) glEnable(GL_MULTISAMPLE); /* no-op if the format has 0 samples */
     {
         GLint depthBits = 0, stencilBits = 0, samples = 0;

--- a/src/r3d_gles_compat.c
+++ b/src/r3d_gles_compat.c
@@ -1,0 +1,367 @@
+/*
+ * OpenGL 1.x immediate-mode emulation for the GLES2/WebGL renderer.
+ *
+ * The legacy renderer emits small batches with glBegin/glEnd and uses only
+ * projection/model-view matrices, vertex colors, texture coordinates, and fog.
+ * Capturing those attributes and drawing them through one shader preserves that
+ * behavior without introducing a second scene implementation.
+ */
+#include "r3d_gles_compat.h"
+
+#include <SDL3/SDL.h>
+
+/* The public compatibility header redirects renderer calls to these wrappers.
+ * Inside the implementation, enable/disable must reach the real GLES entry
+ * points rather than recursively expanding back to the wrappers. */
+#undef glEnable
+#undef glDisable
+
+#define GLES_BATCH_VERTICES 16384
+
+typedef struct {
+    GLfloat x, y, z;
+    GLfloat r, g, b, a;
+    GLfloat u, v;
+    GLfloat fog;
+} GlesVertex;
+
+static GlesVertex s_vertices[GLES_BATCH_VERTICES];
+/* Quad strips emit six vertices per pair after the first pair, almost 3x
+ * their input size. Independent quads need only 1.5x. */
+static GlesVertex s_triangles[GLES_BATCH_VERTICES * 3];
+static bool s_batchOverflow = false;
+static int s_vertexCount;
+static GLenum s_mode;
+static GLfloat s_color[4] = {1, 1, 1, 1};
+static GLfloat s_texCoord[2];
+static GLfloat s_fogCoord;
+static GLfloat s_projection[16];
+static GLfloat s_modelView[16];
+static GLfloat *s_matrix = s_modelView;
+static int s_textureEnabled;
+static int s_fogEnabled;
+static GLint s_fogMode = GL_EXP;
+static GLfloat s_fogDensity;
+static GLfloat s_fogStart;
+static GLfloat s_fogEnd = 1;
+static GLfloat s_fogColor[4];
+static GLfloat s_pointSize = 1;
+
+static GLuint s_program;
+static GLint s_posLoc;
+static GLint s_colorLoc;
+static GLint s_texLoc;
+static GLint s_fogLoc;
+static GLint s_mvpLoc;
+static GLint s_samplerLoc;
+static GLint s_useTextureLoc;
+static GLint s_useFogLoc;
+static GLint s_fogModeLoc;
+static GLint s_fogDensityLoc;
+static GLint s_fogRangeLoc;
+static GLint s_fogColorLoc;
+static GLint s_pointSizeLoc;
+
+static void identity(GLfloat *matrix) {
+    int i;
+    for (i = 0; i < 16; i++) matrix[i] = 0;
+    matrix[0] = matrix[5] = matrix[10] = matrix[15] = 1;
+}
+
+/* Column-major result = left * right, matching OpenGL matrix convention. */
+static void multiply(GLfloat *result, const GLfloat *left, const GLfloat *right) {
+    GLfloat out[16];
+    int row, column, k;
+    for (column = 0; column < 4; column++) {
+        for (row = 0; row < 4; row++) {
+            GLfloat value = 0;
+            for (k = 0; k < 4; k++)
+                value += left[k * 4 + row] * right[column * 4 + k];
+            out[column * 4 + row] = value;
+        }
+    }
+    SDL_memcpy(result, out, sizeof out);
+}
+
+static GLuint compileShader(GLenum type, const char *source) {
+    GLuint shader = glCreateShader(type);
+    GLint okay = 0;
+    glShaderSource(shader, 1, &source, NULL);
+    glCompileShader(shader);
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &okay);
+    if (!okay) {
+        char message[512];
+        glGetShaderInfoLog(shader, sizeof message, NULL, message);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "GLES shader compile failed: %s", message);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+int r3dgles_compatInit(void) {
+    static const char *vertexSource =
+        "attribute vec3 a_position;\n"
+        "attribute vec4 a_color;\n"
+        "attribute vec2 a_texcoord;\n"
+        "attribute float a_fog;\n"
+        "uniform mat4 u_mvp;\n"
+        "uniform float u_point_size;\n"
+        "varying vec4 v_color;\n"
+        "varying vec2 v_texcoord;\n"
+        "varying float v_fog;\n"
+        "void main() {\n"
+        "  gl_Position = u_mvp * vec4(a_position, 1.0);\n"
+        "  v_color = a_color;\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_fog = a_fog;\n"
+        "  gl_PointSize = u_point_size;\n"
+        "}\n";
+    static const char *fragmentSource =
+        "precision mediump float;\n"
+        "varying vec4 v_color;\n"
+        "varying vec2 v_texcoord;\n"
+        "varying float v_fog;\n"
+        "uniform sampler2D u_texture;\n"
+        "uniform int u_use_texture;\n"
+        "uniform int u_use_fog;\n"
+        "uniform int u_fog_mode;\n"
+        "uniform float u_fog_density;\n"
+        "uniform vec2 u_fog_range;\n"
+        "uniform vec4 u_fog_color;\n"
+        "void main() {\n"
+        "  vec4 color = v_color;\n"
+        "  if (u_use_texture != 0) color *= texture2D(u_texture, v_texcoord);\n"
+        "  if (u_use_fog != 0) {\n"
+        "    float keep;\n"
+        "    if (u_fog_mode == 1)\n"
+        "      keep = exp(-u_fog_density * max(v_fog, 0.0));\n"
+        "    else if (u_fog_mode == 2) {\n"
+        "      float d = u_fog_density * max(v_fog, 0.0);\n"
+        "      keep = exp(-(d * d));\n"
+        "    } else\n"
+        "      keep = (u_fog_range.y - v_fog) / max(u_fog_range.y - u_fog_range.x, 0.0001);\n"
+        "    color.rgb = mix(u_fog_color.rgb, color.rgb, clamp(keep, 0.0, 1.0));\n"
+        "  }\n"
+        "  gl_FragColor = color;\n"
+        "}\n";
+    GLuint vertexShader = compileShader(GL_VERTEX_SHADER, vertexSource);
+    GLuint fragmentShader = compileShader(GL_FRAGMENT_SHADER, fragmentSource);
+    GLint okay = 0;
+    if (!vertexShader || !fragmentShader) return 0;
+    s_program = glCreateProgram();
+    glAttachShader(s_program, vertexShader);
+    glAttachShader(s_program, fragmentShader);
+    glLinkProgram(s_program);
+    glDeleteShader(vertexShader);
+    glDeleteShader(fragmentShader);
+    glGetProgramiv(s_program, GL_LINK_STATUS, &okay);
+    if (!okay) {
+        char message[512];
+        glGetProgramInfoLog(s_program, sizeof message, NULL, message);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "GLES program link failed: %s", message);
+        return 0;
+    }
+    s_posLoc = glGetAttribLocation(s_program, "a_position");
+    s_colorLoc = glGetAttribLocation(s_program, "a_color");
+    s_texLoc = glGetAttribLocation(s_program, "a_texcoord");
+    s_fogLoc = glGetAttribLocation(s_program, "a_fog");
+    s_mvpLoc = glGetUniformLocation(s_program, "u_mvp");
+    s_samplerLoc = glGetUniformLocation(s_program, "u_texture");
+    s_useTextureLoc = glGetUniformLocation(s_program, "u_use_texture");
+    s_useFogLoc = glGetUniformLocation(s_program, "u_use_fog");
+    s_fogModeLoc = glGetUniformLocation(s_program, "u_fog_mode");
+    s_fogDensityLoc = glGetUniformLocation(s_program, "u_fog_density");
+    s_fogRangeLoc = glGetUniformLocation(s_program, "u_fog_range");
+    s_fogColorLoc = glGetUniformLocation(s_program, "u_fog_color");
+    s_pointSizeLoc = glGetUniformLocation(s_program, "u_point_size");
+    identity(s_projection);
+    identity(s_modelView);
+    return 1;
+}
+
+void r3dgles_begin(GLenum mode) {
+    s_mode = mode;
+    s_vertexCount = 0;
+    s_batchOverflow = false;
+}
+
+void r3dgles_vertex3f(GLfloat x, GLfloat y, GLfloat z) {
+    GlesVertex *vertex;
+    if (s_vertexCount >= GLES_BATCH_VERTICES) {
+        if (!s_batchOverflow)
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER,
+                         "GLES batch exceeds %d vertices; discarding batch (mode %u)",
+                         GLES_BATCH_VERTICES, (unsigned)s_mode);
+        s_batchOverflow = true;
+        return;
+    }
+    vertex = &s_vertices[s_vertexCount++];
+    vertex->x = x; vertex->y = y; vertex->z = z;
+    vertex->r = s_color[0]; vertex->g = s_color[1];
+    vertex->b = s_color[2]; vertex->a = s_color[3];
+    vertex->u = s_texCoord[0]; vertex->v = s_texCoord[1];
+    vertex->fog = s_fogCoord;
+}
+
+void r3dgles_vertex2f(GLfloat x, GLfloat y) {
+    r3dgles_vertex3f(x, y, 0);
+}
+
+void r3dgles_texCoord2f(GLfloat u, GLfloat v) {
+    s_texCoord[0] = u;
+    s_texCoord[1] = v;
+}
+
+void r3dgles_color3ub(GLubyte r, GLubyte g, GLubyte b) {
+    s_color[0] = r / 255.0f;
+    s_color[1] = g / 255.0f;
+    s_color[2] = b / 255.0f;
+    s_color[3] = 1;
+}
+
+void r3dgles_color4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
+    s_color[0] = r; s_color[1] = g; s_color[2] = b; s_color[3] = a;
+}
+
+void r3dgles_fogCoordf(GLfloat distance) {
+    s_fogCoord = distance;
+}
+
+static int expandTriangles(GlesVertex **vertices, GLenum *mode) {
+    int i, count = 0;
+    if (s_mode == GL_QUADS) {
+        for (i = 0; i + 3 < s_vertexCount; i += 4) {
+            s_triangles[count++] = s_vertices[i];
+            s_triangles[count++] = s_vertices[i + 1];
+            s_triangles[count++] = s_vertices[i + 2];
+            s_triangles[count++] = s_vertices[i];
+            s_triangles[count++] = s_vertices[i + 2];
+            s_triangles[count++] = s_vertices[i + 3];
+        }
+        *vertices = s_triangles;
+        *mode = GL_TRIANGLES;
+        return count;
+    }
+    if (s_mode == GL_QUAD_STRIP) {
+        for (i = 0; i + 3 < s_vertexCount; i += 2) {
+            s_triangles[count++] = s_vertices[i];
+            s_triangles[count++] = s_vertices[i + 1];
+            s_triangles[count++] = s_vertices[i + 3];
+            s_triangles[count++] = s_vertices[i];
+            s_triangles[count++] = s_vertices[i + 3];
+            s_triangles[count++] = s_vertices[i + 2];
+        }
+        *vertices = s_triangles;
+        *mode = GL_TRIANGLES;
+        return count;
+    }
+    if (s_mode == GL_POLYGON) *mode = GL_TRIANGLE_FAN;
+    return s_vertexCount;
+}
+
+void r3dgles_end(void) {
+    /* Never draw an incomplete primitive stream after exceeding capacity. */
+    if (s_batchOverflow) return;
+    GlesVertex *vertices = s_vertices;
+    GLenum mode = s_mode;
+    GLfloat mvp[16];
+    int count = expandTriangles(&vertices, &mode);
+    if (count <= 0) return;
+    multiply(mvp, s_projection, s_modelView);
+    glUseProgram(s_program);
+    glUniformMatrix4fv(s_mvpLoc, 1, GL_FALSE, mvp);
+    glUniform1i(s_samplerLoc, 0);
+    glUniform1i(s_useTextureLoc, s_textureEnabled);
+    glUniform1i(s_useFogLoc, s_fogEnabled);
+    glUniform1i(s_fogModeLoc, s_fogMode == GL_EXP ? 1 : s_fogMode == GL_EXP2 ? 2 : 0);
+    glUniform1f(s_fogDensityLoc, s_fogDensity);
+    glUniform2f(s_fogRangeLoc, s_fogStart, s_fogEnd);
+    glUniform4fv(s_fogColorLoc, 1, s_fogColor);
+    glUniform1f(s_pointSizeLoc, s_pointSize);
+
+    glEnableVertexAttribArray((GLuint)s_posLoc);
+    glEnableVertexAttribArray((GLuint)s_colorLoc);
+    glEnableVertexAttribArray((GLuint)s_texLoc);
+    glEnableVertexAttribArray((GLuint)s_fogLoc);
+    glVertexAttribPointer((GLuint)s_posLoc, 3, GL_FLOAT, GL_FALSE,
+                          sizeof(GlesVertex), &vertices[0].x);
+    glVertexAttribPointer((GLuint)s_colorLoc, 4, GL_FLOAT, GL_FALSE,
+                          sizeof(GlesVertex), &vertices[0].r);
+    glVertexAttribPointer((GLuint)s_texLoc, 2, GL_FLOAT, GL_FALSE,
+                          sizeof(GlesVertex), &vertices[0].u);
+    glVertexAttribPointer((GLuint)s_fogLoc, 1, GL_FLOAT, GL_FALSE,
+                          sizeof(GlesVertex), &vertices[0].fog);
+    glDrawArrays(mode, 0, count);
+    glDisableVertexAttribArray((GLuint)s_posLoc);
+    glDisableVertexAttribArray((GLuint)s_colorLoc);
+    glDisableVertexAttribArray((GLuint)s_texLoc);
+    glDisableVertexAttribArray((GLuint)s_fogLoc);
+}
+
+void r3dgles_matrixMode(GLenum mode) {
+    s_matrix = mode == GL_PROJECTION ? s_projection : s_modelView;
+}
+
+void r3dgles_loadIdentity(void) {
+    identity(s_matrix);
+}
+
+void r3dgles_loadMatrixf(const GLfloat *matrix) {
+    SDL_memcpy(s_matrix, matrix, sizeof(GLfloat) * 16);
+}
+
+void r3dgles_ortho(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top,
+                   GLfloat nearValue, GLfloat farValue) {
+    GLfloat ortho[16];
+    identity(ortho);
+    ortho[0] = 2 / (right - left);
+    ortho[5] = 2 / (top - bottom);
+    ortho[10] = -2 / (farValue - nearValue);
+    ortho[12] = -(right + left) / (right - left);
+    ortho[13] = -(top + bottom) / (top - bottom);
+    ortho[14] = -(farValue + nearValue) / (farValue - nearValue);
+    multiply(s_matrix, s_matrix, ortho);
+}
+
+void r3dgles_enable(GLenum capability) {
+    if (capability == GL_TEXTURE_2D) s_textureEnabled = 1;
+    else if (capability == GL_FOG) s_fogEnabled = 1;
+    else if (capability != GL_LIGHTING && capability != GL_MULTISAMPLE &&
+             capability != GL_POINT_SMOOTH &&
+             capability != GL_POLYGON_OFFSET_LINE &&
+             capability != GL_POLYGON_OFFSET_POINT)
+        glEnable(capability);
+}
+
+void r3dgles_disable(GLenum capability) {
+    if (capability == GL_TEXTURE_2D) s_textureEnabled = 0;
+    else if (capability == GL_FOG) s_fogEnabled = 0;
+    else if (capability != GL_LIGHTING && capability != GL_MULTISAMPLE &&
+             capability != GL_POINT_SMOOTH &&
+             capability != GL_POLYGON_OFFSET_LINE &&
+             capability != GL_POLYGON_OFFSET_POINT)
+        glDisable(capability);
+}
+
+void r3dgles_fogi(GLenum name, GLint value) {
+    if (name == GL_FOG_MODE) s_fogMode = value;
+}
+
+void r3dgles_fogf(GLenum name, GLfloat value) {
+    if (name == GL_FOG_DENSITY) s_fogDensity = value;
+    else if (name == GL_FOG_START) s_fogStart = value;
+    else if (name == GL_FOG_END) s_fogEnd = value;
+}
+
+void r3dgles_fogfv(GLenum name, const GLfloat *value) {
+    if (name == GL_FOG_COLOR) SDL_memcpy(s_fogColor, value, sizeof s_fogColor);
+}
+
+void r3dgles_shadeModel(GLenum mode) {
+    (void)mode; /* Per-vertex colors are interpolated by the GLES2 shader. */
+}
+
+void r3dgles_pointSize(GLfloat size) {
+    s_pointSize = size > 0 ? size : 1;
+}

--- a/src/r3d_gles_compat.h
+++ b/src/r3d_gles_compat.h
@@ -1,0 +1,112 @@
+#ifndef R3D_GLES_COMPAT_H
+#define R3D_GLES_COMPAT_H
+
+#include <SDL3/SDL_opengles2.h>
+
+/* Constants removed from GLES2 but still used as renderer intent. */
+#ifndef GL_QUADS
+#define GL_QUADS 0x0007
+#endif
+#ifndef GL_POLYGON
+#define GL_POLYGON 0x0009
+#endif
+#ifndef GL_QUAD_STRIP
+#define GL_QUAD_STRIP 0x0008
+#endif
+#ifndef GL_MODELVIEW
+#define GL_MODELVIEW 0x1700
+#endif
+#ifndef GL_PROJECTION
+#define GL_PROJECTION 0x1701
+#endif
+#ifndef GL_TEXTURE_2D
+#define GL_TEXTURE_2D 0x0DE1
+#endif
+#ifndef GL_LIGHTING
+#define GL_LIGHTING 0x0B50
+#endif
+#ifndef GL_FOG
+#define GL_FOG 0x0B60
+#endif
+#ifndef GL_FOG_MODE
+#define GL_FOG_MODE 0x0B65
+#endif
+#ifndef GL_FOG_DENSITY
+#define GL_FOG_DENSITY 0x0B62
+#endif
+#ifndef GL_FOG_START
+#define GL_FOG_START 0x0B63
+#endif
+#ifndef GL_FOG_END
+#define GL_FOG_END 0x0B64
+#endif
+#ifndef GL_FOG_COLOR
+#define GL_FOG_COLOR 0x0B66
+#endif
+#ifndef GL_EXP
+#define GL_EXP 0x0800
+#endif
+#ifndef GL_EXP2
+#define GL_EXP2 0x0801
+#endif
+#ifndef GL_FLAT
+#define GL_FLAT 0x1D00
+#endif
+#ifndef GL_SMOOTH
+#define GL_SMOOTH 0x1D01
+#endif
+#ifndef GL_MULTISAMPLE
+#define GL_MULTISAMPLE 0x809D
+#endif
+#ifndef GL_POINT_SMOOTH
+#define GL_POINT_SMOOTH 0x0B10
+#endif
+#ifndef GL_POLYGON_OFFSET_POINT
+#define GL_POLYGON_OFFSET_POINT 0x2A01
+#endif
+#ifndef GL_POLYGON_OFFSET_LINE
+#define GL_POLYGON_OFFSET_LINE 0x2A02
+#endif
+
+int r3dgles_compatInit(void);
+void r3dgles_fogCoordf(GLfloat distance);
+void r3dgles_begin(GLenum mode);
+void r3dgles_end(void);
+void r3dgles_vertex2f(GLfloat x, GLfloat y);
+void r3dgles_vertex3f(GLfloat x, GLfloat y, GLfloat z);
+void r3dgles_texCoord2f(GLfloat u, GLfloat v);
+void r3dgles_color3ub(GLubyte r, GLubyte g, GLubyte b);
+void r3dgles_color4f(GLfloat r, GLfloat g, GLfloat b, GLfloat a);
+void r3dgles_matrixMode(GLenum mode);
+void r3dgles_loadIdentity(void);
+void r3dgles_loadMatrixf(const GLfloat *matrix);
+void r3dgles_ortho(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top,
+                   GLfloat nearValue, GLfloat farValue);
+void r3dgles_enable(GLenum capability);
+void r3dgles_disable(GLenum capability);
+void r3dgles_fogi(GLenum name, GLint value);
+void r3dgles_fogf(GLenum name, GLfloat value);
+void r3dgles_fogfv(GLenum name, const GLfloat *value);
+void r3dgles_shadeModel(GLenum mode);
+void r3dgles_pointSize(GLfloat size);
+
+#define glBegin r3dgles_begin
+#define glEnd r3dgles_end
+#define glVertex2f r3dgles_vertex2f
+#define glVertex3f r3dgles_vertex3f
+#define glTexCoord2f r3dgles_texCoord2f
+#define glColor3ub r3dgles_color3ub
+#define glColor4f r3dgles_color4f
+#define glMatrixMode r3dgles_matrixMode
+#define glLoadIdentity r3dgles_loadIdentity
+#define glLoadMatrixf r3dgles_loadMatrixf
+#define glOrtho r3dgles_ortho
+#define glEnable r3dgles_enable
+#define glDisable r3dgles_disable
+#define glFogi r3dgles_fogi
+#define glFogf r3dgles_fogf
+#define glFogfv r3dgles_fogfv
+#define glShadeModel r3dgles_shadeModel
+#define glPointSize r3dgles_pointSize
+
+#endif

--- a/src/shared/timer.c
+++ b/src/shared/timer.c
@@ -14,6 +14,7 @@
  */
 
 #include "inttype.h"
+#include "web_runtime.h"
 #include <dos.h>
 #include <SDL3/SDL.h>
 
@@ -44,6 +45,7 @@ void setTimerTickHook(void(far *fn)(void)) {
 /* Advance the tick counters to match elapsed real time, firing the hook once
  * per 1/60 s tick. Safe to call as often as a spin loop likes. */
 void timerPump(void) {
+    web_yield();
     Uint64 now;
     if (!timerRunning) return;
     now = SDL_GetTicksNS();

--- a/src/web_runtime.c
+++ b/src/web_runtime.c
@@ -1,0 +1,12 @@
+#include "web_runtime.h"
+#include <emscripten.h>
+
+void web_yield(void) {
+    static double nextYieldMs = 0.0;
+    const double nowMs = emscripten_get_now();
+    if (nowMs < nextYieldMs) return;
+
+    // Legacy polling loops must return control to browser input and audio.
+    emscripten_sleep(0);
+    nextYieldMs = emscripten_get_now() + 8.0;
+}

--- a/src/web_runtime.h
+++ b/src/web_runtime.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef __EMSCRIPTEN__
+void web_yield(void);
+#else
+static inline void web_yield(void) {}
+#endif

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>F-15 Strike Eagle II | Browser flight</title>
+<style>
+:root { color-scheme: dark; --ink:#dfebe3; --panel:#162925; --accent:#e9be69; }
+* { box-sizing:border-box; }
+body { margin:0; background:radial-gradient(ellipse at top,#29483e,#0c1516 75%); color:var(--ink); font:16px Georgia,serif; min-height:100vh; }
+main { max-width:1100px; margin:auto; padding:24px; }
+h1 { margin:0; font-size:clamp(24px,4vw,42px); font-weight:normal; }
+.eyebrow { color:var(--accent); letter-spacing:.16em; font:12px monospace; }
+.toolbar { display:flex; flex-wrap:wrap; gap:12px; align-items:center; margin:20px 0; }
+button,select,.import { background:var(--panel); border:1px solid #749086; color:var(--ink); padding:10px 14px; font:inherit; border-radius:3px; }
+button:not(:disabled),.import { cursor:pointer; }
+button:disabled { opacity:.4; }
+input { max-width:240px; }
+#screen { background:#000; border:1px solid #486359; }
+canvas { display:block; width:100%; height:auto; aspect-ratio:4/3; outline:none; touch-action:none; }
+#screen:fullscreen { display:grid; place-items:center; }
+#screen:fullscreen canvas { width:auto; height:100%; max-width:100%; }
+#status { min-height:1.5em; color:var(--accent); }
+small { display:block; line-height:1.6; max-width:80ch; }
+</style>
+<main>
+<p class="eyebrow">BROWSER FLIGHT / LOCAL ASSETS</p>
+<h1>F-15 Strike Eagle II</h1>
+<div class="toolbar">
+<label class="import">Game folder <input id="files" type="file" webkitdirectory multiple disabled></label>
+<button id="start" disabled>Start flight</button>
+<button id="save" disabled>Save to browser</button>
+<button id="backup" disabled>Export pilot file</button>
+<button id="fullscreen">Fullscreen</button>
+</div>
+<p id="status" role="status">Loading browser runtime...</p>
+<div id="screen"><canvas id="canvas" tabindex="0" width="960" height="720"></canvas></div>
+<p><small>Select the folder containing your original DOS game files. Files stay on this device; nothing is uploaded. ZIP archives must be extracted first. Keyboard, mouse and browser-supported gamepads use the game's controls. Click the canvas to focus it.</small></p>
+<small>Saves belong to this browser and website address. Private browsing, clearing site data or storage eviction can remove them. Export your pilot file as a backup. Reload this page to restart.</small>
+</main>
+<script src="f15se2-ex.js"></script>
+<script src="launcher.js"></script>
+</html>

--- a/web/launcher.js
+++ b/web/launcher.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const element = id => document.getElementById(id);
+const status = message => { element('status').textContent = message; };
+let runtime = null;
+let started = false;
+let saving = false;
+const MAX_IMPORT_BYTES = 128 * 1024 * 1024;
+
+function saveStorage() {
+    if (saving) return Promise.reject(new Error('A save is already in progress.'));
+    saving = true;
+    return new Promise((resolve, reject) => {
+        runtime.FS.syncfs(false, error => {
+            saving = false;
+            if (error) reject(error); else resolve();
+        });
+    });
+}
+
+async function importFiles(files) {
+    const candidates = [...files];
+    const model = candidates.find(file => file.name.toUpperCase() === '15FLT.3D3');
+    if (!model) throw new Error('Choose the original game folder containing 15FLT.3D3.');
+    const relativePath = file => file.webkitRelativePath || file.name;
+    const modelPath = relativePath(model);
+    const prefix = modelPath.slice(0, modelPath.length - model.name.length);
+    const gameFiles = candidates.filter(file => {
+        const path = relativePath(file);
+        return path.startsWith(prefix) && !path.slice(prefix.length).includes('/');
+    });
+    let totalBytes = 0;
+    const names = new Set();
+    for (const file of gameFiles) {
+        const name = file.name.toUpperCase();
+        totalBytes += file.size;
+        if (names.has(name) || name === '.' || name === '..' || /[\\/\0]/.test(name))
+            throw new Error('Duplicate or invalid filename: ' + name);
+        names.add(name);
+    }
+    if (totalBytes > MAX_IMPORT_BYTES) throw new Error('Game folder exceeds the 128 MiB import limit.');
+    // Read everything first so a failed browser read does not erase existing saves.
+    const contents = [];
+    for (const file of gameFiles) contents.push([file.name.toUpperCase(), new Uint8Array(await file.arrayBuffer())]);
+    for (const name of runtime.FS.readdir('/game')) {
+        if (name !== '.' && name !== '..') runtime.FS.unlink('/game/' + name);
+    }
+    for (const [name, data] of contents) runtime.FS.writeFile('/game/' + name, data);
+    await saveStorage();
+    status('Game files imported. Ready to fly.');
+    element('start').disabled = false;
+}
+
+element('files').onchange = async event => {
+    element('start').disabled = true;
+    element('files').disabled = true;
+    try { await importFiles(event.target.files); }
+    catch (error) { status('Import failed: ' + error.message); }
+    finally { element('files').disabled = false; }
+};
+
+element('start').onclick = () => {
+    if (!runtime || started) return;
+    started = true;
+    element('start').disabled = true;
+    element('files').disabled = true;
+    element('canvas').focus();
+    status('Flight running. Saves are synchronized every five seconds.');
+    runtime.callMain(['--game', '/game']);
+};
+
+element('save').onclick = async () => {
+    try { await saveStorage(); status('Saved to browser storage.'); }
+    catch (error) { status('Save failed: ' + error.message); }
+};
+
+element('backup').onclick = () => {
+    const name = runtime.FS.readdir('/game').find(name => name.toUpperCase() === 'HALLFAME');
+    if (!name) { status('No HallFame pilot file exists yet.'); return; }
+    const blob = new Blob([runtime.FS.readFile('/game/' + name)]);
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'HallFame';
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+};
+
+element('fullscreen').onclick = async () => {
+    try { await element('screen').requestFullscreen(); element('canvas').focus(); }
+    catch (error) { status('Fullscreen unavailable: ' + error.message); }
+};
+
+createF15Game({
+    canvas: element('canvas'),
+    noInitialRun: true,
+    print: message => console.log(message),
+    printErr: message => console.error(message),
+    onAbort: message => status('Runtime stopped: ' + message),
+    onExit: () => {
+        saveStorage().then(() => status('Game closed and saved. Reload to play again.'))
+            .catch(error => status('Game closed; save failed: ' + error.message));
+    }
+}).then(module => {
+    runtime = module;
+    if (module.storageError) throw new Error('Browser storage unavailable: ' + module.storageError);
+    element('files').disabled = false;
+    element('save').disabled = false;
+    element('backup').disabled = false;
+    const imported = runtime.FS.analyzePath('/game/15FLT.3D3').exists;
+    element('start').disabled = !imported;
+    status(imported ? 'Saved game folder restored. Ready to fly.' : 'Choose your original game folder.');
+    setInterval(() => {
+        if (started && !saving) saveStorage().catch(error => status('Autosave failed: ' + error.message));
+    }, 5000);
+}).catch(error => status('Unable to start: ' + error.message));

--- a/web/storage.js
+++ b/web/storage.js
@@ -1,0 +1,13 @@
+// Populate both mounts before main: game files and SDL preference files.
+Module['preRun'] = Module['preRun'] || [];
+Module['preRun'].push(function () {
+    addRunDependency('persistent-files');
+    for (const path of ['/game', '/libsdl']) {
+        FS.mkdirTree(path);
+        FS.mount(IDBFS, {}, path);
+    }
+    FS.syncfs(true, function (error) {
+        Module['storageError'] = error;
+        removeRunDependency('persistent-files');
+    });
+});


### PR DESCRIPTION
Adds an optional Emscripten/WebGL build, based directly on current main.

- Reuses the GL scene renderer through a GLES2 compatibility layer.
- Imports the user's game folder locally and stores saves in IndexedDB. No game assets included.
- Includes the temporary SDL Joystick missing-axis fix and a browser build workflow

Two commits separate the GLES layer from browser integration. The GLES layer is the main review burden (~480 new lines).

See docs/wasm.md for build and use instructions.
