### PR TITLE
Add sanitizer, static analysis and mutation checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Change
+
+Describe the problem, its trigger, and the resulting behavior.
+
+## Validation
+
+List tests run and their results. For gameplay or visual changes, include the
+platform, renderer, and a short before/after reproduction. Mention checks that
+were not run and any remaining warnings or surviving mutations.
+
+## Review
+
+Confirm that you read the diff. Explain any changed goldens, suppressions, or
+test expectations. See `docs/quality_checks.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             os: macos-latest
             configure: cmake -S . -B build
             build: cmake --build build -j$(sysctl -n hw.ncpu)
+            test: ctest --test-dir build --output-on-failure
 
     steps:
       - name: Checkout repository
@@ -56,6 +57,14 @@ jobs:
       - name: Test
         run: ${{ matrix.test }}
 
+      - name: Preserve test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests-${{ runner.os }}
+          path: build/Testing/Temporary/
+          retention-days: 14
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -77,7 +86,7 @@ jobs:
         run: cmake -S . -B build -DCOVERAGE=ON
 
       - name: Build
-        run: cmake --build build -j$(nproc)
+        run: cmake --build build -j"$(nproc)"
 
       - name: Run tests + generate coverage report
         run: cmake --build build --target coverage
@@ -91,3 +100,14 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Preserve coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            build/coverage.xml
+            build/coverage.txt
+            build/Testing/Temporary/
+          retention-days: 14

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,59 @@
+name: Mutation tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      test:
+        description: Test executable to measure
+        type: choice
+        default: signed_ratio_behavior_tests
+        options:
+          - signed_ratio_behavior_tests
+          - utility_behavior_tests
+          - eg3drast_behavior_tests
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      MULL_CONFIG: ${{ github.workspace }}/tools/quality/mull.yml
+      TEST_TARGET: ${{ inputs.test }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install matching Clang and Mull
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-18 cmake ninja-build libgl1-mesa-dev libx11-dev libxext-dev
+          curl --fail --location --retry 3 -o mull.deb https://github.com/mull-project/mull/releases/download/0.34.0/Mull-18-0.34.0-LLVM-18.1.3-ubuntu-amd64-24.04.deb
+          echo 'd2491551b2a9d5b28f896c75278e891f748284b4a2523795c62b5315ad7a9e73  mull.deb' | sha256sum --check
+          sudo apt-get install -y ./mull.deb
+      - name: Build instrumented test
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            '-DCMAKE_CXX_FLAGS=-fpass-plugin=/usr/lib/mull-ir-frontend-18 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping'
+          cmake --build build --target "$TEST_TARGET" --parallel 2
+      - name: Check baseline and measure mutants
+        run: |
+          ctest --test-dir build -R "^${TEST_TARGET}$" --output-on-failure --no-tests=error --timeout 120
+          mkdir -p build/quality
+          mull-runner-18 --allow-surviving --workers 2 --timeout 10000 \
+            --reporters Elements --reporters IDE --report-dir build/quality \
+            --report-name mutation "build/$TEST_TARGET" 2>&1 | tee build/quality/mutation.log
+          if grep -q 'No mutants found' build/quality/mutation.log; then
+            echo 'No mutations were exercised; this is not a successful measurement.' >&2
+            exit 1
+          fi
+      - name: Preserve mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-${{ inputs.test }}
+          path: |
+            build/quality/
+            build/Testing/Temporary/
+          retention-days: 14

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -27,7 +27,10 @@ jobs:
       - name: Install matching Clang and Mull
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-18 cmake ninja-build libgl1-mesa-dev libx11-dev libxext-dev
+          sudo apt-get install -y clang-18 cmake ninja-build libgl1-mesa-dev \
+            libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev \
+            libxrandr-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols \
+            libegl1-mesa-dev libgles2-mesa-dev
           curl --fail --location --retry 3 -o mull.deb https://github.com/mull-project/mull/releases/download/0.34.0/Mull-18-0.34.0-LLVM-18.1.3-ubuntu-amd64-24.04.deb
           echo 'd2491551b2a9d5b28f896c75278e891f748284b4a2523795c62b5315ad7a9e73  mull.deb' | sha256sum --check
           sudo apt-get install -y ./mull.deb

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,89 @@
+name: Quality
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizers:
+    name: Address and undefined behavior sanitizers
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build libgl1-mesa-dev libx11-dev libxext-dev
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DASAN=ON -DUBSAN=ON
+      - name: Build
+        run: cmake --build build --parallel 2
+      - name: Test
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --test-dir build --output-on-failure --timeout 120 --no-tests=error
+      - name: Preserve diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitizer-tests
+          path: build/Testing/Temporary/
+          retention-days: 14
+
+  analysis:
+    name: Static analysis and review metrics
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build cppcheck clang-tools-18 libgl1-mesa-dev libx11-dev libxext-dev
+          python -m pip install lizard==1.17.31
+          cppcheck --version
+          clang-check-18 --version
+          lizard --version
+      - name: Configure and generate version header
+        run: |
+          cmake -S . -B build -G Ninja
+          cmake --build build --target GenerateVersionHeader
+      - name: Cppcheck
+        run: python tools/quality/static_analysis.py build --report-only
+      - name: Clang static analyzer
+        run: python tools/quality/static_analysis.py build --tool clang
+      - name: Complexity and dependency reports
+        run: |
+          lizard --csv src > build/quality/complexity.csv
+          cmake --graphviz=build/quality/dependencies.dot -S . -B build
+      - name: Explain report status
+        if: always()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          Static findings and complexity are advisory while existing findings are triaged.
+          Tool failures fail this job. Download `static-analysis` for cppcheck diagnostics,
+          Clang diagnostics, function complexity, and the CMake target dependency graph.
+          Passing analysis does not replace the contributor policy's code review.
+          EOF
+      - name: Preserve reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-analysis
+          path: |
+            build/quality/cppcheck.xml
+            build/quality/clang.txt
+            build/quality/complexity.csv
+            build/quality/dependencies.dot*
+          retention-days: 14

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,7 +20,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libgl1-mesa-dev libx11-dev libxext-dev
+          sudo apt-get install -y cmake ninja-build libgl1-mesa-dev \
+            libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev \
+            libxrandr-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols \
+            libegl1-mesa-dev libgles2-mesa-dev
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DASAN=ON -DUBSAN=ON
       - name: Build
@@ -50,7 +53,10 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build cppcheck clang-tools-18 libgl1-mesa-dev libx11-dev libxext-dev
+          sudo apt-get install -y cmake ninja-build cppcheck clang-tools-18 libgl1-mesa-dev \
+            libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev \
+            libxrandr-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols \
+            libegl1-mesa-dev libgles2-mesa-dev
           python -m pip install lizard==1.17.31
           cppcheck --version
           clang-check-18 --version

--- a/docs/quality_checks.md
+++ b/docs/quality_checks.md
@@ -1,0 +1,118 @@
+# Quality checks
+
+Automated checks give reviewers evidence; the contributor policy still requires
+reading and understanding the change. A green run does not prove correct gameplay.
+
+| Check | When | Result |
+| --- | --- | --- |
+| Behavior tests, including golden images | Every PR; Linux, Windows, macOS | Required job succeeds only when tests pass |
+| ASan and UBSan | Every PR; Linux | Memory/undefined-behavior failures fail the job |
+| Coverage | Every PR; Linux | Codecov plus downloadable XML and text; informational under current policy |
+| Cppcheck and Clang static analyzer | Every PR; Linux | Findings for review; analyzer execution errors fail the job |
+| Function complexity and dependency graph | Every PR; Linux | Downloadable review metrics, no arbitrary legacy-wide threshold |
+| Mutation testing | Manual, selected test target | Baseline must pass; surviving mutations are reported for review |
+| Installed package smoke test | Packaging PRs and nightly | Runs `--help` from the installed directory |
+| Interactive acceptance | Before merging affected gameplay or UI | Contributor records the checks below |
+
+Repository branch protection must be configured by a maintainer to require CI
+jobs. Workflows alone cannot enforce merge policy. Static analysis has existing
+findings; review new findings and triage existing ones before adopting a blocking
+baseline. No blanket suppression of legacy files is applied.
+
+## Local checks
+
+```sh
+cmake -S . -B build
+cmake --build build --parallel 2
+ctest --test-dir build --output-on-failure --timeout 120 --no-tests=error
+
+cmake -S . -B build-sanitizers -DASAN=ON -DUBSAN=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-sanitizers --parallel 2
+ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+  ctest --test-dir build-sanitizers --output-on-failure --timeout 120 --no-tests=error
+
+cmake -S . -B build-coverage -DCOVERAGE=ON
+cmake --build build-coverage --parallel 2
+cmake --build build-coverage --target coverage
+```
+
+For static analysis, install cppcheck and `clang-tools-18`. The game's `.c`
+sources are C++; the tools use the generated compilation database and game
+include paths. Third-party translation units and tests are excluded, but game
+sources compiled by isolation tests remain included with their test definitions.
+
+```sh
+python3 tools/quality/static_analysis.py build
+python3 tools/quality/static_analysis.py build --tool clang
+```
+
+Cppcheck returns a failure for findings locally. `--report-only` matches CI's
+advisory policy; malformed output and analyzer failures still fail. Clang writes
+its findings to `build/quality/clang.txt`. Its exit code checks successful analysis,
+not the absence of warnings. Reports apply only to the configured platform and
+preprocessor branches. Check the other platform builds before drawing conclusions.
+
+Install `lizard==1.17.31` in a Python virtual environment to collect function
+complexity, length, and parameter counts:
+
+```sh
+mkdir -p build/quality
+lizard --csv src > build/quality/complexity.csv
+cmake --graphviz=build/quality/dependencies.dot -S . -B build
+```
+
+Use the CSV to spot functions made harder to follow by a change. The DOT graph
+shows CMake target dependencies, including third-party libraries; it is not a
+function call graph or proof that runtime dependencies are unchanged. Compare
+reports produced with the same tools on the base and PR commits when needed.
+
+## Mutation testing
+
+In Actions, run **Mutation tests** and select a test executable. The workflow
+pins Mull 0.34.0 with matching Clang 18. It changes arithmetic and comparisons
+in compiled game code, then measures whether the selected test detects each
+change. It does not edit working source files.
+
+The default signed-ratio suite keeps the initial run small. Utility and software
+rasterizer suites are also selectable. This is not a whole-project mutation score:
+only code linked into and exercised by that test is measured. Inspect the HTML/JSON
+report and log in the artifact for killed, surviving, timed-out, or uncovered
+mutations. A surviving mutation may identify a missing assertion or an equivalent
+change. Investigate it before adding a test. A timeout is not evidence that an
+assertion detected an error. Zero discovered mutants is treated as a failed run.
+
+For a local run, install the matching tools using the
+[Mull installation guide](https://mull.readthedocs.io/en/latest/Installation.html):
+
+```sh
+export MULL_CONFIG="$PWD/tools/quality/mull.yml"
+cmake -S . -B build-mutation -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  '-DCMAKE_CXX_FLAGS=-fpass-plugin=/usr/lib/mull-ir-frontend-18 -grecord-command-line -fprofile-instr-generate -fcoverage-mapping'
+cmake --build build-mutation --target signed_ratio_behavior_tests --parallel 2
+ctest --test-dir build-mutation -R '^signed_ratio_behavior_tests$' --output-on-failure
+mull-runner-18 --allow-surviving --workers 2 --timeout 10000 \
+  --reporters Elements --reporters IDE --report-dir build-mutation \
+  build-mutation/signed_ratio_behavior_tests
+```
+
+## Acceptance and reviewer spot checks
+
+For changes affecting gameplay, run with your own original game files. Record
+the commit, OS, renderer, settings, inputs, expected behavior, and observed result.
+Use a disposable copy of the game directory because pilot records can change.
+
+- Start from the intro, choose a pilot and mission, enter flight, then return
+  through debriefing and start a second mission.
+- For rendering changes, check both software and OpenGL: cockpit, external views,
+  HUD, palette effects, and title/menu transitions. Compare an affected scene
+  before and after; do not update golden images merely to make tests pass.
+- For input changes, check keyboard and the affected mouse/joystick controls,
+  including pause/resume and releasing a held control.
+- For sound changes, listen to intro music, engine/effects, and a speech cue.
+- Exercise the bug's original trigger and a nearby boundary case. Attach a small
+  reproducer or screenshot when it explains the change better than prose.
+
+Reviewers should inspect changed public interfaces, ownership/lifetimes, array
+bounds, original DOS integer-width semantics, and any changes to tests or goldens.
+Check that assertions observe behavior rather than duplicating the implementation.

--- a/docs/quality_checks.md
+++ b/docs/quality_checks.md
@@ -74,7 +74,7 @@ change. It does not edit working source files.
 
 The default signed-ratio suite keeps the initial run small. Utility and software
 rasterizer suites are also selectable. This is not a whole-project mutation score:
-only code linked into and exercised by that test is measured. Inspect the HTML/JSON
+only code linked into and exercised by that test is measured. Inspect the JSON
 report and log in the artifact for killed, surviving, timed-out, or uncovered
 mutations. A surviving mutation may identify a missing assertion or an equivalent
 change. Investigate it before adding a test. A timeout is not evidence that an

--- a/docs/quality_checks.md
+++ b/docs/quality_checks.md
@@ -11,7 +11,6 @@ reading and understanding the change. A green run does not prove correct gamepla
 | Cppcheck and Clang static analyzer | Every PR; Linux | Findings for review; analyzer execution errors fail the job |
 | Function complexity and dependency graph | Every PR; Linux | Downloadable review metrics, no arbitrary legacy-wide threshold |
 | Mutation testing | Manual, selected test target | Baseline must pass; surviving mutations are reported for review |
-| Installed package smoke test | Packaging PRs and nightly | Runs `--help` from the installed directory |
 | Interactive acceptance | Before merging affected gameplay or UI | Contributor records the checks below |
 
 Repository branch protection must be configured by a maintainer to require CI

--- a/tests/eg3drast_behavior_tests.cpp
+++ b/tests/eg3drast_behavior_tests.cpp
@@ -8,6 +8,7 @@
 
 extern int16 g_dirtyRectMinY;
 extern int16 g_dirtyRectMaxY;
+extern int16 g_rotSinYaw;
 void storeObjTransformByOpcode(void);
 
 namespace {
@@ -26,6 +27,10 @@ enum Eg3dRastOriginalConstant : int {
     kDirtyMinSeed = 12,
     kDirtyMaxSeed = 34,
     kZeroAngle = 0,
+    kHalfTableStepAngle = 0x80,
+    kHalfTableStepSine = 0x192,
+    kDescendingHalfStepAngle = 0x4080,
+    kDescendingHalfStepSine = 0x7ffb,
     kQ15CosineZeroProduct = 32766,
     kLodCommandKeepScanning = 0x80,
     kLodCommandIndex1 = 0x81,
@@ -63,7 +68,8 @@ void setLe16(uint8 *p, int value) {
 } // namespace
 
 int main() {
-    int16 matrix[9] = {};
+    // Nonzero sentinels expose missing writes, including off-diagonal zeroes.
+    int16 matrix[9] = {123, 123, 123, 123, 123, 123, 123, 123, 123};
     uint8 modelStream[16] = {};
 
     resetSpanRows();
@@ -75,6 +81,12 @@ int main() {
         require(g_spanBuf.minX[y] == kResetMinX &&
                     g_spanBuf.maxX[y] == kResetMaxX,
                 "resetScanlineSpans resets every row in the dirty range");
+    }
+    for (int y = 0; y < 220; ++y) {
+        if (y >= kDirtyStartRow && y <= kDirtyEndRow) continue;
+        require(g_spanBuf.minX[y] == kDirtyMinSeed &&
+                    g_spanBuf.maxX[y] == kDirtyMaxSeed,
+                "resetScanlineSpans preserves all rows outside the dirty range");
     }
     require(g_spanBuf.minX[kUntouchedRow] == kDirtyMinSeed &&
                 g_spanBuf.maxX[kUntouchedRow] == kDirtyMaxSeed &&
@@ -94,6 +106,16 @@ int main() {
                 matrix[7] == 0 &&
                 matrix[8] == kQ15CosineZeroProduct,
             "buildRotationMatrixFar builds the original identity-ish Q15 zero-angle matrix");
+
+    buildRotationMatrixFar(matrix, kHalfTableStepAngle, kZeroAngle, kZeroAngle);
+    require(g_rotSinYaw == kHalfTableStepSine,
+            "buildRotationMatrixFar interpolates between adjacent sine-table entries");
+    require(matrix[2] == kHalfTableStepSine - 1 && matrix[6] == -kHalfTableStepSine,
+            "buildRotationMatrixFar applies fractional yaw with the expected Q15 rounding");
+
+    buildRotationMatrixFar(matrix, kDescendingHalfStepAngle, kZeroAngle, kZeroAngle);
+    require(g_rotSinYaw == kDescendingHalfStepSine,
+            "buildRotationMatrixFar interpolates descending sine-table entries");
 
     modelStream[0] = kLodCommandKeepScanning;
     modelStream[3] = kFinalDisplayOpcode;
@@ -122,6 +144,18 @@ int main() {
     storeObjTransformByOpcode();
     require(g_objTransform[kTransformIndex] == kSpinAngle,
             "storeObjTransformByOpcode stores spinAngle into opcode low-two-bit transform slot");
+    for (int selected = 0; selected < 4; ++selected) {
+        for (int slot = 0; slot < 4; ++slot) g_objTransform[slot] = 123;
+        modelStream[0] = static_cast<uint8>(0x80 | selected);
+        g_modelStreamPtr = reinterpret_cast<char *>(modelStream);
+        g_spinAngle = -kSpinAngle;
+        storeObjTransformByOpcode();
+        for (int slot = 0; slot < 4; ++slot) {
+            const int expected = slot == selected ? -kSpinAngle : 123;
+            require(g_objTransform[slot] == expected,
+                    "storeObjTransformByOpcode changes only the selected slot");
+        }
+    }
 
     std::cout << "eg3drast_behavior_tests passed\n";
     return 0;

--- a/tests/load_behavior_tests.cpp
+++ b/tests/load_behavior_tests.cpp
@@ -211,11 +211,14 @@ void fillPattern(void *ptr, size_t count, int seed) {
 }
 
 void writeInt16(void *ptr, int value) {
-    *static_cast<int16 *>(ptr) = static_cast<int16>(value);
+    const int16 word = static_cast<int16>(value);
+    // Fixture records can start at odd byte offsets.
+    std::memcpy(ptr, &word, sizeof(word));
 }
 
 void writeUint16(void *ptr, unsigned int value) {
-    *static_cast<uint16 *>(ptr) = static_cast<uint16>(value);
+    const uint16 word = static_cast<uint16>(value);
+    std::memcpy(ptr, &word, sizeof(word));
 }
 
 bool hasSuffix(const char *text, const char *suffix) {

--- a/tests/utility_behavior_tests.cpp
+++ b/tests/utility_behavior_tests.cpp
@@ -45,6 +45,9 @@ extern char terrainGrid[256];
 extern struct GroundTargetTable g_planeTable;
 extern int16 g_planeCount;
 extern int16 g_planeScanCount;
+extern int16 g_groundUnitCount;
+extern struct FlightUnit flightUnits[];
+extern struct SimObject g_simObjects[];
 
 namespace {
 
@@ -250,6 +253,19 @@ int main() {
     require(isPointInRect(&hitItem) == 1, "isPointInRect includes points inside the rectangle");
     cursorX = 75;
     require(isPointInRect(&hitItem) == 0, "isPointInRect rejects points outside the rectangle");
+    // Test each edge independently: a missing Y check or an exclusive edge
+    // comparison must fail even when the other coordinate is valid.
+    for (auto [x, y, expected] : {
+             std::tuple{30, 30, 1}, std::tuple{50, 30, 1},
+             std::tuple{40, 20, 1}, std::tuple{40, 40, 1},
+             std::tuple{29, 30, 0}, std::tuple{51, 30, 0},
+             std::tuple{40, 19, 0}, std::tuple{40, 41, 0},
+             std::tuple{30, 20, 1}, std::tuple{50, 40, 1}}) {
+        cursorX = x;
+        cursorY = y;
+        require(isPointInRect(&hitItem) == expected,
+                "isPointInRect includes edges and rejects adjacent outside points");
+    }
 
     // --- calcMissionScore: counters, weapon cap, waypoint scale, eject penalty
     resetDebriefState(comm, game);
@@ -298,6 +314,12 @@ int main() {
     require(calcMissionScore(1) == 0, "calcMissionScore floors negative ejected scores before crash penalty");
 
     resetDebriefState(comm, game);
+    comm.weaponCount[0] = 6;
+    flightRecords[0].status = EVENT_AIR_KILL;
+    require(calcMissionScore(0) == 150,
+            "calcMissionScore applies weapon count and air-kill weight independently");
+
+    resetDebriefState(comm, game);
     comm.weaponCount[0] = 2;
     game.difficulty = 0;
     flightRecords[0].status = EVENT_AIR_KILL | STATUS_SECONDARY_HIT;
@@ -323,7 +345,7 @@ int main() {
     // deliberate +2-byte-shifted name-index aliasing (nameIndexLead /
     // secondaryNameIndex). The bulk buffers pass through the g_* views unchanged.
     {
-        std::memset(worldObjects, 0, kPlaneCount * sizeof(struct WorldObject));
+        std::memset(worldObjects, 0, (kPlaneCount + 1) * sizeof(struct WorldObject));
         struct WorldObject orig[kPlaneCount];
         for (int i = 0; i < kPlaneCount; i++) {
             const uint16 base = static_cast<uint16>((i + 1) * 0x100);
@@ -337,10 +359,12 @@ int main() {
             worldObjects[i].objectIdx = static_cast<int16>(base | 8);
             orig[i] = worldObjects[i];
         }
+        worldObjects[kPlaneCount].unitRef = 0x7eed;
         readItemSize = kPlaneCount;
         worldObjectCount = kWorldObjectCount;
         groundUnitCount = kGroundUnitCount;
-        flightUnitCount = 0;
+        flightUnitCount = 3;
+        std::memset(flightUnits, 0x5a, flightUnitCount * sizeof(struct FlightUnit));
         wldReadBuf1[0] = 0x34;
         wldReadBuf1[1] = 0x12;
 
@@ -353,6 +377,10 @@ int main() {
 
         require(g_planeCount == kPlaneCount && g_planeScanCount == kWorldObjectCount,
                 "worldImportToEgame carries plane and scan counts into EGAME");
+        require(g_groundUnitCount == flightUnitCount &&
+                    std::memcmp(g_simObjects, flightUnits,
+                                flightUnitCount * sizeof(struct SimObject)) == 0,
+                "worldImportToEgame copies every flight-unit record into EGAME");
         require(g_planeTable.nameIndexLead == static_cast<int16>(orig[0].unitRef),
                 "worldImportToEgame seeds the +2-shift lead word from the first unitRef");
         for (int i = 0; i < kPlaneCount; i++) {
@@ -374,6 +402,10 @@ int main() {
                 "worldExportToEnd republishes plane count and scan count to END");
         require(worldWaypointCount == 0x1234,
                 "worldExportToEnd recomposes the packed waypoint count word");
+        require(worldSamCount == flightUnitCount &&
+                    std::memcmp(worldSamTable, g_simObjects,
+                                flightUnitCount * sizeof(struct SimObject)) == 0,
+                "worldExportToEnd copies every EGAME ground unit into END");
         for (int i = 0; i < kPlaneCount; i++) {
             require(worldObjects[i].unitRef == orig[i].unitRef &&
                         worldObjects[i].x_coord == orig[i].x_coord &&

--- a/tools/quality/mull.yml
+++ b/tools/quality/mull.yml
@@ -1,0 +1,15 @@
+# Mutate production code, not assertions or downloaded dependencies.
+includePaths:
+  - '/src/'
+excludePaths:
+  - '/_deps/'
+  - '/tests/'
+  - '/src/generated/'
+  - '/src/compat64/'
+mutators:
+  - cxx_add_to_sub
+  - cxx_sub_to_add
+  - cxx_mul_to_div
+  - cxx_div_to_mul
+  - cxx_eq_to_ne
+  - cxx_ne_to_eq

--- a/tools/quality/static_analysis.py
+++ b/tools/quality/static_analysis.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Analyze game sources using CMake's compiler definitions and include paths."""
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import xml.etree.ElementTree as ET
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("build", type=Path)
+    parser.add_argument("--tool", choices=["cppcheck", "clang"], default="cppcheck")
+    parser.add_argument("--report-only", action="store_true",
+                        help="Report cppcheck findings without failing; tool errors still fail")
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+    build = args.build.resolve()
+    commands = json.loads((build / "compile_commands.json").read_text())
+    # Tests compile some sources a second time with different definitions.
+    # Keep those configurations, but exclude tests and third-party source files.
+    commands = [entry for entry in commands
+                if (Path(entry["directory"]) / entry["file"]).resolve()
+                .is_relative_to(root / "src")]
+    if not commands:
+        raise SystemExit("No game sources in the compilation database")
+    report = build / "quality"
+    report.mkdir(exist_ok=True)
+    database = report / "compile_commands.json"
+    database.write_text(json.dumps(commands, indent=2) + "\n")
+    print(f"Checking {len(commands)} game compilation commands", flush=True)
+    if args.tool == "clang":
+        sources = sorted({str((Path(entry["directory"]) / entry["file"]).resolve())
+                          for entry in commands})
+        with (report / "clang.txt").open("w") as diagnostics:
+            result = subprocess.run([
+                "clang-check-18", "--analyze", "-p", str(report), *sources,
+            ], cwd=root, stdout=diagnostics, stderr=subprocess.STDOUT)
+        print(f"Clang diagnostics: {report / 'clang.txt'}")
+        raise SystemExit(result.returncode)
+    with (report / "cppcheck.xml").open("w") as diagnostics:
+        result = subprocess.run([
+            "cppcheck", f"--project={database}", "--enable=warning,performance",
+            "--language=c++", "--std=c++20",
+            "--inline-suppr", "--xml", "--xml-version=2", "--error-exitcode=1",
+            "-j2",
+        ], cwd=root, stderr=diagnostics)
+    diagnostics = ET.parse(report / "cppcheck.xml").findall("./errors/error")
+    for diagnostic in diagnostics:
+        location = diagnostic.find("location")
+        file = location.get("file", "") if location is not None else ""
+        line = location.get("line", "") if location is not None else ""
+        print(f"{file}:{line}: {diagnostic.get('id')}: {diagnostic.get('msg')}")
+    tool_failed = result.returncode not in (0, 1) or any(
+        item.get("id") in {"syntaxError", "internalError", "preprocessorErrorDirective"}
+        for item in diagnostics)
+    if tool_failed or (result.returncode and not diagnostics):
+        raise SystemExit("Cppcheck did not complete successfully")
+    print(f"Cppcheck: {len(diagnostics)} findings")
+    if args.report_only:
+        return
+    raise SystemExit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds automated evidence for review without changing gameplay:

- Run macOS tests, ASan/UBSan, cppcheck, and Clang's static analyzer.
- Retain coverage, complexity, dependency, and test reports; document manual acceptance checks.
- Add a manual Mull workflow for selected test suites.

Static findings, complexity, coverage, and surviving mutations remain advisory while existing findings are triaged. Sanitizer failures and tool failures fail their jobs. Nightly packaging is proposed separately.

Local validation: 31/31 tests pass with ASan and UBSan after fixing unaligned writes in a test fixture. Cppcheck and Clang analysis complete; cppcheck reports 11 existing findings. The signed-ratio mutation run kills the division mutation; two survivors replace multiplication by a sign (+1/-1) with equivalent division. Workflow syntax and shell checks pass.
