### PR TITLE
Publish nightly Windows, Linux and macOS packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,112 @@
+name: Nightly packages
+
+on:
+  schedule:
+    - cron: '23 3 * * *'
+  workflow_dispatch:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '.github/workflows/nightly.yml'
+      - 'cmake/PackageRuntime.cmake'
+      - 'CMakeLists.txt'
+      - 'docs/nightly.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux-x86_64
+          - os: windows-2025-vs2026
+            platform: windows-x86_64
+          - os: macos-15
+            platform: macos-arm64
+          - os: macos-15-intel
+            platform: macos-x86_64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxext-dev \
+            libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev libxss-dev \
+            libxtst-dev libwayland-dev wayland-protocols libegl1-mesa-dev libgles2-mesa-dev
+      - name: Configure Release build
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_DISABLE_FIND_PACKAGE_SDL3=ON -DSDL_SHARED=ON -DSDL_STATIC=OFF
+      - name: Build and test
+        run: |
+          cmake --build build --config Release --parallel 2
+          ctest --test-dir build -C Release --output-on-failure --timeout 120 --no-tests=error
+      - name: Install runtime
+        run: cmake --install build --config Release --component Runtime --prefix stage/f15se2-ex
+      - name: Smoke test installed executable
+        working-directory: stage/f15se2-ex
+        run: ./f15se2-ex --help
+      - name: Archive
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          git rev-parse HEAD > stage/f15se2-ex/COMMIT.txt
+          cd stage
+          cmake -E tar cf "../f15se2-ex-${PLATFORM}.zip" --format=zip f15se2-ex
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nightly-${{ matrix.platform }}
+          path: f15se2-ex-${{ matrix.platform }}.zip
+          if-no-files-found: error
+          retention-days: 7
+      - name: Preserve failing test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-tests-${{ matrix.platform }}
+          path: build/Testing/Temporary/
+
+  release:
+    needs: package
+    if: >-
+      github.event_name != 'pull_request' &&
+      github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-*
+          path: packages
+          merge-multiple: true
+      - name: Publish dated prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ github.sha }}
+        run: |
+          cd packages
+          sha256sum ./*.zip > SHA256SUMS.txt
+          tag="nightly-$(date -u +%Y%m%d)-${COMMIT:0:7}"
+          printf 'Automated build of %s. See COMMIT.txt in each archive.\n\nOriginal game data is required and is not included. Packages are unsigned.\n' "$COMMIT" > notes.md
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" ./*.zip SHA256SUMS.txt --clobber
+          else
+            gh release create "$tag" ./*.zip SHA256SUMS.txt --target "$COMMIT" \
+              --prerelease --latest=false --title "$tag" --notes-file notes.md
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,8 @@ add_custom_command(
 )
 add_custom_target(mirror_assets ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/assets.stamp)
 
+include(cmake/PackageRuntime.cmake)
+
 #==============================================================================
 # Behavior tests
 #==============================================================================

--- a/cmake/PackageRuntime.cmake
+++ b/cmake/PackageRuntime.cmake
@@ -1,0 +1,28 @@
+# Install only the runnable game and its redistributed dependencies.
+# The Runtime component avoids installing SDL development files and test tools.
+if(APPLE)
+    set_property(TARGET f15se2 PROPERTY INSTALL_RPATH "@loader_path")
+elseif(UNIX)
+    set_property(TARGET f15se2 PROPERTY INSTALL_RPATH "$ORIGIN")
+endif()
+
+install(TARGETS f15se2 RUNTIME DESTINATION . COMPONENT Runtime)
+get_target_property(SDL_RUNTIME_TYPE SDL3::SDL3 TYPE)
+if(SDL_RUNTIME_TYPE STREQUAL "SHARED_LIBRARY")
+    install(FILES $<TARGET_FILE:SDL3::SDL3> DESTINATION . COMPONENT Runtime)
+    if(UNIX)
+        install(FILES $<TARGET_SONAME_FILE:SDL3::SDL3> DESTINATION . COMPONENT Runtime)
+    endif()
+endif()
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/assets/" DESTINATION assets COMPONENT Runtime)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE" DESTINATION . COMPONENT Runtime)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/docs/nightly.md"
+        DESTINATION . RENAME README.md COMPONENT Runtime)
+install(FILES "${nuked_opl3_SOURCE_DIR}/LICENSE"
+        DESTINATION licenses RENAME Nuked-OPL3.txt COMPONENT Runtime)
+install(FILES "${quick_digest5_SOURCE_DIR}/LICENSE"
+        DESTINATION licenses RENAME QuickDigest5.txt COMPONENT Runtime)
+if(SDL3_SOURCE_DIR)
+    install(FILES "${SDL3_SOURCE_DIR}/LICENSE.txt"
+            DESTINATION licenses RENAME SDL3.txt COMPONENT Runtime)
+endif()

--- a/docs/nightly.md
+++ b/docs/nightly.md
@@ -1,0 +1,45 @@
+# Nightly builds
+
+Nightly packages are experimental builds of the default branch. They run the
+behavior tests before publishing to this repository's GitHub Releases at
+03:23 UTC each day. All four platforms must pass before a release is published:
+Windows x86-64, Linux x86-64, macOS Apple Silicon, and macOS Intel.
+The workflow can also be started manually from Actions. Pull requests build
+packages for testing but cannot publish a release.
+
+Download the archive for your platform and extract the entire directory.
+Keep the executable, SDL library, and `assets` directory together.
+Check `SHA256SUMS.txt` against the downloaded ZIP and include `COMMIT.txt`
+when reporting a bug. Repeated runs of the same commit on the same day update
+that day's prerelease; older releases are retained.
+
+Original F-15 Strike Eagle II game files are required and are not included.
+The included `assets` directory contains only the repository's replacement art.
+From a terminal in the extracted directory, run:
+
+```sh
+./f15se2-ex --game /path/to/original/game
+```
+
+On Windows, use PowerShell:
+
+```powershell
+.\f15se2-ex.exe --game 'C:\Games\F15'
+```
+
+Without `--game`, the game uses `F15SE2_DIR` if set, otherwise the current
+directory. Linux packages require Ubuntu 24.04 or a compatible newer system,
+OpenGL, and the normal window/audio system libraries. Windows requires the
+Microsoft Visual C++ x64 Redistributable. macOS packages target macOS 15 or newer.
+These builds are unsigned and macOS builds are not notarized; the operating
+system may require explicit approval before running a downloaded executable.
+
+Maintainers can reproduce the package staging step with:
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_DISABLE_FIND_PACKAGE_SDL3=ON -DSDL_SHARED=ON -DSDL_STATIC=OFF
+cmake --build build --config Release --parallel 2
+ctest --test-dir build -C Release --output-on-failure
+cmake --install build --config Release --component Runtime --prefix stage/f15se2-ex
+```


### PR DESCRIPTION
Build and test nightly packages for Windows x86-64, Linux x86-64, and macOS Intel/Apple Silicon.

The packages include SDL, repository art, licenses, and the source commit. Original game data is supplied by the player. PRs build artifacts and run the installed executable's `--help`; only runs on the default branch can publish dated prereleases with checksums. All platform builds must pass before publishing.

Local Linux staging and startup passed. Cross-platform builds run on this PR. This is separate from the quality checks in #54.
