### PR TITLE
Optimize renderer conversion hot paths

### DIFF
--- a/src/eg3drast.c
+++ b/src/eg3drast.c
@@ -118,26 +118,17 @@ static struct EdgeRec *erec(int i) {
 static struct EdgeRec g_clipVtx;
 
 /* ===================================================================== */
-/* Manual 32/16 divides (no long runtime helper; shift-by-1 / mask only).*/
+/* 32/16 divides preserve the original numerator width and trap values. */
 /* Saturate to +/-0x7f00 on overflow, matching the egseg1 INT0 stubs.    */
 /* ===================================================================== */
-static unsigned udiv32by16(unsigned long num, unsigned den) {
-    unsigned long rem = 0;
-    unsigned long q = 0;
-    int i;
-    if (den == 0) return 0x7f00;
-    for (i = 0; i < 32; i++) {
-        rem = rem << 1;
-        if (num & 0x80000000UL) rem |= 1;
-        num = num << 1;
-        q = q << 1;
-        if (rem >= (unsigned long)den) {
-            rem -= den;
-            q |= 1;
-        }
-    }
-    if (q > 0x7fffUL) q = 0x7f00;
-    return (unsigned)q;
+static unsigned udiv32by16(unsigned long numerator, unsigned denominator) {
+    const unsigned maxQuotient = 0x7fffU;
+    const unsigned saturatedQuotient = 0x7f00U;
+    unsigned quotient;
+
+    if (denominator == 0) return saturatedQuotient;
+    quotient = (uint32)numerator / denominator;
+    return quotient > maxQuotient ? saturatedQuotient : quotient;
 }
 
 /* Full-precision unsigned 32/16 divide: returns the complete 32-bit quotient,

--- a/src/r3d_gl.c
+++ b/src/r3d_gl.c
@@ -1504,6 +1504,7 @@ static GLuint imageTexture(R2DImage *img, SDL_Palette *pal, int palGen) {
     const uint8 *src;
     uint8 *rgba;
     int sw, sh, pitch, x, y;
+    uint32 packedRgbaPalette[256];
 
     if (!surf) return 0;
     sw = surf->w;
@@ -1531,17 +1532,21 @@ static GLuint imageTexture(R2DImage *img, SDL_Palette *pal, int palGen) {
     if (!rgba) return 0;
     src = (const uint8 *)surf->pixels;
     pitch = surf->pitch;
+    /* Fill each native word by bytes so its in-memory order is RGBA on either
+     * endian. The conversion loop can then use one lookup and one store. */
+    for (int paletteIndex = 0; paletteIndex < 256; ++paletteIndex) {
+        SDL_Color color = pal->colors[paletteIndex];
+        uint8 *rgbaBytes = (uint8 *)&packedRgbaPalette[paletteIndex];
+        rgbaBytes[0] = color.r;
+        rgbaBytes[1] = color.g;
+        rgbaBytes[2] = color.b;
+        rgbaBytes[3] = paletteIndex == 0 ? 0 : 255;
+    }
     for (y = 0; y < sh; y++) {
-        const uint8 *row = src + y * pitch;
-        uint8 *out = rgba + y * sw * 4;
-        for (x = 0; x < sw; x++) {
-            uint8 idx = row[x];
-            SDL_Color c = pal->colors[idx];
-            out[x * 4 + 0] = c.r;
-            out[x * 4 + 1] = c.g;
-            out[x * 4 + 2] = c.b;
-            out[x * 4 + 3] = (idx == 0) ? 0 : 255;
-        }
+        const uint8 *sourceRow = src + y * pitch;
+        uint32 *destinationPixels = (uint32 *)(rgba + (size_t)y * sw * 4);
+        for (x = 0; x < sw; x++)
+            destinationPixels[x] = packedRgbaPalette[sourceRow[x]];
     }
     if (!tex) glGenTextures(1, &tex);
     glBindTexture(GL_TEXTURE_2D, tex);


### PR DESCRIPTION
Two small renderer hot-path changes:

- Replace the bit-at-a-time saturated 32/16 divide with native division while preserving the 32-bit numerator, divide-by-zero result, and saturation behavior.
- Build a packed RGBA palette before converting indexed OpenGL overlay images, reducing each pixel to one lookup and one store.

Measured with a fixed 1,000-frame Libya mission and presentation/audio/pacing disabled:

| Build | Game instructions | Median loop time |
| --- | ---: | ---: |
| 32-bit software | -4.6% | -3.4% |
| 64-bit software | -5.8% | -5.1% |
| 32-bit OpenGL | -40.0% | -2.9% |
| 64-bit OpenGL | -40.0% | -0.6% |

OpenGL wall time remains driver-bound; the instruction reduction is game-side. Software indexed output and palette/RGBA output matched before and after. OpenGL captures also matched apart from an existing startup-dependent 34-pixel palette variation reproduced by the unchanged baseline.

Validation: 31/31 tests pass in both 32-bit and 64-bit builds.